### PR TITLE
fix: standalone sidebar — tokens and estimated cost not rendering

### DIFF
--- a/standalone/server.ts
+++ b/standalone/server.ts
@@ -11,6 +11,7 @@ import * as fs from 'fs'
 import * as path from 'path'
 import * as os from 'os'
 import { summarizeSpans } from '../src/spanSummarizer'
+import { calcTokenCostUsd } from '../src/pricing'
 import { autoConfigureClaudeCode, autoConfigureCodex, autoConfigureCopilotStandalone } from '../src/autoConfigNode'
 import { classifyOtlpPayload } from '../src/otlpParser'
 import type { Span } from '../src/types'
@@ -253,6 +254,11 @@ function computeSidebarPayload(summary: ReturnType<typeof summarizeSpans>, allSp
     burnRate = { tokensPerMinute: Math.round(tpm), costPerHour: 0 }
   }
 
+  const avgInputTokens = sorted.length > 0
+    ? sorted.reduce((s, x) => s + x.inputTokens, 0) / sorted.length : 1
+  const avgOutputTokens = sorted.length > 0
+    ? sorted.reduce((s, x) => s + x.outputTokens, 0) / sorted.length : 1
+
   const currentSession = latest ? {
     source: latest.source,
     model: latest.model || '',
@@ -264,9 +270,20 @@ function computeSidebarPayload(summary: ReturnType<typeof summarizeSpans>, allSp
     durationMs: latest.durationMs,
     startTime: latest.startTime,
     turnInputTokens,
+    inputTokens: latest.inputTokens,
+    outputTokens: latest.outputTokens,
+    cacheReadTokens: latest.cacheReadTokens,
+    cacheCreateTokens: latest.cacheCreateTokens,
+    costUsd: calcTokenCostUsd(
+      Math.max(0, latest.inputTokens - latest.cacheReadTokens - latest.cacheCreateTokens),
+      latest.cacheReadTokens,
+      latest.cacheCreateTokens,
+      latest.outputTokens,
+      latest.model,
+    ),
   } : null
 
-  return { isActive, lastActivityMs: lastMs, sessionCount: sessions.length, agentSources, currentSession, burnRate }
+  return { isActive, lastActivityMs: lastMs, sessionCount: sessions.length, agentSources, currentSession, burnRate, avgInputTokens, avgOutputTokens }
 }
 
 // Legacy shape kept for data the Preact dashboard still reads


### PR DESCRIPTION
Closes #49

## Summary

`computeSidebarPayload` in `standalone/server.ts` was not including the token and cost fields that `sidebar.js` needs to render the Tokens and Estimated Cost cards.

**Missing from `currentSession`:** `inputTokens`, `outputTokens`, `cacheReadTokens`, `cacheCreateTokens`, `costUsd`

**Missing from top-level return:** `avgInputTokens`, `avgOutputTokens` (used to scale the token bars relative to session history)

One-line change per gap:
- Import `calcTokenCostUsd` from `src/pricing`
- Add the five token fields to `currentSession`
- Compute `costUsd` with the same formula as `sidebarPanel.ts` (subtract cache tokens from raw input before applying base rate)
- Add `avgInputTokens` / `avgOutputTokens` to the return value

## Test plan
- [ ] `node standalone/server.js` starts without error
- [ ] Standalone sidebar Tokens card shows input and output bars with values after a session arrives
- [ ] Standalone sidebar Estimated Cost card shows a dollar value for Claude/Codex sessions
- [ ] VS Code extension sidebar unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)