### PR TITLE
feat: scan all VS Code-family IDEs for Copilot Chat workspace storage

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -36,8 +36,8 @@ graph TB
         CL_LOGS["~/.claude/projects/**/*.jsonl"]
         CX_LOGS["~/.codex/sessions/**/*.jsonl"]
         CP_LOGS["~/.copilot/session-state/**/*.jsonl"]
-        CP_VS["workspaceStorage/<hash>/chatSessions/<uuid>.jsonl<br/>(delta log — newer VS Code Copilot Chat)"]
-        CP_JSON["workspaceStorage/<hash>/chatSessions/<uuid>.json<br/>(snapshot — older VS Code Copilot Chat)"]
+        CP_VS["workspaceStorage/<hash>/chatSessions/<uuid>.jsonl<br/>(delta log — newer VS Code-family Copilot Chat)"]
+        CP_JSON["workspaceStorage/<hash>/chatSessions/<uuid>.json<br/>(snapshot — older VS Code-family Copilot Chat)"]
     end
 
     subgraph VSCode Extension
@@ -197,10 +197,10 @@ A parallel, network-free ingestion path that reads session files written to disk
 | Claude Code | JSONL (append log) | `~/.claude/projects/<project>/<uuid>.jsonl` | `CLAUDE_CONFIG_DIR` (comma-separated config dirs) |
 | Codex | JSONL (append log) | `~/.codex/sessions/<project>/<uuid>.jsonl` | `CODEX_HOME` (comma-separated home dirs) |
 | Copilot CLI | JSONL (event log) | `~/.copilot/session-state/<uuid>/events.jsonl` | — (written automatically) |
-| Copilot Chat (VS Code, newer) | JSONL (delta log) | `workspaceStorage/<hash>/chatSessions/<uuid>.jsonl` | — |
-| Copilot Chat (VS Code, older) | JSON (snapshot) | `workspaceStorage/<hash>/chatSessions/<uuid>.json` | — |
+| Copilot Chat (VS Code-family, newer) | JSONL (delta log) | `workspaceStorage/<hash>/chatSessions/<uuid>.jsonl` | — |
+| Copilot Chat (VS Code-family, older) | JSON (snapshot) | `workspaceStorage/<hash>/chatSessions/<uuid>.json` | — |
 
-`workspaceStorage` is at `~/Library/Application Support/Code/User/workspaceStorage` (macOS), `%APPDATA%\Code\User\workspaceStorage` (Windows), or `~/.config/Code/User/workspaceStorage` (Linux). VS Code Insiders uses "Code - Insiders". Windows: Claude Code also checks `%APPDATA%\Claude\projects`. Linux/Mac: `XDG_CONFIG_HOME` is also checked for Claude.
+`workspaceStorage` is at `~/Library/Application Support/<IDE>/User/workspaceStorage` (macOS), `%APPDATA%\<IDE>\User\workspaceStorage` (Windows), or `$XDG_CONFIG_HOME/<IDE>/User/workspaceStorage` (Linux), where `<IDE>` is any VS Code-family IDE. AgentLens scans all known VS Code-family IDEs automatically — VS Code, VS Code Insiders, Cursor, Windsurf, VSCodium, Trae, and Kiro — via `VSCODE_FAMILY_IDE_NAMES` in `src/vscodeFamilyIdes.ts`. Standalone auto-config writes Copilot settings into every installed IDE's `settings.json`. Windows: Claude Code also checks `%APPDATA%\Claude\projects`. Linux/Mac: `XDG_CONFIG_HOME` is also checked for Claude.
 
 ### Copilot Chat — delta log format (`.jsonl`)
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -36,8 +36,8 @@ graph TB
         CL_LOGS["~/.claude/projects/**/*.jsonl"]
         CX_LOGS["~/.codex/sessions/**/*.jsonl"]
         CP_LOGS["~/.copilot/session-state/**/*.jsonl"]
