### PR TITLE
fix: export broken in standalone; redacted export should replace paths and prompt with [redacted]

### DIFF
--- a/media/dashboard.js
+++ b/media/dashboard.js
@@ -4802,17 +4802,21 @@
             /* @__PURE__ */ u4("span", { class: "export-card-title", children: "Export Session Data (Redacted)" }),
             /* @__PURE__ */ u4("span", { class: "export-card-badge export-badge-redacted", children: "Safer to share" })
           ] }),
-          /* @__PURE__ */ u4("p", { class: "export-card-desc", children: "Same export with prompt text removed. Safe to attach to bug reports or share with teammates for cost and efficiency analysis." }),
+          /* @__PURE__ */ u4("p", { class: "export-card-desc", children: "Same export with prompt text and file paths replaced. Safe to attach to bug reports or share with teammates for cost and efficiency analysis." }),
           /* @__PURE__ */ u4("ul", { class: "export-card-includes", children: [
             /* @__PURE__ */ u4("li", { children: [
-              /* @__PURE__ */ u4("span", { class: "export-redacted-label", children: "[removed]" }),
+              /* @__PURE__ */ u4("span", { class: "export-redacted-label", children: "[redacted]" }),
               " Prompt text"
             ] }),
+            /* @__PURE__ */ u4("li", { children: [
+              /* @__PURE__ */ u4("span", { class: "export-redacted-label", children: "[redacted]" }),
+              " File names and paths"
+            ] }),
             /* @__PURE__ */ u4("li", { children: "\u2713 Token counts, cache stats, model names" }),
-            /* @__PURE__ */ u4("li", { children: "\u2713 Tool call counts and file paths changed" }),
+            /* @__PURE__ */ u4("li", { children: "\u2713 Tool call counts (no paths)" }),
             /* @__PURE__ */ u4("li", { children: "\u2713 Duration, errors, outcome, loop signals" })
           ] }),
