### PR TITLE
fix: clicking AgentLens status bar item opens both sidebar and dashboard

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -134,6 +134,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
   context.subscriptions.push(
     vscode.commands.registerCommand('agentLens.openDashboard', () => {
+      vscode.commands.executeCommand('workbench.view.extension.agent-lens')
       DashboardPanel.show(context, store!, provider)
     })
   )


### PR DESCRIPTION
Closes #20

Tracking branch for issue #20. See issue for full spec.