-        CP_VS["workspaceStorage/<hash>/chatSessions/<uuid>.jsonl<br/>(delta log — newer VS Code-family Copilot Chat)"]
-        CP_JSON["workspaceStorage/<hash>/chatSessions/<uuid>.json<br/>(snapshot — older VS Code-family Copilot Chat)"]
+        CP_VS["workspaceStorage/{hash}/chatSessions/{uuid}.jsonl<br/>(delta log — newer VS Code-family Copilot Chat)"]
+        CP_JSON["workspaceStorage/{hash}/chatSessions/{uuid}.json<br/>(snapshot — older VS Code-family Copilot Chat)"]
     end
 
     subgraph VSCode Extension

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Open <http://localhost:3000> after the server starts. The OTLP receiver listens 
 
 The extension receives OTEL traces in real time **and** reads local session log files, so you get both live telemetry and full session history automatically.
 
+Works in **VS Code, Cursor, Windsurf, VSCodium, Trae, and Kiro** — install from your IDE's extension marketplace or from the VS Code Marketplace directly.
+
 1. **[Install from the VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=agentlens.agentlens-dashboard)**
 2. Open the **AgentLens** view from the Activity Bar
 3. AgentLens auto-configures OTEL telemetry for Copilot, Claude Code, and Codex — restart any running agent sessions to start streaming traces
@@ -78,7 +80,7 @@ Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
 ## Features
 
 - **OpenTelemetry collection** — Built-in OTEL receiver captures real-time traces and logs from Copilot, Claude Code, and Codex with no external infrastructure; auto-configured on first activation
-- **Log file ingestion** — Reads local session files written automatically by each agent as a zero-config fallback, backfilling history when OTEL isn't configured (VS Code and native process only)
+- **Log file ingestion** — Reads local session files written automatically by each agent as a zero-config fallback, backfilling history when OTEL isn't configured (VS Code-family IDEs and native process only)
 - **Sessions Table** — Drill into any session: expand a row to see a full waterfall trace, turn-to-tool flow graph, tool distribution chart, and modified files — all without leaving the session list
 - **Analytics** — Aggregate charts across the active time range: per-agent breakdown, estimated cost with a daily total overlay, token usage per session, and context growth
 - **Cost Estimation** — Estimates session cost for Copilot (three billing models), Claude Code, and Codex, broken down by model in a day-grouped table
