### PR TITLE
fix: automation notifications — consistent 'AgentLens Automation [label]' format

### DIFF
--- a/src/dashboardPanel.ts
+++ b/src/dashboardPanel.ts
@@ -357,13 +357,13 @@ async function handleAutomation(msg: { label: string; writePromptsFile: boolean;
   if (msg.writePromptsFile) {
     const filename = await writeAutomationPrompt(msg.agent, msg.label, fullPrompt)
     if (filename) {
-      vscode.window.showInformationMessage(`AgentLens [${msg.label}]: prompt written to ${filename}`, 'Dismiss')
+      vscode.window.showInformationMessage(`AgentLens Automation [${msg.label}]: prompt written to ${filename}`, 'Dismiss')
     }
     return
   }
 
   const action = await vscode.window.showWarningMessage(
-    `AgentLens Automation: ${msg.label}`,
+    `AgentLens Automation [${msg.label}]`,
     { modal: false },
     'Copy Prompt',
     'Dismiss',

--- a/standalone/server.ts
+++ b/standalone/server.ts
@@ -520,7 +520,7 @@ function getHtml(): string {
 
       var labelEl = document.createElement('span');
       labelEl.style.cssText = 'font-weight:600;color:' + color + ';line-height:1.3;';
-      labelEl.textContent = 'AgentLens: ' + label;
+      labelEl.textContent = 'AgentLens Automation [' + label + ']';
 
       var closeBtn = document.createElement('button');
       closeBtn.textContent = '×';


### PR DESCRIPTION
Closes #59

## Summary

Three automation notifications were using inconsistent labels. All now read **AgentLens Automation [label]**:

| Location | Before | After |
|---|---|---|
| VS Code writePromptsFile | `AgentLens [Context Compaction]: prompt written…` | `AgentLens Automation [Context Compaction]: prompt written…` |
| VS Code popup | `AgentLens Automation: Context Compaction` | `AgentLens Automation [Context Compaction]` |
| Standalone popup | `AgentLens: Context Compaction` | `AgentLens Automation [Context Compaction]` |

## Test plan
- [ ] Trigger an automation (e.g. Context Compaction threshold) in VS Code — notification reads "AgentLens Automation [Context Compaction]"
- [ ] Enable writePromptsFile — file-written notification reads "AgentLens Automation [...]"
- [ ] Trigger in standalone — popup header reads "AgentLens Automation [...]"

🤖 Generated with [Claude Code](https://claude.com/claude-code)