### PR TITLE
feat: SQLite write path (phase 2 — persist sessions after summarization)

### DIFF
--- a/src/database/db.ts
+++ b/src/database/db.ts
@@ -5,7 +5,8 @@ import { SCHEMA_SQL } from './schema'
 // Minimal sql.js surface we use — avoids pulling in @types/sql.js
 // which has a transitive @types/emscripten dep that requires browser lib types.
 interface SqlDatabase {
-  run(sql: string): void
+  run(sql: string, params?: unknown[]): void
+  exec(sql: string): Array<{ columns: string[]; values: unknown[][] }>
   export(): Uint8Array
   close(): void
 }
@@ -46,7 +47,6 @@ export async function openDatabase(storagePath: string, extensionPath: string): 
   return new AgentLensDb(db, dbPath, path.join(storagePath, BLOBS_DIR))
 }
 
-/** Wrapper that keeps the SqlDatabase and its file path together. */
 export class AgentLensDb {
   constructor(
     private readonly db: SqlDatabase,

--- a/src/database/writer.ts
+++ b/src/database/writer.ts
@@ -1,0 +1,226 @@
+import * as vscode from 'vscode'
+import type { SessionSummaryCard, TimelineEntry, EditDetail } from '../summarizers/summarizerTypes'
+
+// Strings below this length are kept inline in the DB row rather than written to a blob file.
+const BLOB_MIN_LENGTH = 512
+
+// Minimal sql.js surface needed for write operations.
+interface WriteableDb {
+  run(sql: string, params?: unknown[]): void
+  exec(sql: string): Array<{ columns: string[]; values: unknown[][] }>
+}
+
+export class DatabaseWriter {
+  private readonly pending = new Map<string, { card: SessionSummaryCard; workspace: string }>()
+  private drainPromise: Promise<void> = Promise.resolve()
+  private writing = false
+
+  constructor(
+    private readonly db: WriteableDb,
+    private readonly storageUri: vscode.Uri,
+    private readonly log: (msg: string) => void,
+  ) {}
+
+  enqueue(card: SessionSummaryCard, workspace: string): void {
+    this.pending.set(card.sessionId, { card, workspace })
+    if (!this.writing) {
+      this.drainPromise = this._drain()
+    }
+  }
+
+  async drain(): Promise<void> {
+    return this.drainPromise
+  }
+
+  clearAll(): void {
+    try {
+      // Delete order respects FK constraints (child tables first).
+      // CASCADE would handle it, but explicit order is clearer.
+      this.db.run('DELETE FROM edit_details')
+      this.db.run('DELETE FROM timeline_entries')
+      this.db.run('DELETE FROM sessions')
+    } catch (err) {
+      this.log(`DatabaseWriter.clearAll error: ${err}`)
+    }
+  }
+
+  dispose(): void {
+    void this.drain()
+  }
+
+  private async _drain(): Promise<void> {
+    this.writing = true
+    while (this.pending.size > 0) {
+      const batch = [...this.pending.entries()]
+      this.pending.clear()
+      for (const [, { card, workspace }] of batch) {
+        await this._writeOnce(card, workspace).catch(err => {
+          this.log(`DatabaseWriter write error for session ${card.sessionId}: ${err}`)
+        })
+      }
+    }
+    this.writing = false
+  }
+
+  private async _writeOnce(card: SessionSummaryCard, workspace: string): Promise<void> {
+    this.db.run('BEGIN')
+    try {
+      this._writeSessionRow(card, workspace)
+      // Delete-then-reinsert: no stable PK on timeline_entries to upsert against.
+      // CASCADE on the FK handles edit_details cleanup.
+      this.db.run('DELETE FROM timeline_entries WHERE session_id = ?', [card.sessionId])
+
+      for (let i = 0; i < card.timeline.length; i++) {
+        const entry = card.timeline[i]
+        this._writeTimelineEntry(card.sessionId, entry, i)
+        const rows = this.db.exec('SELECT last_insert_rowid()')
+        const entryId = rows[0]?.values[0]?.[0] as number ?? 0
+
+        if (entry.editDetails) {
+          for (const ed of entry.editDetails) {
+            this._writeEditDetail(entryId, ed)
+          }
+        }
+      }
+      this.db.run('COMMIT')
+    } catch (err) {
+      try { this.db.run('ROLLBACK') } catch { /* ignore rollback errors */ }
+      throw err
+    }
+
+    // Blob writes are async and intentionally outside the transaction.
+    for (const entry of card.timeline) {
+      await this._writeBlobsForEntry(entry)
+    }
+  }
+
+  private _writeSessionRow(card: SessionSummaryCard, workspace: string): void {
+    // Fields not yet present on SessionSummaryCard are noted below.
+    this.db.run(
+      `INSERT OR REPLACE INTO sessions (
+        session_id, trace_id, source, workspace, project_path, model,
+        start_time, duration_ms, turns, input_tokens, output_tokens,
+        cache_read_tokens, cache_create_tokens, cache_hit_rate,
+        total_tool_calls, total_llm_calls, errors, outcome,
+        is_sidechain, speed, user_request, tool_counts, loop_signals,
+        files_read, files_changed, files_searched, files_changed_note
+      ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+      [
+        card.sessionId,
+        card.traceId,
+        card.source,
+        workspace,
+        null,           // project_path — not yet on SessionSummaryCard
+        card.model,
+        Date.parse(card.startTime) || 0,
+        card.durationMs,
+        card.turns,
+        card.inputTokens,
+        card.outputTokens,
+        card.cacheReadTokens,
+        card.cacheCreateTokens,
+        card.cacheHitRate,
+        card.totalToolCalls,
+        card.totalLlmCalls,
+        card.errors,
+        card.outcome,
+        0,              // is_sidechain — not yet on SessionSummaryCard
+        null,           // speed — not yet on SessionSummaryCard
+        card.userRequest,
+        JSON.stringify(card.toolCounts),
+        JSON.stringify(card.loopSignals),
+        JSON.stringify(card.filesRead),
+        JSON.stringify(card.filesChanged),
+        JSON.stringify(card.filesSearched),
+        card.filesChangedNote ?? null,
+      ]
+    )
+  }
+
+  private _writeTimelineEntry(sessionId: string, entry: TimelineEntry, position: number): void {
+    const hasBlob = [entry.responseText, entry.thinking, entry.toolInput, entry.fullResult]
+      .some(v => v && v.length >= BLOB_MIN_LENGTH)
+
+    this.db.run(
+      `INSERT INTO timeline_entries (
+        session_id, span_id, position, type, label, model,
+        input_tokens, output_tokens, ttft, duration_ms, action, decision,
+        is_error, error_message, timestamp, has_blob
+      ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+      [
+        sessionId,
+        entry.spanId,
+        position,
+        entry.type,
+        entry.label,
+        entry.model ?? null,
+        entry.inputTokens ?? null,
+        entry.outputTokens ?? null,
+        entry.ttft ?? null,
+        entry.durationMs,
+        entry.action ?? null,
+        entry.decision ?? null,
+        entry.isError ? 1 : 0,
+        entry.errorMessage ?? null,
+        entry.timestamp,
+        hasBlob ? 1 : 0,
+      ]
+    )
+  }
+
+  private _writeEditDetail(timelineEntryId: number, ed: EditDetail): void {
+    const hasBlob = [ed.oldString, ed.newString, ed.content]
+      .some(v => v && v.length >= BLOB_MIN_LENGTH)
+
+    this.db.run(
+      `INSERT INTO edit_details (timeline_entry_id, file_path, tool_name, has_blob)
+       VALUES (?,?,?,?)`,
+      [timelineEntryId, ed.filePath, ed.toolName ?? null, hasBlob ? 1 : 0]
+    )
+  }
+
+  private async _writeBlobsForEntry(entry: TimelineEntry): Promise<void> {
+    const entryFields: Array<[string | undefined, string]> = [
+      [entry.responseText, `${entry.spanId}-response.txt`],
+      [entry.thinking,     `${entry.spanId}-thinking.txt`],
+      [entry.toolInput,    `${entry.spanId}-tool-input.txt`],
+      [entry.fullResult,   `${entry.spanId}-full-result.txt`],
+    ]
+    for (const [value, filename] of entryFields) {
+      if (value && value.length >= BLOB_MIN_LENGTH) {
+        await this._writeBlob(filename, value)
+      }
+    }
+
+    if (entry.editDetails) {
+      for (let i = 0; i < entry.editDetails.length; i++) {
+        const ed = entry.editDetails[i]
+        const editId = `${entry.spanId}-${i}`
+        const edFields: Array<[string | undefined, string]> = [
+          [ed.oldString,              `${editId}-old.txt`],
+          [ed.newString ?? ed.content, `${editId}-new.txt`],
+        ]
+        for (const [value, filename] of edFields) {
+          if (value && value.length >= BLOB_MIN_LENGTH) {
+            await this._writeBlob(filename, value)
+          }
+        }
+      }
+    }
+  }
+
+  private async _writeBlob(filename: string, content: string): Promise<void> {
+    const fileUri = vscode.Uri.joinPath(this.storageUri, 'blobs', filename)
+    try {
+      await vscode.workspace.fs.stat(fileUri)
+      return  // already exists; span content is immutable
+    } catch {
+      // file absent — proceed to write
+    }
+    try {
+      await vscode.workspace.fs.writeFile(fileUri, Buffer.from(content, 'utf8'))
+    } catch (err) {
+      this.log(`DatabaseWriter: blob write failed for ${filename}: ${err}`)
+    }
+  }
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,11 +6,15 @@ import { SidebarPanel } from './sidebarPanel'
 import { DashboardPanel } from './dashboardPanel'
 import { autoConfigureCopilot, autoConfigureClaudeCode, autoConfigureCodex } from './autoConfig'
 import { exportSpans, exportSpansRedacted } from './exportData'
-import { openDatabase } from './database/db'
+import { openDatabase, AgentLensDb } from './database/db'
+import { DatabaseWriter } from './database/writer'
+import { summarizeSpans } from './spanSummarizer'
 
 let collector: OtlpCollector | undefined
 let store: SessionStore | undefined
 let outputChannel: vscode.OutputChannel | undefined
+let agentLensDb: AgentLensDb | undefined
+let writer: DatabaseWriter | undefined
 
 function probePort(port: number, path: string): Promise<boolean> {
   return new Promise((resolve) => {
@@ -47,11 +51,11 @@ export async function activate(context: vscode.ExtensionContext) {
   outputChannel.appendLine('AgentLens activating...')
 
   try {
-    const db = await openDatabase(
+    agentLensDb = await openDatabase(
       context.globalStorageUri.fsPath,
       context.extensionUri.fsPath,
     )
-    context.subscriptions.push(db)
+    context.subscriptions.push(agentLensDb)
     outputChannel.appendLine('AgentLens database initialized.')
   } catch (err) {
     outputChannel.appendLine(`Failed to initialize database: ${err}`)
@@ -63,6 +67,21 @@ export async function activate(context: vscode.ExtensionContext) {
     outputChannel.appendLine(`Failed to initialize session store: ${err}`)
     vscode.window.showErrorMessage('AgentLens: Failed to initialize session store.')
     return
+  }
+
+  if (agentLensDb) {
+    writer = new DatabaseWriter(agentLensDb.raw, context.globalStorageUri, (msg) => outputChannel!.appendLine(msg))
+    context.subscriptions.push(
+      store.onUpdate((traceId) => {
+        if (!traceId || !writer) { return }
+        const { sessions } = summarizeSpans(store!.getSpans())
+        const card = sessions.find(s => s.traceId === traceId)
+        if (card) {
+          const workspace = vscode.workspace.workspaceFolders?.[0]?.uri.toString() ?? ''
+          writer.enqueue(card, workspace)
+        }
+      })
+    )
   }
 
   // Start local OTLP receiver
@@ -139,6 +158,7 @@ export async function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(
     vscode.commands.registerCommand('agentLens.clearSessions', () => {
       store!.clear()
+      writer?.clearAll()
       provider.refresh()
       vscode.window.showInformationMessage('AgentLens: session data cleared')
     })
@@ -283,7 +303,6 @@ async function notifySetupRequired(
 
 export async function deactivate() {
   DashboardPanel.disposePanel()
-  if (collector) {
-    await collector.stop()
-  }
+  if (collector) { await collector.stop() }
+  if (writer) { await writer.drain() }
 }

--- a/src/sessionStore.ts
+++ b/src/sessionStore.ts
@@ -6,9 +6,9 @@ export type { Span, SessionSummary } from './types'
 export class SessionStore {
   private spans: Span[] = []
   private summary: SessionSummary = this.emptySummary()
-  private onUpdateCallbacks: Array<() => void> = []
+  private onUpdateCallbacks: Array<(traceId?: string) => void> = []
 
-  onUpdate(fn: () => void): { dispose(): void } {
+  onUpdate(fn: (traceId?: string) => void): { dispose(): void } {
     this.onUpdateCallbacks.push(fn)
     return { dispose: () => {
       const i = this.onUpdateCallbacks.indexOf(fn)
@@ -16,8 +16,8 @@ export class SessionStore {
     }}
   }
 
-  private notifyUpdate(): void {
-    for (const fn of this.onUpdateCallbacks) { fn() }
+  private notifyUpdate(traceId?: string): void {
+    for (const fn of this.onUpdateCallbacks) { fn(traceId) }
   }
 
   constructor(
@@ -34,7 +34,7 @@ export class SessionStore {
     this.spans.push(span)
     this.updateSummary(span)
     this.context.globalState.update('agentLens.spans', this.spans)
-    this.notifyUpdate()
+    this.notifyUpdate(span.traceId)
   }
 
   private updateSummary(span: Span) {
@@ -145,7 +145,7 @@ export class SessionStore {
     } else {
       span.attributes.push({ key, value: { stringValue: value } })
     }
-    this.notifyUpdate()
+    this.notifyUpdate(traceId)
     return true
   }
   

--- a/src/test/__mocks__/vscode.js
+++ b/src/test/__mocks__/vscode.js
@@ -11,6 +11,7 @@ const workspace = {
   workspaceFolders: [],
   fs: {
     writeFile: () => Promise.resolve(),
+    stat: () => Promise.reject(new Error('file not found')),
   },
 }
 

--- a/src/test/database/writer.test.ts
+++ b/src/test/database/writer.test.ts
@@ -1,0 +1,243 @@
+import * as assert from 'assert'
+import * as path from 'path'
+import type * as vscode from 'vscode'
+import { SCHEMA_SQL } from '../../database/schema'
+import { DatabaseWriter } from '../../database/writer'
+import type { SessionSummaryCard } from '../../summarizers/summarizerTypes'
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+type SqlDb = {
+  run(sql: string, params?: unknown[]): void
+  exec(sql: string): Array<{ columns: string[]; values: unknown[][] }>
+  export(): Uint8Array
+  close(): void
+}
+
+async function openInMemoryDb(): Promise<SqlDb> {
+  // Locate the sql.js WASM binary relative to the package entry point.
+  const sqlJsDir = path.dirname(require.resolve('sql.js'))
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const initSqlJs = require('sql.js') as (cfg: { locateFile: (f: string) => string }) => Promise<{ Database: new () => SqlDb }>
+  const SQL = await initSqlJs({ locateFile: (f: string) => path.join(sqlJsDir, f) })
+  const db = new SQL.Database()
+  db.run(SCHEMA_SQL)
+  return db
+}
+
+function makeCard(overrides: Partial<SessionSummaryCard> = {}): SessionSummaryCard {
+  return {
+    sessionId: 'sess-1',
+    traceId: 'trace-1',
+    source: 'claude_code',
+    userRequest: 'test prompt',
+    model: 'claude-sonnet',
+    turns: 2,
+    inputTokens: 1000,
+    outputTokens: 200,
+    cacheReadTokens: 500,
+    cacheCreateTokens: 100,
+    cacheHitRate: 0.5,
+    durationMs: 5000,
+    startTime: '2024-01-01T00:00:00.000Z',
+    filesRead: ['a.ts'],
+    filesSearched: [],
+    filesChanged: ['b.ts'],
+    filesChangedNote: undefined,
+    toolCounts: { Bash: 3 },
+    totalToolCalls: 3,
+    totalLlmCalls: 2,
+    errors: 0,
+    outcome: 'text_response',
+    timeline: [],
+    backgroundSpans: [],
+    loopSignals: [],
+    ...overrides,
+  }
+}
+
+function makeStorageUri(tag = 'test'): vscode.Uri {
+  return { scheme: 'file', path: `/tmp/agentlens-${tag}`, fsPath: `/tmp/agentlens-${tag}` } as unknown as vscode.Uri
+}
+
+function queryInt(db: SqlDb, sql: string): number {
+  const result = db.exec(sql)
+  return result[0]?.values[0]?.[0] as number ?? 0
+}
+
+function countRows(db: SqlDb, table: string): number {
+  return queryInt(db, `SELECT COUNT(*) FROM ${table}`)
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+suite('DatabaseWriter', () => {
+  test('writeSession inserts one row into sessions for a minimal card', async () => {
+    const db = await openInMemoryDb()
+    const w = new DatabaseWriter(db, makeStorageUri(), () => {})
+    w.enqueue(makeCard(), 'ws-root')
+    await w.drain()
+    assert.strictEqual(countRows(db, 'sessions'), 1)
+    db.close()
+  })
+
+  test('writing the same session twice does not create duplicate rows', async () => {
+    const db = await openInMemoryDb()
+    const w = new DatabaseWriter(db, makeStorageUri(), () => {})
+    w.enqueue(makeCard(), 'ws-root')
+    await w.drain()
+    w.enqueue(makeCard({ model: 'claude-opus' }), 'ws-root')
+    await w.drain()
+    assert.strictEqual(countRows(db, 'sessions'), 1)
+    db.close()
+  })
+
+  test('timeline_entries has correct count after a write', async () => {
+    const db = await openInMemoryDb()
+    const w = new DatabaseWriter(db, makeStorageUri(), () => {})
+    const card = makeCard({
+      timeline: [
+        { type: 'llm', spanId: 'sp-1', label: 'LLM', durationMs: 100, isError: false, timestamp: '' },
+        { type: 'tool', spanId: 'sp-2', label: 'Bash', durationMs: 50, isError: false, timestamp: '' },
+      ],
+    })
+    w.enqueue(card, 'ws')
+    await w.drain()
+    assert.strictEqual(countRows(db, 'timeline_entries'), 2)
+    db.close()
+  })
+
+  test('edit_details rows are created for entries that have editDetails', async () => {
+    const db = await openInMemoryDb()
+    const w = new DatabaseWriter(db, makeStorageUri(), () => {})
+    const card = makeCard({
+      timeline: [{
+        type: 'tool', spanId: 'sp-1', label: 'Edit', durationMs: 50, isError: false, timestamp: '',
+        editDetails: [
+          { filePath: 'src/foo.ts', toolName: 'Edit' },
+          { filePath: 'src/bar.ts', toolName: 'Edit' },
+        ],
+      }],
+    })
+    w.enqueue(card, 'ws')
+    await w.drain()
+    assert.strictEqual(countRows(db, 'timeline_entries'), 1)
+    assert.strictEqual(countRows(db, 'edit_details'), 2)
+    db.close()
+  })
+
+  test('re-writing a session with fewer entries removes stale entries', async () => {
+    const db = await openInMemoryDb()
+    const w = new DatabaseWriter(db, makeStorageUri(), () => {})
+    const card = makeCard({
+      timeline: [
+        { type: 'llm', spanId: 'sp-1', label: 'LLM', durationMs: 100, isError: false, timestamp: '' },
+        { type: 'tool', spanId: 'sp-2', label: 'Bash', durationMs: 50, isError: false, timestamp: '' },
+        { type: 'tool', spanId: 'sp-3', label: 'Read', durationMs: 30, isError: false, timestamp: '' },
+      ],
+    })
+    w.enqueue(card, 'ws')
+    await w.drain()
+    assert.strictEqual(countRows(db, 'timeline_entries'), 3)
+
+    const smaller = makeCard({ timeline: [{ type: 'llm', spanId: 'sp-1', label: 'LLM', durationMs: 100, isError: false, timestamp: '' }] })
+    w.enqueue(smaller, 'ws')
+    await w.drain()
+    assert.strictEqual(countRows(db, 'timeline_entries'), 1)
+    db.close()
+  })
+
+  test('blob files are written for string fields at or above the threshold', async () => {
+    const written: string[] = []
+    const vscode = require('vscode')
+    const origWrite = vscode.workspace.fs.writeFile
+    const origStat  = vscode.workspace.fs.stat
+    vscode.workspace.fs.writeFile = (_uri: vscode.Uri) => { written.push(_uri.path); return Promise.resolve() }
+    vscode.workspace.fs.stat      = () => Promise.reject(new Error('not found'))
+
+    try {
+      const db = await openInMemoryDb()
+      const longText = 'x'.repeat(600)
+      const card = makeCard({
+        timeline: [{
+          type: 'llm', spanId: 'sp-blob', label: 'LLM', durationMs: 100,
+          isError: false, timestamp: '', responseText: longText,
+        }],
+      })
+      const w = new DatabaseWriter(db, makeStorageUri('blob'), () => {})
+      w.enqueue(card, 'ws')
+      await w.drain()
+      assert.ok(written.some(p => p.includes('sp-blob-response.txt')), 'response blob not written')
+      db.close()
+    } finally {
+      vscode.workspace.fs.writeFile = origWrite
+      vscode.workspace.fs.stat      = origStat
+    }
+  })
+
+  test('blob files are not re-written when they already exist', async () => {
+    const writeCount = { n: 0 }
+    const vscode = require('vscode')
+    const origWrite = vscode.workspace.fs.writeFile
+    const origStat  = vscode.workspace.fs.stat
+    vscode.workspace.fs.writeFile = () => { writeCount.n++; return Promise.resolve() }
+    vscode.workspace.fs.stat      = () => Promise.resolve({})  // file exists
+
+    try {
+      const db = await openInMemoryDb()
+      const longText = 'x'.repeat(600)
+      const card = makeCard({
+        timeline: [{
+          type: 'llm', spanId: 'sp-exists', label: 'LLM', durationMs: 100,
+          isError: false, timestamp: '', responseText: longText,
+        }],
+      })
+      const w = new DatabaseWriter(db, makeStorageUri('exists'), () => {})
+      w.enqueue(card, 'ws')
+      await w.drain()
+      assert.strictEqual(writeCount.n, 0, 'should not write when file already exists')
+      db.close()
+    } finally {
+      vscode.workspace.fs.writeFile = origWrite
+      vscode.workspace.fs.stat      = origStat
+    }
+  })
+
+  test('write failure is caught and does not throw from enqueue', async () => {
+    const logs: string[] = []
+    const db = await openInMemoryDb()
+    db.close()  // close to force SQL errors on next use
+
+    const w = new DatabaseWriter(db, makeStorageUri(), (msg) => logs.push(msg))
+    let threw = false
+    try {
+      w.enqueue(makeCard(), 'ws')
+      await w.drain()
+    } catch {
+      threw = true
+    }
+    assert.ok(!threw, 'enqueue/drain should not throw on DB error')
+    assert.ok(logs.length > 0, 'error should be logged')
+  })
+
+  test('clearAll leaves all three tables empty', async () => {
+    const db = await openInMemoryDb()
+    const w = new DatabaseWriter(db, makeStorageUri(), () => {})
+    const card = makeCard({
+      timeline: [{
+        type: 'tool', spanId: 'sp-1', label: 'Edit', durationMs: 10,
+        isError: false, timestamp: '',
+        editDetails: [{ filePath: 'x.ts' }],
+      }],
+    })
+    w.enqueue(card, 'ws')
+    await w.drain()
+    assert.ok(countRows(db, 'sessions') > 0)
+
+    w.clearAll()
+    assert.strictEqual(countRows(db, 'sessions'), 0)
+    assert.strictEqual(countRows(db, 'timeline_entries'), 0)
+    assert.strictEqual(countRows(db, 'edit_details'), 0)
+    db.close()
+  })
+})


### PR DESCRIPTION
Closes #29

## Summary

Wires a `DatabaseWriter` into the extension so every session is persisted to SQLite after each span arrival. The `globalState` array is left untouched as the authoritative source for the dashboard — this is additive.

## What changed

| File | Change |
|------|--------|
| `src/database/writer.ts` | New `DatabaseWriter` class with debounced write queue, transactional session/timeline/edit_details writes, and blob file management |
| `src/database/db.ts` | Extended `SqlDatabase` interface with parameterized `run(sql, params?)` and `exec(sql)` |
| `src/sessionStore.ts` | `onUpdate`/`notifyUpdate` now pass `traceId?` so the writer targets only the changed session |
| `src/extension.ts` | Creates writer after DB open, registers `onUpdate` subscriber, `clearAll` on clearSessions command, `drain()` in `deactivate` |
| `src/test/__mocks__/vscode.js` | Added `workspace.fs.stat` stub |
| `src/test/database/writer.test.ts` | 9 unit tests using real in-memory sql.js DB |

## Key design decisions

- **Debounce by session ID** — rapid span arrivals for the same session coalesce into a single write; only the latest card is flushed
- **Delete-then-reinsert for timeline_entries** — no stable unique key on AUTOINCREMENT rows; FK CASCADE handles `edit_details` cleanup automatically
- **Blobs outside the transaction** — async `vscode.workspace.fs.writeFile` with skip-if-exists (`stat` check); failures are logged, never thrown
- **`drain()` in `deactivate`** — runs before VS Code disposes `context.subscriptions` (which closes the DB), ensuring in-flight writes commit cleanly

## Test plan
- [x] `pnpm run check-types` — zero TypeScript errors
- [x] `pnpm run test:unit` — all 124 tests pass (9 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)