-          /* @__PURE__ */ u4("div", { class: "export-card-safe", children: "Safer to share \u2014 no prompt content." }),
+          /* @__PURE__ */ u4("div", { class: "export-card-safe", children: "Safer to share \u2014 no prompt text or file paths." }),
           /* @__PURE__ */ u4(
             "button",
             {

--- a/media/src/tabs/Export.tsx
+++ b/media/src/tabs/Export.tsx
@@ -71,16 +71,17 @@ export function Export() {
             <span class="export-card-badge export-badge-redacted">Safer to share</span>
           </div>
           <p class="export-card-desc">
-            Same export with prompt text removed. Safe to attach to bug reports
+            Same export with prompt text and file paths replaced. Safe to attach to bug reports
             or share with teammates for cost and efficiency analysis.
           </p>
           <ul class="export-card-includes">
-            <li><span class="export-redacted-label">[removed]</span> Prompt text</li>
+            <li><span class="export-redacted-label">[redacted]</span> Prompt text</li>
+            <li><span class="export-redacted-label">[redacted]</span> File names and paths</li>
             <li>✓ Token counts, cache stats, model names</li>
-            <li>✓ Tool call counts and file paths changed</li>
+            <li>✓ Tool call counts (no paths)</li>
             <li>✓ Duration, errors, outcome, loop signals</li>
           </ul>
-          <div class="export-card-safe">Safer to share — no prompt content.</div>
+          <div class="export-card-safe">Safer to share — no prompt text or file paths.</div>
           <button
             class={'export-btn export-btn-secondary' + (redactedDone ? ' export-btn-done' : '')}
             onClick={doRedacted}

--- a/src/dashboardPanel.ts
+++ b/src/dashboardPanel.ts
@@ -173,7 +173,12 @@ export class DashboardPanel {
         filesChanged:     s.filesChanged,
         loopSignals:      s.loopSignals,
       }
-      if (redact) return base
+      if (redact) return {
+        ...base,
+        userRequest:  '[redacted]',
+        filesRead:    (s.filesRead    ?? []).map(() => '[redacted]'),
+        filesChanged: (s.filesChanged ?? []).map(() => '[redacted]'),
+      }
       return { ...base, userRequest: s.userRequest }
     })
 

--- a/standalone/cli.js
+++ b/standalone/cli.js
@@ -3400,7 +3400,42 @@ function getHtml() {
               showToast('Could not copy \u2014 check browser clipboard permissions');
             });
           } else if (msg.type === 'exportSessionData' || msg.type === 'exportSessionDataRedacted') {
-            window.dispatchEvent(new MessageEvent('message', { data: { type: msg.type } }));
+            var redact = msg.type === 'exportSessionDataRedacted';
+            var exportable = (__latestSessions__ || []).map(function(s) {
+              return {
+                sessionId:         s.sessionId,
+                traceId:           s.traceId,
+                source:            s.source,
+                model:             s.model,
+                startTime:         s.startTime,
+                durationMs:        s.durationMs,
+                turns:             s.totalLlmCalls,
+                totalToolCalls:    s.totalToolCalls,
+                inputTokens:       s.inputTokens,
+                outputTokens:      s.outputTokens,
+                cacheReadTokens:   s.cacheReadTokens,
+                cacheCreateTokens: s.cacheCreateTokens,
+                cacheHitRate:      s.cacheHitRate,
+                errors:            s.errors,
+                outcome:           s.outcome,
+                toolCounts:        s.toolCounts,
+                filesRead:    redact ? (s.filesRead    || []).map(function() { return '[redacted]'; }) : s.filesRead,
+                filesChanged: redact ? (s.filesChanged || []).map(function() { return '[redacted]'; }) : s.filesChanged,
+                loopSignals:  s.loopSignals,
+                userRequest:  redact ? '[redacted]' : (s.userRequest || null),
+              };
+            });
+            var now = new Date();
+            var pad = function(n) { return String(n).padStart(2, '0'); };
+            var ts = '' + now.getFullYear() + pad(now.getMonth() + 1) + pad(now.getDate()) +
+                     '_' + pad(now.getHours()) + pad(now.getMinutes()) + pad(now.getSeconds());
+            var filename = (redact ? 'export_redacted' : 'export') + '_sessions_' + ts + '.json';
+            var blob = new Blob([JSON.stringify(exportable, null, 2)], { type: 'application/json' });
+            var url = URL.createObjectURL(blob);
+            var a = document.createElement('a');
+            a.href = url; a.download = filename; a.click();
+            URL.revokeObjectURL(url);
+            showToast('Downloaded ' + filename);
           } else if (msg.type === 'openSidebar' || msg.type === 'closeSidebar') {
             window.dispatchEvent(new CustomEvent('agentlens:sidebar', { detail: { open: msg.type === 'openSidebar' } }));
           } else if (msg.type === 'searchSessions' && msg.query) {

--- a/standalone/server.ts
+++ b/standalone/server.ts
@@ -682,7 +682,42 @@ function getHtml(): string {
               showToast('Could not copy — check browser clipboard permissions');
             });
           } else if (msg.type === 'exportSessionData' || msg.type === 'exportSessionDataRedacted') {
-            window.dispatchEvent(new MessageEvent('message', { data: { type: msg.type } }));
+            var redact = msg.type === 'exportSessionDataRedacted';
+            var exportable = (__latestSessions__ || []).map(function(s) {
+              return {
+                sessionId:         s.sessionId,
+                traceId:           s.traceId,
+                source:            s.source,
+                model:             s.model,
+                startTime:         s.startTime,
+                durationMs:        s.durationMs,
+                turns:             s.totalLlmCalls,
+                totalToolCalls:    s.totalToolCalls,
+                inputTokens:       s.inputTokens,
+                outputTokens:      s.outputTokens,
+                cacheReadTokens:   s.cacheReadTokens,
+                cacheCreateTokens: s.cacheCreateTokens,
+                cacheHitRate:      s.cacheHitRate,
+                errors:            s.errors,
+                outcome:           s.outcome,
+                toolCounts:        s.toolCounts,
+                filesRead:    redact ? (s.filesRead    || []).map(function() { return '[redacted]'; }) : s.filesRead,
+                filesChanged: redact ? (s.filesChanged || []).map(function() { return '[redacted]'; }) : s.filesChanged,
+                loopSignals:  s.loopSignals,
+                userRequest:  redact ? '[redacted]' : (s.userRequest || null),
+              };
+            });
+            var now = new Date();
+            var pad = function(n) { return String(n).padStart(2, '0'); };
+            var ts = '' + now.getFullYear() + pad(now.getMonth() + 1) + pad(now.getDate()) +
+                     '_' + pad(now.getHours()) + pad(now.getMinutes()) + pad(now.getSeconds());
+            var filename = (redact ? 'export_redacted' : 'export') + '_sessions_' + ts + '.json';
+            var blob = new Blob([JSON.stringify(exportable, null, 2)], { type: 'application/json' });
+            var url = URL.createObjectURL(blob);
+            var a = document.createElement('a');
+            a.href = url; a.download = filename; a.click();
+            URL.revokeObjectURL(url);
+            showToast('Downloaded ' + filename);
           } else if (msg.type === 'openSidebar' || msg.type === 'closeSidebar') {
             window.dispatchEvent(new CustomEvent('agentlens:sidebar', { detail: { open: msg.type === 'openSidebar' } }));
           } else if (msg.type === 'searchSessions' && msg.query) {


### PR DESCRIPTION
Closes #89

## Summary
- Standalone export now triggers a real browser download (was silently no-op)
- Redacted export replaces `userRequest` with `"[redacted]"` instead of omitting it
- Redacted export replaces each entry in `filesRead`/`filesChanged` with `"[redacted]"` instead of leaking paths
- Export.tsx UI updated to accurately describe what the redacted export includes/excludes

## Test plan
- [ ] Standalone: click Export → file downloads
- [ ] Standalone: click Export (Redacted) → file downloads with `userRequest: "[redacted]"` and `filesRead: ["[redacted]", ...]`
- [ ] VS Code: Export (Redacted) — same redaction behavior
- [ ] Export UI card shows `[redacted] File names and paths`

🤖 Generated with [Claude Code](https://claude.com/claude-code)