@@ -96,15 +98,18 @@ The VS Code extension runs a built-in OTEL HTTP receiver on port `4318` and auto
 
 See [Manual Configuration](#manual-configuration) for the specific settings each agent needs. OTEL is the only data source available in Docker mode.
 
-### Log file ingestion (fallback source, VS Code and native process only)
+### Log file ingestion (fallback source, VS Code-family IDEs and native process only)
 
-AgentLens also reads the local session files that Claude Code, Codex, and Copilot CLI write automatically to your home directory. This requires no configuration and backfills session history that predates OTEL setup. Log-sourced sessions show a **Log** badge. **Not available in Docker mode** — the container cannot access host log directories without explicit volume mounts for every agent path.
+AgentLens also reads the local session files that Claude Code, Codex, Copilot CLI, and Copilot Chat write automatically to your home directory. This requires no configuration and backfills session history that predates OTEL setup. Log-sourced sessions show a **Log** badge. **Not available in Docker mode** — the container cannot access host log directories without explicit volume mounts for every agent path.
 
 | Agent | Log file location (Mac/Linux) | Windows |
 | --- | --- | --- |
 | **Claude Code** | `~/.claude/projects/<project>/<session>.jsonl` | `%APPDATA%\Claude\projects\...` |
 | **Codex CLI** | `~/.codex/sessions/<project>/<session>.jsonl` | `%USERPROFILE%\.codex\sessions\...` |
 | **Copilot CLI** | `~/.copilot/session-state/<session>/events.jsonl` | `%USERPROFILE%\.copilot\session-state\...` |
+| **Copilot Chat** | `~/Library/Application Support/<IDE>/User/workspaceStorage/…/chatSessions/` | `%APPDATA%\<IDE>\User\workspaceStorage\…\chatSessions\` |
+
+Copilot Chat sessions are scanned across all installed VS Code-family IDEs automatically — VS Code, VS Code Insiders, Cursor, Windsurf, VSCodium, Trae, and Kiro.
 
 Loading is incremental and runs in the background, sorted newest-first so recent sessions appear immediately. A 30-second poll picks up new sessions as they complete.
 
@@ -172,7 +177,7 @@ The VS Code extension configures agents automatically on first activation. For s
 
 ### GitHub Copilot
 
-**VS Code extension** — Add to VS Code User Settings (`Cmd+Shift+P` / `Ctrl+Shift+P` → *Preferences: Open User Settings (JSON)*):
+**VS Code-family IDE extension** — Add to User Settings (`Cmd+Shift+P` / `Ctrl+Shift+P` → *Preferences: Open User Settings (JSON)*) in VS Code, Cursor, Windsurf, or any VS Code-family IDE:
 
 ```json
 {

--- a/media/dashboard.js
+++ b/media/dashboard.js
@@ -4964,7 +4964,7 @@
         /* @__PURE__ */ u4("strong", { children: "AgentLens" }),
         " is a local observability tool that makes AI ",
         /* @__PURE__ */ u4("a", { href: "#gl-agent", children: "agent" }),
-        " sessions more transparent \u2014 see what's happening inside each run. Available as a VS Code extension, a local web app (npx), or Docker, with no data leaving your machine. It captures ",
+        " sessions more transparent \u2014 see what's happening inside each run. Available as a VS Code-family IDE extension (VS Code, Cursor, Windsurf, VSCodium, Trae, Kiro), a local web app (npx), or Docker, with no data leaving your machine. It captures ",
         /* @__PURE__ */ u4("a", { href: "#gl-otlp", children: "OpenTelemetry" }),
         " ",
         /* @__PURE__ */ u4("a", { href: "#gl-trace", children: "traces" }),
@@ -5038,7 +5038,7 @@ chmod +x scripts/configure-agents.sh
     ] }) : /* @__PURE__ */ u4("div", { style: "margin-bottom:20px;background:var(--hover);border:1px solid var(--border);border-left:3px solid var(--warning,#ffb74d);border-radius:4px;padding:10px 14px", children: [
       /* @__PURE__ */ u4("p", { style: "font-size:12px;font-weight:600;margin:0 0 8px;color:var(--foreground)", children: "Not seeing any data?" }),
       /* @__PURE__ */ u4("p", { style: "font-size:12px;color:var(--muted);margin:0 0 8px", children: [
-        "AgentLens automatically configures all supported agents on first activation. Just restart each ",
+        "AgentLens automatically configures all supported agents on first activation. Works in VS Code, Cursor, Windsurf, VSCodium, Trae, Kiro, and other VS Code-family IDEs. Just restart each ",
         /* @__PURE__ */ u4("a", { href: "#gl-agent", children: "agent" }),
         " once \u2014 ",
         /* @__PURE__ */ u4("a", { href: "#gl-session", children: "sessions" }),
@@ -5054,7 +5054,7 @@ chmod +x scripts/configure-agents.sh
             /* @__PURE__ */ u4("kbd", { style: kbdStyle, children: "Ctrl+Shift+P" }),
             " \u2192 ",
             /* @__PURE__ */ u4("em", { children: "Reload Window" }),
-            " to restart the VS Code extension host."
+            " to restart the extension host (works in all VS Code-family IDEs)."
           ] })
         ] }),
         /* @__PURE__ */ u4("tr", { style: "border-bottom:1px solid var(--border)", children: [
@@ -5114,15 +5114,15 @@ export OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=true
 [System.Environment]::SetEnvironmentVariable("OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT", "true", "User")` })
       ] }) : /* @__PURE__ */ u4(S, { children: [
         /* @__PURE__ */ u4("p", { style: mutedP, children: [
-          "Add to VS Code ",
+          "Add to ",
           /* @__PURE__ */ u4("strong", { children: "User Settings" }),
-          " (",
+          " in your VS Code-family IDE (",
           /* @__PURE__ */ u4("kbd", { style: kbdStyle, children: "Cmd+Shift+P" }),
           " / ",
           /* @__PURE__ */ u4("kbd", { style: kbdStyle, children: "Ctrl+Shift+P" }),
           " \u2192 ",
           /* @__PURE__ */ u4("em", { children: "Preferences: Open User Settings (JSON)" }),
-          "):"
+          "). Works in VS Code, Cursor, Windsurf, VSCodium, Trae, and Kiro."
         ] }),
         /* @__PURE__ */ u4("pre", { style: preStyle, children: `{
   "github.copilot.chat.otel.enabled": true,

--- a/media/src/tabs/Help.tsx
+++ b/media/src/tabs/Help.tsx
@@ -149,7 +149,7 @@ function OverviewSection() {
       )}
       <h3 class="help-heading">{HELP_SECTIONS.overview.heading}</h3>
       <div class="help-overview-body">
-        <p><strong>AgentLens</strong> is a local observability tool that makes AI <a href="#gl-agent">agent</a> sessions more transparent — see what's happening inside each run. Available as a VS Code extension, a local web app (npx), or Docker, with no data leaving your machine. It captures <a href="#gl-otlp">OpenTelemetry</a> <a href="#gl-trace">traces</a> from GitHub Copilot, Claude Code, and Codex, and also reads <strong>local session log files</strong> written automatically by each agent as a zero-config fallback — so history loads even without OTEL configured. Both sources feed one unified dashboard and surface efficiency metrics, session cost estimates, human-readable summaries, and actionable insights in real time.</p>
+        <p><strong>AgentLens</strong> is a local observability tool that makes AI <a href="#gl-agent">agent</a> sessions more transparent — see what's happening inside each run. Available as a VS Code-family IDE extension (VS Code, Cursor, Windsurf, VSCodium, Trae, Kiro), a local web app (npx), or Docker, with no data leaving your machine. It captures <a href="#gl-otlp">OpenTelemetry</a> <a href="#gl-trace">traces</a> from GitHub Copilot, Claude Code, and Codex, and also reads <strong>local session log files</strong> written automatically by each agent as a zero-config fallback — so history loads even without OTEL configured. Both sources feed one unified dashboard and surface efficiency metrics, session cost estimates, human-readable summaries, and actionable insights in real time.</p>
       </div>
     </div>
   )
@@ -203,13 +203,13 @@ chmod +x scripts/configure-agents.sh
   ) : (
     <div style="margin-bottom:20px;background:var(--hover);border:1px solid var(--border);border-left:3px solid var(--warning,#ffb74d);border-radius:4px;padding:10px 14px">
       <p style="font-size:12px;font-weight:600;margin:0 0 8px;color:var(--foreground)">Not seeing any data?</p>
-      <p style="font-size:12px;color:var(--muted);margin:0 0 8px">AgentLens automatically configures all supported agents on first activation. Just restart each <a href="#gl-agent">agent</a> once — <a href="#gl-session">sessions</a> will start appearing immediately.</p>
+      <p style="font-size:12px;color:var(--muted);margin:0 0 8px">AgentLens automatically configures all supported agents on first activation. Works in VS Code, Cursor, Windsurf, VSCodium, Trae, Kiro, and other VS Code-family IDEs. Just restart each <a href="#gl-agent">agent</a> once — <a href="#gl-session">sessions</a> will start appearing immediately.</p>
       <p style="font-size:11px;color:var(--muted);margin:0 0 6px">Config is read at startup — restart after AgentLens activates:</p>
       <table style="font-size:11px;border-collapse:collapse;width:100%">
         <tbody style="color:var(--muted)">
           <tr style="border-bottom:1px solid var(--border)">
             <td style="padding:4px 12px 4px 0;white-space:nowrap;vertical-align:top;color:var(--foreground)">GitHub Copilot</td>
-            <td style="padding:4px 0;vertical-align:top"><kbd style={kbdStyle}>Cmd+Shift+P</kbd> / <kbd style={kbdStyle}>Ctrl+Shift+P</kbd> → <em>Reload Window</em> to restart the VS Code extension host.</td>
+            <td style="padding:4px 0;vertical-align:top"><kbd style={kbdStyle}>Cmd+Shift+P</kbd> / <kbd style={kbdStyle}>Ctrl+Shift+P</kbd> → <em>Reload Window</em> to restart the extension host (works in all VS Code-family IDEs).</td>
           </tr>
           <tr style="border-bottom:1px solid var(--border)">
             <td style="padding:4px 12px 4px 0;white-space:nowrap;vertical-align:top;color:var(--foreground)">Claude Code (CLI)</td>
@@ -249,7 +249,7 @@ export OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=true
         </>
       ) : (
         <>
-          <p style={mutedP}>Add to VS Code <strong>User Settings</strong> (<kbd style={kbdStyle}>Cmd+Shift+P</kbd> / <kbd style={kbdStyle}>Ctrl+Shift+P</kbd> → <em>Preferences: Open User Settings (JSON)</em>):</p>
+          <p style={mutedP}>Add to <strong>User Settings</strong> in your VS Code-family IDE (<kbd style={kbdStyle}>Cmd+Shift+P</kbd> / <kbd style={kbdStyle}>Ctrl+Shift+P</kbd> → <em>Preferences: Open User Settings (JSON)</em>). Works in VS Code, Cursor, Windsurf, VSCodium, Trae, and Kiro.</p>
           <pre style={preStyle}>{`{
   "github.copilot.chat.otel.enabled": true,
   "github.copilot.chat.otel.exporterType": "otlp-http",

--- a/src/autoConfigNode.ts
+++ b/src/autoConfigNode.ts
@@ -1,6 +1,7 @@
 import * as path from 'path'
 import * as os from 'os'
 import * as fs from 'fs/promises'
+import { VSCODE_FAMILY_IDE_NAMES } from './vscodeFamilyIdes'
 
 export interface ConfigResult {
   changed: boolean
@@ -148,9 +149,6 @@ export async function autoConfigureClaudeCode(port: number): Promise<ConfigResul
   }
 }
 
-// VS Code variants to check, in preference order
-const VS_CODE_VARIANTS = ['Code', 'Code - Insiders', 'Cursor', 'Windsurf']
-
 function vscodeUserSettingsPaths(): string[] {
   const home = os.homedir()
   let base: string
@@ -161,7 +159,7 @@ function vscodeUserSettingsPaths(): string[] {
   } else {
     base = process.env.APPDATA ?? path.join(home, 'AppData', 'Roaming')
   }
-  return VS_CODE_VARIANTS.map(v => path.join(base, v, 'User', 'settings.json'))
+  return VSCODE_FAMILY_IDE_NAMES.map(v => path.join(base, v, 'User', 'settings.json'))
 }
 
 export async function autoConfigureCopilotStandalone(port: number): Promise<ConfigResult[]> {

--- a/src/logReader.ts
+++ b/src/logReader.ts
@@ -13,10 +13,10 @@
  *
  *   Copilot CLI  ~/.copilot/session-state/<uuid>/events.jsonl
  *
- *   Copilot Chat ~/Library/Application Support/Code/User/workspaceStorage/<hash>/chatSessions/<uuid>.jsonl
- *   (VS Code)    %APPDATA%\Code\User\workspaceStorage\<hash>\chatSessions\<uuid>.jsonl
- *                ~/.config/Code/User/workspaceStorage/<hash>/chatSessions/<uuid>.jsonl
- *                (VS Code Insiders: "Code - Insiders" in place of "Code")
+ *   Copilot Chat ~/Library/Application Support/<IDE>/User/workspaceStorage/<hash>/chatSessions/<uuid>.jsonl
+ *   (VS Code-   %APPDATA%\<IDE>\User\workspaceStorage\<hash>\chatSessions\<uuid>.jsonl
+ *   family IDE) ~/.config/<IDE>/User/workspaceStorage/<hash>/chatSessions/<uuid>.jsonl
+ *               where <IDE> is any VS Code-family IDE (see VSCODE_FAMILY_IDE_NAMES)
  *
  * Data available from logs (vs OTEL):
  *   Claude / Codex: session ID, workspace, model, timestamps, full token counts
@@ -31,6 +31,7 @@ import * as fs from 'fs'
 import * as path from 'path'
 import * as os from 'os'
 import type { SessionSummaryCard, TimelineEntry } from './summarizers/summarizerTypes'
+import { VSCODE_FAMILY_IDE_NAMES } from './vscodeFamilyIdes'
 
 // ── Cross-platform home resolution ────────────────────────────────────────────
 
@@ -79,33 +80,29 @@ function copilotSessionStateDir(): string | null {
   return fs.existsSync(dir) ? dir : null
 }
 
-function copilotVSCodeChatRoots(): string[] {
-  // VS Code Copilot Chat writes one JSONL per session into:
-  //   macOS:   ~/Library/Application Support/Code/User/workspaceStorage/<hash>/chatSessions/
-  //   Windows: %APPDATA%\Code\User\workspaceStorage\<hash>\chatSessions\
-  //   Linux:   ~/.config/Code/User/workspaceStorage/<hash>/chatSessions/
-  // VS Code Insiders uses "Code - Insiders" in place of "Code".
+function vscodeFamilyWorkspaceStorageRoots(): string[] {
+  // Returns all existing workspaceStorage directories across every known
+  // VS Code-family IDE (see VSCODE_FAMILY_IDE_NAMES). Copilot Chat and other
+  // VS Code extensions always write chatSessions under the host IDE's directory,
+  // so scanning all of them covers Cursor, Windsurf, VSCodium, Trae, Kiro, etc.
   const home = homeDir()
   const candidates: string[] = []
 
-  switch (process.platform) {
-    case 'win32': {
-      const appData = process.env['APPDATA']
-      if (appData) {
-        candidates.push(path.join(appData, 'Code', 'User', 'workspaceStorage'))
-        candidates.push(path.join(appData, 'Code - Insiders', 'User', 'workspaceStorage'))
+  for (const name of VSCODE_FAMILY_IDE_NAMES) {
+    switch (process.platform) {
+      case 'win32': {
+        const appData = process.env['APPDATA']
+        if (appData) candidates.push(path.join(appData, name, 'User', 'workspaceStorage'))
+        break
       }
-      break
-    }
-    case 'darwin':
-      candidates.push(path.join(home, 'Library', 'Application Support', 'Code', 'User', 'workspaceStorage'))
-      candidates.push(path.join(home, 'Library', 'Application Support', 'Code - Insiders', 'User', 'workspaceStorage'))
-      break
-    default: {
-      const xdg = process.env['XDG_CONFIG_HOME'] ?? path.join(home, '.config')
-      candidates.push(path.join(xdg, 'Code', 'User', 'workspaceStorage'))
-      candidates.push(path.join(xdg, 'Code - Insiders', 'User', 'workspaceStorage'))
-      break
+      case 'darwin':
+        candidates.push(path.join(home, 'Library', 'Application Support', name, 'User', 'workspaceStorage'))
+        break
+      default: {
+        const xdg = process.env['XDG_CONFIG_HOME'] ?? path.join(home, '.config')
+        candidates.push(path.join(xdg, name, 'User', 'workspaceStorage'))
+        break
+      }
     }
   }
 
@@ -179,7 +176,7 @@ export class LogReader {
     // Two file formats exist: <uuid>.jsonl (delta log, newer) and <uuid>.json (full snapshot, older).
     // Prefer .jsonl; skip a .json file when a .jsonl sibling exists for the same session UUID.
     // Build a Set from the directory listing to avoid per-file fs.existsSync calls.
-    for (const root of copilotVSCodeChatRoots()) {
+    for (const root of vscodeFamilyWorkspaceStorageRoots()) {
       try {
         for (const hashDir of fs.readdirSync(root)) {
           const chatDir = path.join(root, hashDir, 'chatSessions')
@@ -231,7 +228,7 @@ export class LogReader {
       ...claudeProjectsDirs(),
       ...codexSessionsDirs(),
       ...((() => { const d = copilotSessionStateDir(); return d ? [d] : [] })()),
-      ...copilotVSCodeChatRoots(),
+      ...vscodeFamilyWorkspaceStorageRoots(),
     ]
   }
 
@@ -551,7 +548,7 @@ export class LogReader {
 
   private _scanCopilotVSCode(): LogSessionResult[] {
     const results: LogSessionResult[] = []
-    for (const root of copilotVSCodeChatRoots()) {
+    for (const root of vscodeFamilyWorkspaceStorageRoots()) {
       try {
         for (const hashDir of fs.readdirSync(root)) {
           const chatDir = path.join(root, hashDir, 'chatSessions')

--- a/src/vscodeFamilyIdes.ts
+++ b/src/vscodeFamilyIdes.ts
@@ -1,0 +1,20 @@
+/**
+ * App-directory names for all known VS Code-family IDEs.
+ *
+ * The directory name is the same segment used in:
+ *   macOS:   ~/Library/Application Support/<name>/User/
+ *   Windows: %APPDATA%\<name>\User\
+ *   Linux:   $XDG_CONFIG_HOME/<name>/User/  (falls back to ~/.config/<name>/User/)
+ *
+ * Both log ingestion (workspaceStorage scanning) and standalone auto-config
+ * import this list. Add new IDEs here and both features pick them up automatically.
+ */
+export const VSCODE_FAMILY_IDE_NAMES: readonly string[] = [
+  'Code',
+  'Code - Insiders',
+  'Cursor',
+  'Windsurf',
+  'VSCodium',
+  'Trae',
+  'Kiro',
+]

--- a/standalone/cli.js
+++ b/standalone/cli.js
@@ -1735,6 +1735,19 @@ function calcTokenCostUsd(inputTokens, cacheReadTokens, cacheWriteTokens, output
 var path = __toESM(require("path"));
 var os = __toESM(require("os"));
 var fs = __toESM(require("fs/promises"));
+
+// src/vscodeFamilyIdes.ts
+var VSCODE_FAMILY_IDE_NAMES = [
+  "Code",
+  "Code - Insiders",
+  "Cursor",
+  "Windsurf",
+  "VSCodium",
+  "Trae",
+  "Kiro"
+];
+
+// src/autoConfigNode.ts
 async function autoConfigureCodex(port) {
   const codexHome = process.env.CODEX_HOME || path.join(os.homedir(), ".codex");
   const configPath = path.join(codexHome, "config.toml");
@@ -1861,7 +1874,6 @@ async function autoConfigureClaudeCode(port) {
     return { changed: false, error: String(e) };
   }
 }
-var VS_CODE_VARIANTS = ["Code", "Code - Insiders", "Cursor", "Windsurf"];
 function vscodeUserSettingsPaths() {
   const home = os.homedir();
   let base;
@@ -1872,7 +1884,7 @@ function vscodeUserSettingsPaths() {
   } else {
     base = process.env.APPDATA ?? path.join(home, "AppData", "Roaming");
   }
-  return VS_CODE_VARIANTS.map((v) => path.join(base, v, "User", "settings.json"));
+  return VSCODE_FAMILY_IDE_NAMES.map((v) => path.join(base, v, "User", "settings.json"));
 }
 async function autoConfigureCopilotStandalone(port) {
   const required = {
@@ -1974,27 +1986,24 @@ function copilotSessionStateDir() {
   const dir = path2.join(homeDir(), ".copilot", "session-state");
   return fs2.existsSync(dir) ? dir : null;
 }
-function copilotVSCodeChatRoots() {
+function vscodeFamilyWorkspaceStorageRoots() {
   const home = homeDir();
   const candidates = [];
-  switch (process.platform) {
-    case "win32": {
-      const appData = process.env["APPDATA"];
-      if (appData) {
-        candidates.push(path2.join(appData, "Code", "User", "workspaceStorage"));
-        candidates.push(path2.join(appData, "Code - Insiders", "User", "workspaceStorage"));
+  for (const name of VSCODE_FAMILY_IDE_NAMES) {
+    switch (process.platform) {
+      case "win32": {
+        const appData = process.env["APPDATA"];
+        if (appData) candidates.push(path2.join(appData, name, "User", "workspaceStorage"));
+        break;
       }
-      break;
-    }
-    case "darwin":
-      candidates.push(path2.join(home, "Library", "Application Support", "Code", "User", "workspaceStorage"));
-      candidates.push(path2.join(home, "Library", "Application Support", "Code - Insiders", "User", "workspaceStorage"));
-      break;
-    default: {
-      const xdg = process.env["XDG_CONFIG_HOME"] ?? path2.join(home, ".config");
-      candidates.push(path2.join(xdg, "Code", "User", "workspaceStorage"));
-      candidates.push(path2.join(xdg, "Code - Insiders", "User", "workspaceStorage"));
-      break;
+      case "darwin":
+        candidates.push(path2.join(home, "Library", "Application Support", name, "User", "workspaceStorage"));
+        break;
+      default: {
+        const xdg = process.env["XDG_CONFIG_HOME"] ?? path2.join(home, ".config");
+        candidates.push(path2.join(xdg, name, "User", "workspaceStorage"));
+        break;
+      }
     }
   }
   return candidates.filter((d) => {
@@ -2052,7 +2061,7 @@ var LogReader = class {
       } catch {
       }
     }
-    for (const root of copilotVSCodeChatRoots()) {
+    for (const root of vscodeFamilyWorkspaceStorageRoots()) {
       try {
         for (const hashDir of fs2.readdirSync(root)) {
           const chatDir = path2.join(root, hashDir, "chatSessions");
@@ -2115,7 +2124,7 @@ var LogReader = class {
         const d = copilotSessionStateDir();
         return d ? [d] : [];
       })(),
-      ...copilotVSCodeChatRoots()
+      ...vscodeFamilyWorkspaceStorageRoots()
     ];
   }
   /**
@@ -2416,7 +2425,7 @@ var LogReader = class {
   // NOT available: input tokens, cache tokens, model per turn.
   _scanCopilotVSCode() {
     const results = [];
-    for (const root of copilotVSCodeChatRoots()) {
+    for (const root of vscodeFamilyWorkspaceStorageRoots()) {
       try {
         for (const hashDir of fs2.readdirSync(root)) {
           const chatDir = path2.join(root, hashDir, "chatSessions");


### PR DESCRIPTION
Closes #88

## Summary
- Extracts `VSCODE_FAMILY_IDE_NAMES` into shared `src/vscodeFamilyIdes.ts`
- Adds Cursor, Windsurf, VSCodium, Trae, Kiro to Copilot Chat log scanning
- Refactors `copilotVSCodeChatRoots()` → `vscodeFamilyWorkspaceStorageRoots()` to use shared list
- Updates `autoConfigNode.ts` to use shared constant (was missing VSCodium, Trae, Kiro)
- Updates ARCHITECTURE.md references

## Test plan
- [ ] TypeScript compiles cleanly
- [ ] On macOS with Cursor installed: sessions appear under Copilot source after log scan
- [ ] No regressions for VS Code and VS Code Insiders paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)