### PR TITLE
chore: code cleanup — log silent catches, handle unhandled promise

### DIFF
--- a/src/database/reader.ts
+++ b/src/database/reader.ts
@@ -446,12 +446,14 @@ export function openReadonlySnapshot(
 ): DatabaseReader | null {
   const dbPath = path.join(storagePath, 'agentlens.db')
   try {
+    // sql.js has no bundled types; require is intentional (no ESM build available)
     // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-explicit-any
-    const SQL = (require('sql.js') as any)
+    const SQL = require('sql.js') as any
     const fileBuffer = fs.readFileSync(dbPath)
     const db = new SQL.Database(fileBuffer)
     return new DatabaseReader(db, storageUri)
-  } catch {
+  } catch (e) {
+    console.warn('[AgentLens] Could not open database:', e)
     return null
   }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -31,7 +31,7 @@ function writeLastWriteSignal(storageUri: vscode.Uri): void {
   try {
     const filePath = path.join(storageUri.fsPath, LAST_WRITE_FILENAME)
     fs.writeFileSync(filePath, JSON.stringify({ lastWriteMs: Date.now() }))
-  } catch { /* non-fatal */ }
+  } catch { /* non-fatal — cross-window signal only */ }
 }
 
 function readLastWriteMs(storageUri: vscode.Uri): number {
@@ -137,7 +137,7 @@ export async function activate(context: vscode.ExtensionContext) {
           void writer.drain().then(() => {
             agentLensDb?.save()
             writeLastWriteSignal(context.globalStorageUri)
-          })
+          }).catch(err => console.error('[AgentLens] writer.drain error:', err))
         }
       })
     )

--- a/standalone/server.ts
+++ b/standalone/server.ts
@@ -364,7 +364,7 @@ function computeAnalyticsData(sessions: ReturnType<typeof summarizeSpans>['sessi
 
 function buildUpdatePayload(): string {
   let sessionSummary: ReturnType<typeof summarizeSpans> | null = null
-  try { sessionSummary = summarizeSpans(spans) } catch { /* ignore */ }
+  try { sessionSummary = summarizeSpans(spans) } catch (e) { console.warn('[AgentLens] summarizeSpans error:', e) }
   const sidebar = sessionSummary ? computeSidebarData(sessionSummary, spans) : null
   const sidebarLive = sessionSummary ? computeSidebarPayload(sessionSummary, spans) : null
   const analyticsData = sessionSummary ? computeAnalyticsData(sessionSummary.sessions) : null
@@ -812,7 +812,7 @@ const uiServer = http.createServer((req, res) => {
 
   if (req.method === 'POST' && url === '/api/clear') {
     spans = []
-    try { fs.writeFileSync(DATA_FILE, '[]') } catch { /* ignore */ }
+    try { fs.writeFileSync(DATA_FILE, '[]') } catch (e) { console.warn('[AgentLens] Could not clear data file:', e) }
     pushUpdate()
     res.writeHead(200); res.end()
     return
@@ -851,10 +851,10 @@ const uiServer = http.createServer((req, res) => {
         const body = JSON.parse(Buffer.concat(chunks).toString('utf-8')) as { type?: string }
         if (body.type === 'clearAll') {
           spans = []
-          try { fs.writeFileSync(DATA_FILE, '[]') } catch { /* ignore */ }
+          try { fs.writeFileSync(DATA_FILE, '[]') } catch (e) { console.warn('[AgentLens] Could not clear data file:', e) }
           pushUpdate()
         }
-      } catch { /* ignore malformed */ }
+      } catch (e) { console.warn('[AgentLens] Malformed /action body:', e) }
       res.writeHead(200); res.end()
     })
     return


### PR DESCRIPTION
Closes #63

## Summary

No behavior changes. Pure cleanup targeting the highest-confidence items from the audit.

**Silent catch blocks → console.warn** (`standalone/server.ts`)
- `summarizeSpans()` failure in `buildUpdatePayload`
- `/api/clear` file write failure
- `/action` body parse failure

**Unhandled promise** (`src/extension.ts`)
- Added `.catch()` to `writer.drain().then()` so drain failures surface in the Output channel

**Database open failure** (`src/database/reader.ts`)
- Added `console.warn` when the DB fails to load instead of silently returning null
- Improved sql.js require comment

## Test plan
- [ ] `pnpm run compile` passes
- [ ] `pnpm test` passes
- [ ] No behavior changes in normal operation

🤖 Generated with [Claude Code](https://claude.com/claude-code)