### PR TITLE
ux: Patterns tab polish — shared filters, chart interactions, analytics spacing

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,10 +83,11 @@ Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
 - **Log file ingestion** — Reads local session files written automatically by each agent as a zero-config fallback, backfilling history when OTEL isn't configured (VS Code-family IDEs and native process only)
 - **Sessions Table** — Drill into any session: expand a row to see a full waterfall trace, turn-to-tool flow graph, tool distribution chart, and modified files — all without leaving the session list
 - **Analytics** — Aggregate charts across the active time range: per-agent breakdown, estimated cost with a daily total overlay, token usage per session, and context growth
+- **Patterns** — Cross-session behavioral trends: an efficiency scatter plot (cost vs. LLM calls, colored by cache hit rate) and hot files ranked by how often the agent reads or changes them — click any dot or bar to jump straight to that session
 - **Cost Estimation** — Estimates session cost for Copilot (three billing models), Claude Code, and Codex, broken down by model in a day-grouped table
 - **Efficiency & Inefficiency Detection** — Surfaces context bloat, redundant tool calls, cache misses, and five loop/malfunction patterns with suggested prompts to correct course
 - **Configurable Alerts** — Threshold-based notifications for turns, errors, active time, and repeat tool calls — per-agent or shared
-- **Export** — Export all sessions as JSON (full or redacted) directly from the SQLite history
+- **Export** — Export filtered sessions as JSON (full or redacted); respects the active agent, source, time range, and text filters
 
 ## Data Sources
 

--- a/media/dashboard.js
+++ b/media/dashboard.js
@@ -1760,13 +1760,14 @@
   }
   function CostBarChart({ sessions, mode }) {
     const canvasRef = A2(null);
+    const barDataRef = A2([]);
     y2(() => {
       const canvas = canvasRef.current;
       if (!canvas) return;
-      const data = sessions.map((sess) => {
+      const data = sessions.slice().reverse().map((sess) => {
         const cost = calcSessionCost(sess, sessionCostMode(sess, mode));
-        return { cost: cost.totalUsd, unknown: cost.modelUnknown, startTime: sess.startTime, source: sess.source };
-      }).reverse();
+        return { sessionId: sess.sessionId, cost: cost.totalUsd, unknown: cost.modelUnknown, startTime: sess.startTime, source: sess.source };
+      });
       const dayKey = (t4) => t4 ? new Date(t4).toISOString().slice(0, 10) : "none";
       const dayTotals = /* @__PURE__ */ new Map();
       data.forEach((d5) => {
@@ -1819,6 +1820,7 @@
       const barPad = n3 > 100 ? 0 : n3 > 50 ? 0.3 : n3 > 20 ? 0.7 : 1.2;
       const barW = Math.max(0.5, slotW - barPad * 2);
       const offsetX = pad.left;
+      barDataRef.current = data.map((d5, i4) => ({ sessionId: d5.sessionId, slotX: offsetX + i4 * slotW, slotW }));
       data.forEach((d5, i4) => {
         const x4 = offsetX + i4 * slotW + barPad;
         const barH = d5.cost / maxCost * chartH;
@@ -1905,7 +1907,26 @@
         });
       }
     });
-    return /* @__PURE__ */ u4("div", { style: "margin-bottom:16px", children: /* @__PURE__ */ u4("canvas", { ref: canvasRef, style: "width:100%;height:230px;display:block" }) });
+    function handleClick(e4) {
+      const canvas = canvasRef.current;
+      if (!canvas) return;
+      const rect = canvas.getBoundingClientRect();
+      const mx = e4.clientX - rect.left;
+      const hit = barDataRef.current.find((b4) => mx >= b4.slotX && mx < b4.slotX + b4.slotW);
+      if (hit) {
+        focusedSessionId.value = hit.sessionId;
+        activeTab.value = "sessions";
+      }
+    }
+    return /* @__PURE__ */ u4("div", { style: "margin-bottom:16px", children: /* @__PURE__ */ u4(
+      "canvas",
+      {
+        ref: canvasRef,
+        style: "width:100%;height:230px;display:block;cursor:pointer",
+        onClick: handleClick,
+        title: "Click a bar to open that session"
+      }
+    ) });
   }
 
   // node_modules/.pnpm/clsx@2.1.1/node_modules/clsx/dist/clsx.mjs
@@ -3390,9 +3411,16 @@
   function SessionRow({ sess }) {
     const [expanded, setExpanded] = d2(false);
     const isFocused = focusedSessionId.value === sess.sessionId;
+    const rowRef = A2(null);
     const cost = calcSessionCost(sess, "token");
     const color = getAgentColor(sess.source);
     const prompt = sess.userRequest ?? "";
+    y2(() => {
+      if (focusedSessionId.value === sess.sessionId) {
+        setExpanded(true);
+        rowRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+      }
+    }, [focusedSessionId.value]);
     function toggle() {
       const next = !expanded;
       setExpanded(next);
@@ -3403,6 +3431,7 @@
       /* @__PURE__ */ u4(
         "tr",
         {
+          ref: rowRef,
           onClick: toggle,
           style: `cursor:pointer;background:${rowBg};border-bottom:1px solid var(--vscode-panel-border)`,
           children: [
@@ -3450,7 +3479,7 @@
     const thBase = "padding:3px 6px;font-size:10px;font-weight:600;white-space:nowrap;user-select:none";
     const thSort = thBase + ";cursor:pointer;color:var(--fg)";
     const thMuted = thBase + ";color:var(--muted);font-weight:500";
-    return /* @__PURE__ */ u4("div", { id: "sessions-content", children: [
+    return /* @__PURE__ */ u4("div", { id: "sessions-content", style: "padding-top:8px", children: [
       /* @__PURE__ */ u4("div", { style: "overflow-x:auto", children: /* @__PURE__ */ u4("table", { style: "width:100%;border-collapse:collapse;font-size:11px", children: [
         /* @__PURE__ */ u4("thead", { children: /* @__PURE__ */ u4("tr", { style: "border-bottom:2px solid var(--vscode-panel-border)", children: [
           /* @__PURE__ */ u4("th", { style: "width:16px;padding:3px 4px 3px 8px" }),
@@ -3517,6 +3546,7 @@
     focusedIdRef.current = focusedId;
     const [paused, setPaused] = d2(false);
     const [hasData, setHasData] = d2(false);
+    const [seriesCount, setSeriesCount] = d2(0);
     const [speed, setSpeed] = d2(1);
     const pausedRef = A2(false);
     const speedRef = A2(1);
@@ -3549,7 +3579,7 @@
       if (!canvas) return;
       const seriesData = [];
       sessions.forEach((sess) => {
-        const llmEntries = (timelines[sess.sessionId] ?? sess.timeline ?? []).filter((e4) => e4.type === "llm" && (e4.inputTokens ?? 0) > 0);
+        const llmEntries = (timelines[sess.sessionId] ?? sess.timeline ?? []).filter((e4) => (e4.type === "llm" || e4.type === "tool") && (e4.inputTokens ?? 0) > 0);
         if (llmEntries.length < 1) return;
         seriesData.push({
           sessionId: sess.sessionId,
@@ -3568,6 +3598,7 @@
       }
       canvas.style.display = "block";
       setHasData(true);
+      setSeriesCount(seriesData.length);
       seriesCountRef.current = seriesData.length;
       const maxTurns = Math.max(...seriesData.map((s4) => s4.points.length), 2);
       const allTokens = seriesData.flatMap((s4) => s4.points.map((p5) => p5.tokens));
@@ -3698,6 +3729,7 @@
       clearTimer();
       pausedRef.current = true;
       setPaused(true);
+      focusedSessionId.value = null;
       activeIdxRef.current = Math.max(0, activeIdxRef.current - 1);
       drawFnRef.current?.(activeIdxRef.current);
     }
@@ -3705,6 +3737,7 @@
       clearTimer();
       pausedRef.current = true;
       setPaused(true);
+      focusedSessionId.value = null;
       activeIdxRef.current = Math.min(seriesCountRef.current - 1, activeIdxRef.current + 1);
       drawFnRef.current?.(activeIdxRef.current);
     }
@@ -3726,7 +3759,10 @@
           }
         });
       });
-      if (bestId) focusedSessionId.value = focusedSessionId.peek() === bestId ? null : bestId;
+      if (bestId) {
+        focusedSessionId.value = focusedSessionId.peek() === bestId ? null : bestId;
+        if (focusedSessionId.value) activeTab.value = "sessions";
+      }
     }
     const btnStyle = "padding:2px 8px;font-size:11px;cursor:pointer;background:transparent;border:1px solid var(--border);border-radius:3px;color:var(--muted);line-height:1.4";
     return /* @__PURE__ */ u4(S, { children: [
@@ -3735,11 +3771,12 @@
         {
           ref: canvasRef,
           id: "context-growth-chart",
-          style: "width:100%;height:200px;display:block;cursor:pointer",
+          style: "width:100%;height:200px;cursor:pointer",
           onClick: handleCanvasClick,
           title: "Click a line to select that session"
         }
       ),
+      !hasData && /* @__PURE__ */ u4("div", { class: "empty-state", style: "font-size:11px", children: "No per-turn token data for these sessions. Context Growth requires sessions with per-turn input token counts \u2014 available for OTel-sourced sessions and Claude Code log sessions." }),
       hasData && /* @__PURE__ */ u4("div", { style: "display:flex;align-items:center;justify-content:space-between;margin-top:5px", children: [
         /* @__PURE__ */ u4("div", { style: "display:flex;align-items:center;gap:6px", children: [
           /* @__PURE__ */ u4("button", { style: btnStyle, onClick: togglePause, title: paused ? "Play" : "Pause", children: paused ? "\u25B6" : "\u23F8" }),
@@ -3752,11 +3789,17 @@
               children: s4 === 0.5 ? "\xBD\xD7" : `${s4}\xD7`
             },
             s4
-          ))
-        ] }),
-        /* @__PURE__ */ u4("div", { style: "display:flex;align-items:center;gap:6px", children: [
+          )),
           /* @__PURE__ */ u4("button", { style: btnStyle, onClick: stepPrev, title: "Previous session", children: "\u25C0" }),
           /* @__PURE__ */ u4("button", { style: btnStyle, onClick: stepNext, title: "Next session", children: "\u25B6" })
+        ] }),
+        /* @__PURE__ */ u4("span", { style: "font-size:10px;color:var(--muted)", children: [
+          "most recent ",
+          seriesCount,
+          " of ",
+          sessions.length,
+          " session",
+          sessions.length !== 1 ? "s" : ""
         ] })
       ] }),
       /* @__PURE__ */ u4("div", { style: "text-align:center;font-size:9px;color:var(--muted);margin-top:4px", children: /* @__PURE__ */ u4(TurnsLink, {}) })
@@ -3764,6 +3807,7 @@
   }
   function SessionTokenChart({ sessions }) {
     const canvasRef = A2(null);
+    const sessionDataRef = A2([]);
     y2(() => {
       const canvas = canvasRef.current;
       if (!canvas) return;
@@ -3771,7 +3815,7 @@
       if (rect.width === 0 || rect.height === 0) return;
       const sessionData = [...sessions].reverse().map((sess) => {
         const input = sess.inputTokens ?? 0, output = sess.outputTokens ?? 0;
-        return input + output > 0 ? { startTime: sess.startTime, input, output, source: sess.source } : null;
+        return input + output > 0 ? { sessionId: sess.sessionId, startTime: sess.startTime, input, output, source: sess.source } : null;
       }).filter(Boolean);
       if (sessionData.length === 0) {
         canvas.style.display = "none";
@@ -3824,6 +3868,7 @@
       const textColor = cs.getPropertyValue("--vscode-descriptionForeground").trim() || "#888";
       let lastDayLabelX = -Infinity;
       const MIN_DAY_LABEL_GAP = 30;
+      sessionDataRef.current = sessionData.map((s4, i4) => ({ ...s4, slotX: pad.left + i4 * slotW, slotW }));
       sessionData.forEach((s4, i4) => {
         const slotX = pad.left + i4 * slotW;
         const inH = s4.input / maxIn * chartH;
@@ -3855,10 +3900,29 @@
         }
       });
     });
+    function handleTokenChartClick(e4) {
+      const canvas = canvasRef.current;
+      if (!canvas) return;
+      const rect = canvas.getBoundingClientRect();
+      const mx = e4.clientX - rect.left;
+      const hit = sessionDataRef.current.find((s4) => mx >= s4.slotX && mx < s4.slotX + s4.slotW);
+      if (hit) {
+        focusedSessionId.value = hit.sessionId;
+        activeTab.value = "sessions";
+      }
+    }
     const presentSources = new Set(sessions.map((s4) => s4.source).filter(Boolean));
     const agentSources = ["copilot", "claude_code", "codex"].filter((src) => presentSources.has(src));
     return /* @__PURE__ */ u4(S, { children: [
-      /* @__PURE__ */ u4("canvas", { ref: canvasRef, style: "width:100%;height:160px;display:block" }),
+      /* @__PURE__ */ u4(
+        "canvas",
+        {
+          ref: canvasRef,
+          style: "width:100%;height:160px;display:block;cursor:pointer",
+          onClick: handleTokenChartClick,
+          title: "Click a bar to open that session"
+        }
+      ),
       agentSources.length > 0 && /* @__PURE__ */ u4("div", { style: "display:flex;gap:10px;justify-content:center;margin-top:4px;flex-wrap:wrap", children: agentSources.map((src) => /* @__PURE__ */ u4("span", { style: "display:flex;align-items:center;gap:4px;font-size:10px;color:var(--muted)", children: [
         /* @__PURE__ */ u4("span", { style: `display:inline-block;width:7px;height:7px;border-radius:50%;background:${getAgentColor(src)}` }),
         getAgentSourceLabel(src)
@@ -3903,12 +3967,12 @@
   }
 
   // media/src/tabs/Analytics.tsx
-  function SectionHead({ title, tip }) {
+  function SectionHead({ title, tip, first }) {
     return /* @__PURE__ */ u4(
       "h3",
       {
         class: tip ? "has-metric-tip" : void 0,
-        style: "margin:16px 0 6px;font-size:12px;color:var(--muted)",
+        style: `margin:${first ? "8px" : "16px"} 0 6px;font-size:12px;color:var(--muted);text-transform:uppercase;letter-spacing:.3px`,
         "data-tip": tip,
         children: title
       }
@@ -3998,8 +4062,8 @@
     const codexSess = sessions.filter((s4) => s4.source === "codex");
     const timeOrdered = rangedSessions.value;
     const pricedChartSess = timeOrdered.filter((s4) => s4.source === "copilot" || s4.source === "codex" || s4.source === "claude_code");
-    const chartSessions = timeOrdered.slice().reverse();
-    chartSessions.slice(0, CHART_MAX).forEach((sess) => {
+    const chartSessions = timeOrdered.slice(0, CHART_MAX).reverse();
+    chartSessions.forEach((sess) => {
       if (!sessionTimelines.value[sess.sessionId] && vscode) {
         vscode.postMessage({ type: "loadSessionDetail", sessionId: sess.sessionId });
       }
@@ -4061,7 +4125,7 @@
     };
     return /* @__PURE__ */ u4("div", { id: "analytics-content", children: [
       pricedSess.length > 0 && /* @__PURE__ */ u4(S, { children: [
-        /* @__PURE__ */ u4(SectionHead, { title: "ESTIMATED COST" }),
+        /* @__PURE__ */ u4(SectionHead, { title: "ESTIMATED COST", first: true }),
         disclaimer,
         copilotSess.length > 0 && /* @__PURE__ */ u4("div", { style: "display:flex;align-items:center;gap:6px;flex-wrap:wrap;font-size:11px;color:var(--muted);margin-bottom:8px", children: [
           /* @__PURE__ */ u4("span", { style: "display:inline-block;width:6px;height:6px;border-radius:50%;background:" + getAgentColor("copilot") }),
@@ -4202,8 +4266,8 @@
           codexSess.length > 0 && /* @__PURE__ */ u4(AgentCard, { source: "codex", sessions: codexSess })
         ] })
       ] }),
-      /* @__PURE__ */ u4(SectionHead, { title: "CONTEXT GROWTH" }),
-      /* @__PURE__ */ u4(ContextGrowthChart, { sessions: chartSessions.slice(0, CHART_MAX), timelines }),
+      /* @__PURE__ */ u4(SectionHead, { title: "CONTEXT GROWTH", first: pricedSess.length === 0 }),
+      /* @__PURE__ */ u4(ContextGrowthChart, { sessions: chartSessions, timelines }),
       /* @__PURE__ */ u4(SectionHead, { title: "TOKEN USAGE PER SESSION" }),
       /* @__PURE__ */ u4("div", { style: "display:flex;gap:12px;margin-bottom:6px;font-size:10px;color:var(--muted)", children: [
         /* @__PURE__ */ u4("span", { children: [
@@ -4742,37 +4806,29 @@
   }
 
   // media/src/tabs/Export.tsx
-  function send(type) {
+  function send(type, sessionIds) {
     if (vscode) {
-      vscode.postMessage({ type });
+      vscode.postMessage({ type, sessionIds });
     } else {
-      window.dispatchEvent(new MessageEvent("message", { data: { type } }));
+      window.dispatchEvent(new MessageEvent("message", { data: { type, sessionIds } }));
     }
   }
   function Export() {
     const [rawDone, setRawDone] = d2(false);
     const [redactedDone, setRedactedDone] = d2(false);
-    const standalone = !!window.__STANDALONE__;
-    const sessionCount = sessionSummary.value?.sessions?.length ?? 0;
+    const sessions = filteredSessions.value;
+    const empty = sessions.length === 0;
     const doExport = () => {
-      send("exportSessionData");
+      send("exportSessionData", sessions.map((s4) => s4.sessionId));
       setRawDone(true);
       setTimeout(() => setRawDone(false), 3e3);
     };
     const doRedacted = () => {
-      send("exportSessionDataRedacted");
+      send("exportSessionDataRedacted", sessions.map((s4) => s4.sessionId));
       setRedactedDone(true);
       setTimeout(() => setRedactedDone(false), 3e3);
     };
-    const empty = sessionCount === 0;
-    return /* @__PURE__ */ u4("div", { id: "export-content", children: [
-      /* @__PURE__ */ u4("div", { class: "export-meta", children: [
-        sessionCount,
-        " session",
-        sessionCount !== 1 ? "s" : "",
-        standalone && /* @__PURE__ */ u4("span", { class: "export-meta-mode", children: " \xB7 browser download" }),
-        !standalone && /* @__PURE__ */ u4("span", { class: "export-meta-mode", children: " \xB7 written to workspace root" })
-      ] }),
+    return /* @__PURE__ */ u4("div", { id: "export-content", style: "padding-top:8px", children: [
       /* @__PURE__ */ u4("div", { class: "export-cards", children: [
         /* @__PURE__ */ u4("div", { class: "export-card", children: [
           /* @__PURE__ */ u4("div", { class: "export-card-header", children: [
@@ -4851,8 +4907,9 @@
     ["Cache Create Tokens", "Tokens written into the prompt cache on the server during this request. These tokens become available for cache hits on subsequent requests."],
     ["Cache Hit Rate", "The percentage of input tokens served from a server-side prompt cache instead of being reprocessed. Higher rates reduce latency and cost."],
     ["Cache Read Tokens", "Input tokens served from the server-side prompt cache, avoiding reprocessing. Shown in efficiency metrics."],
+    ["Context", "The content sent to the model on a given LLM call: system instructions, conversation history, tool definitions, and the current prompt. Must fit within the context window. Every token costs money \u2014 agents that read large files or accumulate long conversation histories use more context per call, driving up cost."],
     ["Context Bloat", "An efficiency insight triggered when input tokens grow significantly across turns within a session."],
-    ["Context Window", "The block of text sent to the language model on every LLM call. It includes your system instructions, conversation history, tool definitions, and the current prompt. Every token in the context window costs money \u2014 larger context windows mean higher cost per call. Agents that frequently read large files or accumulate long conversation histories fill the context window quickly, driving up cost per session."],
+    ["Context Window", "The maximum number of tokens an LLM can process in a single request, counting both input and output tokens combined. For example, Claude Sonnet has a 200K token context window. This is a hard per-call limit set by the model architecture \u2014 not the same as context, which is what actually fills that window on a given call."],
     ["Files Changed", "Unique files that were created or modified by the agent during the current data collection period."],
     ["Input Tokens", "The number of tokens sent to the language model in a request, including system instructions, conversation history, tool definitions, and the user prompt."],
     ["Loop Signal", "A behavioral signal in the Insights panel (inside the Overview sub-tab of each session) indicating the agent is stuck, oscillating, or making no forward progress. Shown with a \u21BA icon."],
@@ -4883,6 +4940,7 @@
     otel: { href: "#help-otel", heading: "OTEL Data" },
     sessions: { href: "#help-sessions", heading: "Sessions" },
     analytics: { href: "#help-analytics", heading: "Analytics" },
+    patterns: { href: "#help-patterns", heading: "Patterns" },
     settings: { href: "#help-settings", heading: "Settings" },
     mcp: { href: "#help-mcp", heading: "Agent Integration" },
     export: { href: "#help-export", heading: "Export" },
@@ -5498,6 +5556,24 @@ trace_exporter = { otlp-http = { endpoint = "http://localhost:4318", protocol = 
       ] })
     ] });
   }
+  function PatternsSection() {
+    return /* @__PURE__ */ u4("div", { class: "help-section", id: "help-patterns", children: [
+      /* @__PURE__ */ u4("h3", { class: "help-heading", children: HELP_SECTIONS.patterns.heading }),
+      /* @__PURE__ */ u4("div", { class: "help-overview-body", children: [
+        /* @__PURE__ */ u4("p", { children: "The Patterns tab shows behavioral trends across sessions \u2014 not individual session detail, but what happens repeatedly. All panels respect the shared filter bar (agent, source, time range, text search)." }),
+        /* @__PURE__ */ u4("div", { class: "glossary", children: [
+          /* @__PURE__ */ u4("div", { class: "glossary-item", style: "flex-direction:column;gap:4px", children: [
+            /* @__PURE__ */ u4("dt", { class: "glossary-term", children: "Efficiency Map" }),
+            /* @__PURE__ */ u4("dd", { class: "glossary-def", style: "display:block", children: "A scatter plot where each dot is one session. Right = more expensive. Up = more LLM calls. Color = cache hit rate (green \u226560%, orange 20\u201360%, red <20%). Click a dot to navigate to that session. The table below shows the top 10 sessions sorted by the active column \u2014 click any column header to re-sort. Click a session's timestamp to open it in the Sessions tab." })
+          ] }),
+          /* @__PURE__ */ u4("div", { class: "glossary-item", style: "flex-direction:column;gap:4px", children: [
+            /* @__PURE__ */ u4("dt", { class: "glossary-term", children: "Hot Files" }),
+            /* @__PURE__ */ u4("dd", { class: "glossary-def", style: "display:block", children: "Files the agent accessed most frequently across sessions, ranked by session count. Switch between Read, Changed, and Both modes to understand whether the agent is mainly reading or modifying each file. Use this to decide which files to document in your instructions file \u2014 frequently read files cost tokens every session; frequently changed files benefit from explicit constraints." })
+          ] })
+        ] })
+      ] })
+    ] });
+  }
   function SettingsSection() {
     return /* @__PURE__ */ u4("div", { class: "help-section", id: "help-settings", children: [
       /* @__PURE__ */ u4("h3", { class: "help-heading", children: HELP_SECTIONS.settings.heading }),
@@ -5778,6 +5854,7 @@ less expensive, and which loop signals keep recurring.` })
       /* @__PURE__ */ u4(AgentOtelSection, {}),
       /* @__PURE__ */ u4(SessionsSection, {}),
       /* @__PURE__ */ u4(AnalyticsSection, {}),
+      /* @__PURE__ */ u4(PatternsSection, {}),
       /* @__PURE__ */ u4(SettingsSection, {}),
       /* @__PURE__ */ u4(McpSection, {}),
       /* @__PURE__ */ u4(ExportSection, {}),
@@ -5791,28 +5868,35 @@ less expensive, and which loop signals keep recurring.` })
   }
 
   // media/src/tabs/Patterns.tsx
+  var AGENT_DOT_COLOR = {
+    claude_code: "#FFB085",
+    copilot: "#00EAFF",
+    codex: "#F0FF42"
+  };
+  function agentDotColor(source) {
+    return AGENT_DOT_COLOR[source] ?? "#888";
+  }
   function sessionCost(s4) {
     return calcSessionCost(s4, s4.source === "copilot" ? "token" : "token").totalUsd;
   }
   function basename(p5) {
     return p5.replace(/\\/g, "/").split("/").pop() ?? p5;
   }
-  var sectionHead = "font-size:11px;font-weight:600;text-transform:uppercase;letter-spacing:.4px;color:var(--muted);margin:0 0 10px";
+  var sectionHead = "font-size:12px;color:var(--muted);margin:16px 0 6px;text-transform:uppercase;letter-spacing:.3px";
   function EfficiencyMap({ sessions }) {
-    const [filter, setFilter] = d2("");
+    const filter = sessionTextFilter.value;
     const [tooltip, setTooltip] = d2(null);
     const [sort, setSort] = d2({ col: "cost", dir: "desc" });
+    const [clicked, setClicked] = d2(null);
     const svgRef = A2(null);
     const points = sessions.filter((s4) => s4.totalLlmCalls > 0).map((s4) => ({
       s: s4,
       cost: sessionCost(s4),
       turns: s4.totalLlmCalls,
-      cacheHitRate: s4.cacheHitRate ?? 0,
-      matches: filter ? (s4.userRequest ?? "").toLowerCase().includes(filter.toLowerCase()) : true
+      cacheHitRate: s4.cacheHitRate ?? 0
     }));
     if (points.length === 0) return /* @__PURE__ */ u4("div", { class: "empty-state", style: "padding:20px", children: "No sessions with turn data yet." });
-    const matched = points.filter((p5) => p5.matches);
-    const axisPoints = filter.trim() && matched.length > 0 ? matched : points;
+    const axisPoints = points;
     const W = 560, H2 = 240, PAD = { top: 12, right: 16, bottom: 32, left: 52 };
     const cw = W - PAD.left - PAD.right;
     const ch = H2 - PAD.top - PAD.bottom;
@@ -5822,8 +5906,8 @@ less expensive, and which loop signals keep recurring.` })
     const yPos = (turns) => PAD.top + ch - turns / maxTurns * ch;
     const xTicks = [0, 0.25, 0.5, 0.75, 1].map((f5) => ({ v: f5 * maxCost, x: PAD.left + f5 * cw }));
     const yTicks = [0, 0.25, 0.5, 0.75, 1].map((f5) => ({ v: Math.round(f5 * maxTurns), y: PAD.top + ch - f5 * ch }));
-    const sortedMatches = filter.trim() ? (() => {
-      const m4 = [...matched];
+    const sortedMatches = (() => {
+      const m4 = [...points];
       const d5 = sort.dir === "asc" ? 1 : -1;
       if (sort.col === "time") m4.sort((a4, b4) => d5 * (new Date(a4.s.startTime).getTime() - new Date(b4.s.startTime).getTime()));
       if (sort.col === "prompt") m4.sort((a4, b4) => d5 * (a4.s.userRequest ?? "").localeCompare(b4.s.userRequest ?? ""));
@@ -5831,7 +5915,7 @@ less expensive, and which loop signals keep recurring.` })
       if (sort.col === "turns") m4.sort((a4, b4) => d5 * (a4.turns - b4.turns));
       if (sort.col === "cache") m4.sort((a4, b4) => d5 * (a4.cacheHitRate - b4.cacheHitRate));
       return m4.slice(0, 10);
-    })() : [];
+    })();
     const toggleSort = (col) => setSort((s4) => s4.col === col ? { col, dir: s4.dir === "desc" ? "asc" : "desc" } : { col, dir: "desc" });
     const topMatchIds = new Set(sortedMatches.map((p5) => p5.s.traceId));
     return /* @__PURE__ */ u4("div", { children: [
@@ -5849,19 +5933,11 @@ less expensive, and which loop signals keep recurring.` })
         " = model reprocessed everything from scratch on every call (wasteful)."
       ] }),
       /* @__PURE__ */ u4("div", { style: "margin-bottom:8px;display:flex;align-items:center;gap:8px", children: [
-        /* @__PURE__ */ u4(
-          "input",
-          {
-            type: "text",
-            placeholder: "Filter by prompt keyword\u2026",
-            value: filter,
-            onInput: (e4) => setFilter(e4.target.value),
-            style: "flex:1;max-width:240px;padding:3px 7px;font-size:11px;background:var(--vscode-input-background,#3c3c3c);color:var(--vscode-input-foreground,#ccc);border:1px solid var(--vscode-input-border,#555);border-radius:3px;outline:none"
-          }
-        ),
         /* @__PURE__ */ u4("span", { style: "font-size:10px;color:var(--muted)", children: [
-          matched.length,
-          " sessions"
+          points.length,
+          " session",
+          points.length !== 1 ? "s" : "",
+          filter.trim() ? " matching filter" : ""
         ] }),
         /* @__PURE__ */ u4("span", { style: "display:flex;align-items:center;gap:4px;font-size:10px;color:var(--muted)", children: [
           /* @__PURE__ */ u4("span", { style: "display:inline-block;width:8px;height:8px;border-radius:50%;background:#81c784" }),
@@ -5900,8 +5976,7 @@ less expensive, and which loop signals keep recurring.` })
             /* @__PURE__ */ u4("text", { x: PAD.left - 6, y: t4.y + 4, "text-anchor": "end", "font-size": "9", fill: "var(--muted)", children: t4.v })
           ] }, t4.v)),
           /* @__PURE__ */ u4("g", { "clip-path": "url(#plot-area)", children: points.map((p5, i4) => {
-            const inTop = filter.trim() ? topMatchIds.has(p5.s.traceId) : false;
-            if (filter.trim() && !inTop) return null;
+            const inTop = topMatchIds.has(p5.s.traceId);
             const cx = xPos(p5.cost), cy = yPos(p5.turns);
             const color = p5.cacheHitRate >= 0.6 ? "#81c784" : p5.cacheHitRate >= 0.2 ? "#f6a623" : "#f44747";
             return /* @__PURE__ */ u4(
@@ -5909,12 +5984,22 @@ less expensive, and which loop signals keep recurring.` })
               {
                 cx,
                 cy,
-                r: filter.trim() ? 6 : 4,
+                r: inTop ? 5 : 4,
                 fill: color,
-                opacity: 0.85,
+                opacity: inTop ? 1 : 0.6,
                 style: "cursor:pointer",
+                stroke: clicked === p5.s.traceId ? "#fff" : "none",
+                "stroke-width": "2",
                 onMouseEnter: () => setTooltip({ x: cx, y: cy, s: p5.s }),
-                onMouseLeave: () => setTooltip(null)
+                onMouseLeave: () => setTooltip(null),
+                onClick: () => {
+                  const next = clicked === p5.s.traceId ? null : p5.s.traceId;
+                  setClicked(next);
+                  if (next) {
+                    focusedSessionId.value = p5.s.sessionId;
+                    activeTab.value = "sessions";
+                  }
+                }
               },
               i4
             );
@@ -5949,6 +6034,11 @@ less expensive, and which loop signals keep recurring.` })
           ] });
         })()
       ] }),
+      sortedMatches.length > 0 && /* @__PURE__ */ u4("div", { style: "margin-top:8px;font-size:10px;color:var(--muted)", children: [
+        "Top ",
+        sortedMatches.length,
+        " sessions"
+      ] }),
       sortedMatches.length > 0 && (() => {
         const thStyle = (col) => `padding:4px 8px 4px 0;color:${sort.col === col ? "var(--fg)" : "var(--muted)"};font-weight:500;white-space:nowrap;cursor:pointer;user-select:none;font-size:11px`;
         const arrow = (col) => sort.col === col ? sort.dir === "desc" ? " \u2193" : " \u2191" : "";
@@ -5975,16 +6065,33 @@ less expensive, and which loop signals keep recurring.` })
               arrow("cache")
             ] })
           ] }) }),
-          /* @__PURE__ */ u4("tbody", { children: sortedMatches.map((p5, i4) => /* @__PURE__ */ u4("tr", { style: "border-bottom:1px solid var(--border)", children: [
-            /* @__PURE__ */ u4("td", { style: "padding:4px 8px 4px 0;white-space:nowrap;color:var(--muted);font-size:10px;font-variant-numeric:tabular-nums", children: formatSessionTime(p5.s) }),
-            /* @__PURE__ */ u4("td", { style: "padding:4px 8px 4px 0;max-width:280px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;color:var(--fg)", children: p5.s.userRequest?.slice(0, 80) ?? "\u2014" }),
-            /* @__PURE__ */ u4("td", { style: "padding:4px 8px;text-align:right;white-space:nowrap;font-variant-numeric:tabular-nums", children: fmtUsd2(p5.cost) }),
-            /* @__PURE__ */ u4("td", { style: "padding:4px 8px;text-align:right;font-variant-numeric:tabular-nums", children: p5.turns }),
-            /* @__PURE__ */ u4("td", { style: "padding:4px 8px;text-align:right;font-variant-numeric:tabular-nums;color:var(--muted)", children: [
-              Math.round(p5.cacheHitRate * 100),
-              "%"
-            ] })
-          ] }, i4)) })
+          /* @__PURE__ */ u4("tbody", { children: sortedMatches.map((p5, i4) => {
+            const isClicked = clicked === p5.s.traceId;
+            return /* @__PURE__ */ u4("tr", { style: `border-bottom:1px solid var(--border);${isClicked ? "background:rgba(79,195,247,0.08);box-shadow:inset 3px 0 0 var(--accent)" : ""}`, children: [
+              /* @__PURE__ */ u4("td", { style: "padding:4px 8px 4px 0;white-space:nowrap;font-size:10px;font-variant-numeric:tabular-nums", children: [
+                /* @__PURE__ */ u4("span", { style: `display:inline-block;width:7px;height:7px;border-radius:50%;background:${agentDotColor(p5.s.source)};margin-right:5px;flex-shrink:0;vertical-align:middle`, title: getAgentSourceLabel(p5.s.source) }),
+                /* @__PURE__ */ u4(
+                  "span",
+                  {
+                    style: "color:var(--accent);cursor:pointer;text-decoration:underline;text-underline-offset:2px",
+                    title: "Open in Sessions tab",
+                    onClick: () => {
+                      activeTab.value = "sessions";
+                      focusedSessionId.value = p5.s.sessionId;
+                    },
+                    children: formatSessionTime(p5.s)
+                  }
+                )
+              ] }),
+              /* @__PURE__ */ u4("td", { style: "padding:4px 8px 4px 0;max-width:280px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;color:var(--fg)", children: p5.s.userRequest?.slice(0, 80) ?? "\u2014" }),
+              /* @__PURE__ */ u4("td", { style: "padding:4px 8px;text-align:right;white-space:nowrap;font-variant-numeric:tabular-nums", children: fmtUsd2(p5.cost) }),
+              /* @__PURE__ */ u4("td", { style: "padding:4px 8px;text-align:right;font-variant-numeric:tabular-nums", children: p5.turns }),
+              /* @__PURE__ */ u4("td", { style: "padding:4px 8px;text-align:right;font-variant-numeric:tabular-nums;color:var(--muted)", children: [
+                Math.round(p5.cacheHitRate * 100),
+                "%"
+              ] })
+            ] }, i4);
+          }) })
         ] }) });
       })()
     ] });
@@ -6054,9 +6161,9 @@ less expensive, and which loop signals keep recurring.` })
       return /* @__PURE__ */ u4("div", { class: "empty-state", children: "No sessions recorded yet \u2014 patterns will appear once you have session history." });
     }
     const divider = /* @__PURE__ */ u4("div", { style: "border-top:1px solid var(--border);margin:4px 0" });
-    return /* @__PURE__ */ u4("div", { id: "patterns-content", style: "display:flex;flex-direction:column;gap:20px", children: [
+    return /* @__PURE__ */ u4("div", { id: "patterns-content", style: "display:flex;flex-direction:column;gap:20px;padding-top:8px", children: [
       /* @__PURE__ */ u4("section", { children: [
-        /* @__PURE__ */ u4("h3", { style: sectionHead, children: "Efficiency Map" }),
+        /* @__PURE__ */ u4("h3", { style: sectionHead + ";margin-top:0", children: "Efficiency Map" }),
         /* @__PURE__ */ u4(EfficiencyMap, { sessions })
       ] }),
       divider,
@@ -6668,8 +6775,9 @@ Aim to reach a clear stopping point or completion within the next 2-3 steps.`;
     );
   }
   function McpToggle() {
-    const initial = typeof window.__MCP_ENABLED__ === "boolean" ? window.__MCP_ENABLED__ : true;
-    const port = typeof window.__MCP_PORT__ === "number" ? window.__MCP_PORT__ : 4316;
+    const w5 = window;
+    const initial = typeof w5.__MCP_ENABLED__ === "boolean" ? w5.__MCP_ENABLED__ : true;
+    const port = typeof w5.__MCP_PORT__ === "number" ? w5.__MCP_PORT__ : 4316;
     const [enabled, setEnabled] = d2(initial);
     function toggle() {
       const next = !enabled;
@@ -6893,7 +7001,7 @@ Aim to reach a clear stopping point or completion within the next 2-3 steps.`;
           }
         } else if (msg.type === "switchTab" && msg.tab) {
           const tab2 = normalizeTabId(msg.tab);
-          if (tab2 === "alerts" || tab2 === "automation") {
+          if (tab2 === "alerts" || tab2 === "automation" || tab2 === "settings-automation") {
             configOpen.value = true;
           } else {
             activeTab.value = tab2;
@@ -6927,7 +7035,7 @@ Aim to reach a clear stopping point or completion within the next 2-3 steps.`;
       return () => window.removeEventListener("message", handler);
     }, []);
     const tab = normalizeTabId(activeTab.value);
-    const showFilterBars = tab !== "export" && tab !== "help" && tab !== "patterns";
+    const showFilterBars = tab !== "help";
     return /* @__PURE__ */ u4(S, { children: [
       /* @__PURE__ */ u4("div", { class: "tabs", children: [
         /* @__PURE__ */ u4(
@@ -6973,7 +7081,7 @@ Aim to reach a clear stopping point or completion within the next 2-3 steps.`;
     const debounce = A2(null);
     const [loading, setLoading] = d2(false);
     const tab = normalizeTabId(activeTab.value);
-    const showReset = tab === "sessions" || tab === "analytics";
+    const showReset = tab !== "help";
     const isFiltered = sessionTextFilter.value !== "" || selectedAgentFilter.value !== "all" || initiatorFilter.value !== "all" || dataSourceFilter.value !== "all" || sessionLimit.value !== 25 || timeRange.value.preset !== "all" || sessionSortKey.value !== "start_time" || sessionSortDir.value !== "desc";
     function resetFilters() {
       sessionTextFilter.value = "";
@@ -7113,11 +7221,8 @@ Aim to reach a clear stopping point or completion within the next 2-3 steps.`;
     const text = sessionTextFilter.value;
     const iFilter = initiatorFilter.value;
     const dsFilter = dataSourceFilter.value;
-    const tab = normalizeTabId(activeTab.value);
-    const isSessionsTab = tab === "sessions";
-    const isAnalyticsTab = tab === "analytics";
     return /* @__PURE__ */ u4("div", { style: "display:flex;align-items:center;gap:5px;padding:4px 8px 6px;background:var(--vscode-editor-background);border-bottom:1px solid var(--vscode-panel-border);flex-shrink:0;flex-wrap:wrap", children: [
-      isSessionsTab && /* @__PURE__ */ u4(
+      /* @__PURE__ */ u4(
         "input",
         {
           type: "text",
@@ -7129,32 +7234,28 @@ Aim to reach a clear stopping point or completion within the next 2-3 steps.`;
           style: "flex:1;min-width:100px;max-width:200px;padding:3px 7px;font-size:11px;background:var(--vscode-input-background,#3c3c3c);color:var(--vscode-input-foreground,#ccc);border:1px solid var(--vscode-input-border,#555);border-radius:3px;outline:none"
         }
       ),
-      isSessionsTab && /* @__PURE__ */ u4(S, { children: [
-        /* @__PURE__ */ u4("span", { style: "font-size:10px;color:var(--muted);white-space:nowrap;text-transform:uppercase;letter-spacing:.3px", children: "From" }),
-        /* @__PURE__ */ u4(
-          FilterPills,
-          {
-            options: INITIATOR_FILTER_OPTIONS.map((o4) => ({ ...o4, title: o4.value === "all" ? "Show all sessions" : o4.value === "user" ? "Human-typed prompts only" : o4.value === "agent" ? "Agent-spawned sub-tasks only" : "Non-interactive claude -p calls only" })),
-            value: iFilter,
-            onChange: (v4) => {
-              initiatorFilter.value = v4;
-            }
+      /* @__PURE__ */ u4("span", { style: "font-size:10px;color:var(--muted);white-space:nowrap;text-transform:uppercase;letter-spacing:.3px", children: "From" }),
+      /* @__PURE__ */ u4(
+        FilterPills,
+        {
+          options: INITIATOR_FILTER_OPTIONS.map((o4) => ({ ...o4, title: o4.value === "all" ? "Show all sessions" : o4.value === "user" ? "Human-typed prompts only" : o4.value === "agent" ? "Agent-spawned sub-tasks only" : "Non-interactive claude -p calls only" })),
+          value: iFilter,
+          onChange: (v4) => {
+            initiatorFilter.value = v4;
           }
-        )
-      ] }),
-      (isSessionsTab || isAnalyticsTab) && /* @__PURE__ */ u4(S, { children: [
-        /* @__PURE__ */ u4("span", { style: "font-size:10px;color:var(--muted);white-space:nowrap;text-transform:uppercase;letter-spacing:.3px", children: "Source" }),
-        /* @__PURE__ */ u4(
-          FilterPills,
-          {
-            options: DATA_SOURCE_FILTER_OPTIONS.map((o4) => ({ ...o4, title: o4.value === "all" ? "Show all data sources" : o4.value === "otel" ? "OpenTelemetry sessions only" : "Log-file sessions only" })),
-            value: dsFilter,
-            onChange: (v4) => {
-              dataSourceFilter.value = v4;
-            }
+        }
+      ),
+      /* @__PURE__ */ u4("span", { style: "font-size:10px;color:var(--muted);white-space:nowrap;text-transform:uppercase;letter-spacing:.3px", children: "Source" }),
+      /* @__PURE__ */ u4(
+        FilterPills,
+        {
+          options: DATA_SOURCE_FILTER_OPTIONS.map((o4) => ({ ...o4, title: o4.value === "all" ? "Show all data sources" : o4.value === "otel" ? "OpenTelemetry sessions only" : "Log-file sessions only" })),
+          value: dsFilter,
+          onChange: (v4) => {
+            dataSourceFilter.value = v4;
           }
-        )
-      ] }),
+        }
+      ),
       /* @__PURE__ */ u4("span", { style: "margin-left:auto;font-size:10px;color:var(--muted);white-space:nowrap;padding-right:2px", children: [
         filteredSessions.value.length,
         " sessions"

--- a/media/src/App.tsx
+++ b/media/src/App.tsx
@@ -395,7 +395,7 @@ export function App() {
   }, [])
 
   const tab = normalizeTabId(activeTab.value)
-  const showFilterBars = tab !== 'export' && tab !== 'help' && tab !== 'patterns'
+  const showFilterBars = tab !== 'help'
 
   return (
     <>

--- a/media/src/App.tsx
+++ b/media/src/App.tsx
@@ -360,7 +360,7 @@ export function App() {
         }
       } else if (msg.type === 'switchTab' && msg.tab) {
         const tab = normalizeTabId(msg.tab)
-        if (tab === 'alerts' || tab === 'automation') {
+        if (tab === 'alerts' || tab === 'automation' || tab === 'settings-automation') {
           configOpen.value = true
         } else {
           activeTab.value = tab

--- a/media/src/App.tsx
+++ b/media/src/App.tsx
@@ -448,7 +448,7 @@ function TimeRangePicker({ hideAgentFilter = false }: { hideAgentFilter?: boolea
   const debounce = useRef<ReturnType<typeof setTimeout> | null>(null)
   const [loading, setLoading] = useState(false)
   const tab = normalizeTabId(activeTab.value)
-  const showReset = tab === 'sessions' || tab === 'analytics'
+  const showReset = tab !== 'help'
 
   const isFiltered = sessionTextFilter.value !== '' ||
     selectedAgentFilter.value !== 'all' ||
@@ -625,41 +625,28 @@ function SearchFilterBar() {
   const text = sessionTextFilter.value
   const iFilter = initiatorFilter.value
   const dsFilter = dataSourceFilter.value
-  const tab = normalizeTabId(activeTab.value)
-  const isSessionsTab = tab === 'sessions'
-  const isAnalyticsTab = tab === 'analytics'
 
   return (
     <div style="display:flex;align-items:center;gap:5px;padding:4px 8px 6px;background:var(--vscode-editor-background);border-bottom:1px solid var(--vscode-panel-border);flex-shrink:0;flex-wrap:wrap">
-      {isSessionsTab && (
-        <input
-          type="text"
-          placeholder="Filter sessions…"
-          value={text}
-          onInput={e => { sessionTextFilter.value = (e.target as HTMLInputElement).value }}
-          style="flex:1;min-width:100px;max-width:200px;padding:3px 7px;font-size:11px;background:var(--vscode-input-background,#3c3c3c);color:var(--vscode-input-foreground,#ccc);border:1px solid var(--vscode-input-border,#555);border-radius:3px;outline:none"
-        />
-      )}
-      {isSessionsTab && (
-        <>
-          <span style="font-size:10px;color:var(--muted);white-space:nowrap;text-transform:uppercase;letter-spacing:.3px">From</span>
-          <FilterPills
-            options={INITIATOR_FILTER_OPTIONS.map(o => ({ ...o, title: o.value === 'all' ? 'Show all sessions' : o.value === 'user' ? 'Human-typed prompts only' : o.value === 'agent' ? 'Agent-spawned sub-tasks only' : 'Non-interactive claude -p calls only' }))}
-            value={iFilter}
-            onChange={v => { initiatorFilter.value = v }}
-          />
-        </>
-      )}
-      {(isSessionsTab || isAnalyticsTab) && (
-        <>
-          <span style="font-size:10px;color:var(--muted);white-space:nowrap;text-transform:uppercase;letter-spacing:.3px">Source</span>
-          <FilterPills
-            options={DATA_SOURCE_FILTER_OPTIONS.map(o => ({ ...o, title: o.value === 'all' ? 'Show all data sources' : o.value === 'otel' ? 'OpenTelemetry sessions only' : 'Log-file sessions only' }))}
-            value={dsFilter}
-            onChange={v => { dataSourceFilter.value = v }}
-          />
-        </>
-      )}
+      <input
+        type="text"
+        placeholder="Filter sessions…"
+        value={text}
+        onInput={e => { sessionTextFilter.value = (e.target as HTMLInputElement).value }}
+        style="flex:1;min-width:100px;max-width:200px;padding:3px 7px;font-size:11px;background:var(--vscode-input-background,#3c3c3c);color:var(--vscode-input-foreground,#ccc);border:1px solid var(--vscode-input-border,#555);border-radius:3px;outline:none"
+      />
+      <span style="font-size:10px;color:var(--muted);white-space:nowrap;text-transform:uppercase;letter-spacing:.3px">From</span>
+      <FilterPills
+        options={INITIATOR_FILTER_OPTIONS.map(o => ({ ...o, title: o.value === 'all' ? 'Show all sessions' : o.value === 'user' ? 'Human-typed prompts only' : o.value === 'agent' ? 'Agent-spawned sub-tasks only' : 'Non-interactive claude -p calls only' }))}
+        value={iFilter}
+        onChange={v => { initiatorFilter.value = v }}
+      />
+      <span style="font-size:10px;color:var(--muted);white-space:nowrap;text-transform:uppercase;letter-spacing:.3px">Source</span>
+      <FilterPills
+        options={DATA_SOURCE_FILTER_OPTIONS.map(o => ({ ...o, title: o.value === 'all' ? 'Show all data sources' : o.value === 'otel' ? 'OpenTelemetry sessions only' : 'Log-file sessions only' }))}
+        value={dsFilter}
+        onChange={v => { dataSourceFilter.value = v }}
+      />
       <span style="margin-left:auto;font-size:10px;color:var(--muted);white-space:nowrap;padding-right:2px">{filteredSessions.value.length} sessions</span>
     </div>
   )

--- a/media/src/tabs/Analytics.tsx
+++ b/media/src/tabs/Analytics.tsx
@@ -93,11 +93,11 @@ export function Analytics() {
   const timeOrdered = rangedSessions.value
   const pricedChartSess = timeOrdered.filter(s => s.source === 'copilot' || s.source === 'codex' || s.source === 'claude_code')
 
-  // rangedSessions: time-range + agent filtered, with correct in-memory fallback while DB results load
-  const chartSessions = timeOrdered.slice().reverse()
+  // Most recent CHART_MAX sessions (newest-first slice, then reversed to oldest-first for charts)
+  const chartSessions = timeOrdered.slice(0, CHART_MAX).reverse()
 
   // Load timelines for context growth chart
-  chartSessions.slice(0, CHART_MAX).forEach(sess => {
+  chartSessions.forEach(sess => {
     if (!sessionTimelines.value[sess.sessionId] && vscode) {
       vscode.postMessage({ type: 'loadSessionDetail', sessionId: sess.sessionId })
     }
@@ -323,7 +323,7 @@ export function Analytics() {
 
       {/* Context growth */}
       <SectionHead title="CONTEXT GROWTH" />
-      <ContextGrowthChart sessions={chartSessions.slice(0, CHART_MAX)} timelines={timelines} />
+      <ContextGrowthChart sessions={chartSessions} timelines={timelines} />
 
       {/* Token usage per session */}
       <SectionHead title="TOKEN USAGE PER SESSION" />

--- a/media/src/tabs/Analytics.tsx
+++ b/media/src/tabs/Analytics.tsx
@@ -16,11 +16,11 @@ import { computeStats } from './Agents'
 
 // ── Section heading helper ────────────────────────────────────────────────────
 
-function SectionHead({ title, tip }: { title: string; tip?: string }) {
+function SectionHead({ title, tip, first }: { title: string; tip?: string; first?: boolean }) {
   return (
     <h3
       class={tip ? 'has-metric-tip' : undefined}
-      style="margin:16px 0 6px;font-size:12px;color:var(--muted)"
+      style={`margin:${first ? '0' : '16px'} 0 6px;font-size:12px;color:var(--muted);text-transform:uppercase;letter-spacing:.3px`}
       data-tip={tip}
     >{title}</h3>
   )
@@ -166,7 +166,7 @@ export function Analytics() {
       {/* Estimated cost */}
       {pricedSess.length > 0 && (
         <>
-          <SectionHead title="ESTIMATED COST" />
+          <SectionHead title="ESTIMATED COST" first />
           {disclaimer}
 
           {copilotSess.length > 0 && (
@@ -322,7 +322,7 @@ export function Analytics() {
       )}
 
       {/* Context growth */}
-      <SectionHead title="CONTEXT GROWTH" />
+      <SectionHead title="CONTEXT GROWTH" first={pricedSess.length === 0} />
       <ContextGrowthChart sessions={chartSessions} timelines={timelines} />
 
       {/* Token usage per session */}

--- a/media/src/tabs/Analytics.tsx
+++ b/media/src/tabs/Analytics.tsx
@@ -20,7 +20,7 @@ function SectionHead({ title, tip, first }: { title: string; tip?: string; first
   return (
     <h3
       class={tip ? 'has-metric-tip' : undefined}
-      style={`margin:${first ? '0' : '16px'} 0 6px;font-size:12px;color:var(--muted);text-transform:uppercase;letter-spacing:.3px`}
+      style={`margin:${first ? '8px' : '16px'} 0 6px;font-size:12px;color:var(--muted);text-transform:uppercase;letter-spacing:.3px`}
       data-tip={tip}
     >{title}</h3>
   )

--- a/media/src/tabs/Cost.tsx
+++ b/media/src/tabs/Cost.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'preact/hooks'
 import { useEffect, useRef } from 'preact/hooks'
-import { sessionSummary, displaySessions, filteredSessions, dailyStats, lifetimeStats, selectedAgentFilter, timeRange, makeTimeRange } from '../state'
+import { sessionSummary, displaySessions, filteredSessions, dailyStats, lifetimeStats, selectedAgentFilter, timeRange, makeTimeRange, focusedSessionId, activeTab } from '../state'
 import type { TimePreset } from '../state'
 import { getAgentColor, getSessionGlobalNumber, formatCompact, getAgentSourceLabel, formatSessionTime } from '../utils'
 import { calcSessionCost } from '../sessionMetrics'
@@ -229,15 +229,16 @@ export function HistoryChart({ rows }: { rows: DailyStatRow[] }) {
 
 export function CostBarChart({ sessions, mode }: { sessions: SessionSummaryCard[]; mode: PricingMode }) {
   const canvasRef = useRef<HTMLCanvasElement>(null)
+  const barDataRef = useRef<Array<{ sessionId: string; slotX: number; slotW: number }>>([])
 
   useEffect(() => {
     const canvas = canvasRef.current
     if (!canvas) return
 
-    const data = sessions.map(sess => {
+    const data = sessions.slice().reverse().map(sess => {  // oldest → newest left → right
       const cost = calcSessionCost(sess, sessionCostMode(sess, mode))
-      return { cost: cost.totalUsd, unknown: cost.modelUnknown, startTime: sess.startTime, source: sess.source }
-    }).reverse()  // oldest → newest left → right
+      return { sessionId: sess.sessionId, cost: cost.totalUsd, unknown: cost.modelUnknown, startTime: sess.startTime, source: sess.source }
+    })
 
     // Daily totals for the step-function line overlay
     const dayKey = (t: string) => t ? new Date(t).toISOString().slice(0, 10) : 'none'
@@ -290,6 +291,8 @@ export function CostBarChart({ sessions, mode }: { sessions: SessionSummaryCard[
     const barPad = n > 100 ? 0 : n > 50 ? 0.3 : n > 20 ? 0.7 : 1.2
     const barW = Math.max(0.5, slotW - barPad * 2)
     const offsetX = pad.left
+
+    barDataRef.current = data.map((d, i) => ({ sessionId: d.sessionId, slotX: offsetX + i * slotW, slotW }))
 
     // Draw bars
     data.forEach((d, i) => {
@@ -381,9 +384,18 @@ export function CostBarChart({ sessions, mode }: { sessions: SessionSummaryCard[
 
   })
 
+  function handleClick(e: MouseEvent) {
+    const canvas = canvasRef.current; if (!canvas) return
+    const rect = canvas.getBoundingClientRect()
+    const mx = e.clientX - rect.left
+    const hit = barDataRef.current.find(b => mx >= b.slotX && mx < b.slotX + b.slotW)
+    if (hit) { focusedSessionId.value = hit.sessionId; activeTab.value = 'sessions' }
+  }
+
   return (
     <div style="margin-bottom:16px">
-      <canvas ref={canvasRef} style="width:100%;height:230px;display:block" />
+      <canvas ref={canvasRef} style="width:100%;height:230px;display:block;cursor:pointer"
+        onClick={handleClick} title="Click a bar to open that session" />
     </div>
   )
 }

--- a/media/src/tabs/Export.tsx
+++ b/media/src/tabs/Export.tsx
@@ -34,7 +34,7 @@ export function Export() {
     <div id="export-content">
       <div class="export-meta">
         {sessionCount} session{sessionCount !== 1 ? 's' : ''}
-        {standalone && <span class="export-meta-mode"> · browser download</span>}
+        {standalone && null}
         {!standalone && <span class="export-meta-mode"> · written to workspace root</span>}
       </div>
 

--- a/media/src/tabs/Export.tsx
+++ b/media/src/tabs/Export.tsx
@@ -29,7 +29,7 @@ export function Export() {
   }
 
   return (
-    <div id="export-content">
+    <div id="export-content" style="padding-top:8px">
 
       <div class="export-cards">
 

--- a/media/src/tabs/Export.tsx
+++ b/media/src/tabs/Export.tsx
@@ -1,42 +1,35 @@
 import { useState } from 'preact/hooks'
-import { sessionSummary, vscode } from '../state'
+import { filteredSessions, vscode } from '../state'
 
-function send(type: string) {
+function send(type: string, sessionIds: string[]) {
   if (vscode) {
-    vscode.postMessage({ type })
+    vscode.postMessage({ type, sessionIds })
   } else {
-    window.dispatchEvent(new MessageEvent('message', { data: { type } }))
+    window.dispatchEvent(new MessageEvent('message', { data: { type, sessionIds } }))
   }
 }
 
 export function Export() {
   const [rawDone, setRawDone] = useState(false)
   const [redactedDone, setRedactedDone] = useState(false)
-  const standalone = !!(window as { __STANDALONE__?: boolean }).__STANDALONE__
 
-  const sessionCount = sessionSummary.value?.sessions?.length ?? 0
+  const sessions = filteredSessions.value
+  const empty = sessions.length === 0
 
   const doExport = () => {
-    send('exportSessionData')
+    send('exportSessionData', sessions.map(s => s.sessionId))
     setRawDone(true)
     setTimeout(() => setRawDone(false), 3000)
   }
 
   const doRedacted = () => {
-    send('exportSessionDataRedacted')
+    send('exportSessionDataRedacted', sessions.map(s => s.sessionId))
     setRedactedDone(true)
     setTimeout(() => setRedactedDone(false), 3000)
   }
 
-  const empty = sessionCount === 0
-
   return (
     <div id="export-content">
-      <div class="export-meta">
-        {sessionCount} session{sessionCount !== 1 ? 's' : ''}
-        {standalone && null}
-        {!standalone && <span class="export-meta-mode"> · written to workspace root</span>}
-      </div>
 
       <div class="export-cards">
 

--- a/media/src/tabs/Help.tsx
+++ b/media/src/tabs/Help.tsx
@@ -45,6 +45,7 @@ const HELP_SECTIONS = {
   otel:       { href: '#help-otel',       heading: 'OTEL Data' },
   sessions:   { href: '#help-sessions',   heading: 'Sessions' },
   analytics:  { href: '#help-analytics',  heading: 'Analytics' },
+  patterns:   { href: '#help-patterns',   heading: 'Patterns' },
   settings:   { href: '#help-settings',   heading: 'Settings' },
   mcp:        { href: '#help-mcp',        heading: 'Agent Integration' },
   export:     { href: '#help-export',     heading: 'Export' },
@@ -505,6 +506,27 @@ function AnalyticsSection() {
   )
 }
 
+function PatternsSection() {
+  return (
+    <div class="help-section" id="help-patterns">
+      <h3 class="help-heading">{HELP_SECTIONS.patterns.heading}</h3>
+      <div class="help-overview-body">
+        <p>The Patterns tab shows behavioral trends across sessions — not individual session detail, but what happens repeatedly. All panels respect the shared filter bar (agent, source, time range, text search).</p>
+        <div class="glossary">
+          <div class="glossary-item" style="flex-direction:column;gap:4px">
+            <dt class="glossary-term">Efficiency Map</dt>
+            <dd class="glossary-def" style="display:block">A scatter plot where each dot is one session. Right = more expensive. Up = more LLM calls. Color = cache hit rate (green ≥60%, orange 20–60%, red &lt;20%). Click a dot to navigate to that session. The table below shows the top 10 sessions sorted by the active column — click any column header to re-sort. Click a session's timestamp to open it in the Sessions tab.</dd>
+          </div>
+          <div class="glossary-item" style="flex-direction:column;gap:4px">
+            <dt class="glossary-term">Hot Files</dt>
+            <dd class="glossary-def" style="display:block">Files the agent accessed most frequently across sessions, ranked by session count. Switch between Read, Changed, and Both modes to understand whether the agent is mainly reading or modifying each file. Use this to decide which files to document in your instructions file — frequently read files cost tokens every session; frequently changed files benefit from explicit constraints.</dd>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
 function SettingsSection() {
   return (
     <div class="help-section" id="help-settings">
@@ -741,6 +763,7 @@ export function Help() {
       <AgentOtelSection />
       <SessionsSection />
       <AnalyticsSection />
+      <PatternsSection />
       <SettingsSection />
       <McpSection />
       <ExportSection />

--- a/media/src/tabs/Patterns.tsx
+++ b/media/src/tabs/Patterns.tsx
@@ -22,7 +22,7 @@ function basename(p: string): string {
   return p.replace(/\\/g, '/').split('/').pop() ?? p
 }
 
-const sectionHead = 'font-size:12px;color:var(--muted);margin:16px 0 6px'
+const sectionHead = 'font-size:12px;color:var(--muted);margin:16px 0 6px;text-transform:uppercase;letter-spacing:.3px'
 
 // ── Efficiency Map ────────────────────────────────────────────────────────────
 

--- a/media/src/tabs/Patterns.tsx
+++ b/media/src/tabs/Patterns.tsx
@@ -1,11 +1,18 @@
 import { useState, useRef } from 'preact/hooks'
-import { filteredSessions } from '../state'
+import { filteredSessions, activeTab, focusedSessionId } from '../state'
 import { getAgentSourceLabel, formatSessionTime } from '../utils'
 import { calcSessionCost } from '../sessionMetrics'
 import { fmtUsd } from './Cost'
 import type { SessionSummaryCard } from '../types'
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
+
+const AGENT_DOT_COLOR: Record<string, string> = {
+  claude_code: '#FFB085',
+  copilot:     '#00EAFF',
+  codex:       '#F0FF42',
+}
+function agentDotColor(source: string): string { return AGENT_DOT_COLOR[source] ?? '#888' }
 
 function sessionCost(s: SessionSummaryCard): number {
   return calcSessionCost(s, s.source === 'copilot' ? 'token' : 'token').totalUsd
@@ -25,6 +32,7 @@ function EfficiencyMap({ sessions }: { sessions: SessionSummaryCard[] }) {
   const [filter, setFilter] = useState('')
   const [tooltip, setTooltip] = useState<{ x: number; y: number; s: SessionSummaryCard } | null>(null)
   const [sort, setSort] = useState<{ col: MatchSort; dir: 'asc' | 'desc' }>({ col: 'cost', dir: 'desc' })
+  const [clicked, setClicked] = useState<string | null>(null)
   const svgRef = useRef<SVGSVGElement>(null)
 
   const points = sessions
@@ -81,7 +89,7 @@ function EfficiencyMap({ sessions }: { sessions: SessionSummaryCard[] }) {
           type="text"
           placeholder="Filter by prompt keyword…"
           value={filter}
-          onInput={e => setFilter((e.target as HTMLInputElement).value)}
+          onInput={e => { setFilter((e.target as HTMLInputElement).value); setClicked(null) }}
           style="flex:1;max-width:240px;padding:3px 7px;font-size:11px;background:var(--vscode-input-background,#3c3c3c);color:var(--vscode-input-foreground,#ccc);border:1px solid var(--vscode-input-border,#555);border-radius:3px;outline:none"
         />
         <span style="font-size:10px;color:var(--muted)">{matched.length} sessions</span>
@@ -129,8 +137,10 @@ function EfficiencyMap({ sessions }: { sessions: SessionSummaryCard[] }) {
               return (
                 <circle key={i} cx={cx} cy={cy} r={filter.trim() ? 6 : 4}
                   fill={color} opacity={0.85} style="cursor:pointer"
+                  stroke={clicked === p.s.traceId ? '#fff' : 'none'} stroke-width="2"
                   onMouseEnter={() => setTooltip({ x: cx, y: cy, s: p.s })}
                   onMouseLeave={() => setTooltip(null)}
+                  onClick={() => setClicked(id => id === p.s.traceId ? null : p.s.traceId)}
                 />
               )
             })}
@@ -172,15 +182,23 @@ function EfficiencyMap({ sessions }: { sessions: SessionSummaryCard[] }) {
                 </tr>
               </thead>
               <tbody>
-                {sortedMatches.map((p, i) => (
-                  <tr key={i} style="border-bottom:1px solid var(--border)">
-                    <td style="padding:4px 8px 4px 0;white-space:nowrap;color:var(--muted);font-size:10px;font-variant-numeric:tabular-nums">{formatSessionTime(p.s)}</td>
+                {sortedMatches.map((p, i) => {
+                  const isClicked = clicked === p.s.traceId
+                  return (
+                  <tr key={i} style={`border-bottom:1px solid var(--border);${isClicked ? 'background:rgba(79,195,247,0.08);box-shadow:inset 3px 0 0 var(--accent)' : ''}`}>
+                    <td style="padding:4px 8px 4px 0;white-space:nowrap;font-size:10px;font-variant-numeric:tabular-nums">
+                      <span style={`display:inline-block;width:7px;height:7px;border-radius:50%;background:${agentDotColor(p.s.source)};margin-right:5px;flex-shrink:0;vertical-align:middle`} title={getAgentSourceLabel(p.s.source)} />
+                      <span style="color:var(--accent);cursor:pointer;text-decoration:underline;text-underline-offset:2px"
+                        title="Open in Sessions tab"
+                        onClick={() => { activeTab.value = 'sessions'; focusedSessionId.value = p.s.sessionId }}
+                      >{formatSessionTime(p.s)}</span>
+                    </td>
                     <td style="padding:4px 8px 4px 0;max-width:280px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;color:var(--fg)">{p.s.userRequest?.slice(0, 80) ?? '—'}</td>
                     <td style="padding:4px 8px;text-align:right;white-space:nowrap;font-variant-numeric:tabular-nums">{fmtUsd(p.cost)}</td>
                     <td style="padding:4px 8px;text-align:right;font-variant-numeric:tabular-nums">{p.turns}</td>
                     <td style="padding:4px 8px;text-align:right;font-variant-numeric:tabular-nums;color:var(--muted)">{Math.round(p.cacheHitRate * 100)}%</td>
                   </tr>
-                ))}
+                )})}
               </tbody>
             </table>
           </div>

--- a/media/src/tabs/Patterns.tsx
+++ b/media/src/tabs/Patterns.tsx
@@ -140,7 +140,11 @@ function EfficiencyMap({ sessions }: { sessions: SessionSummaryCard[] }) {
                   stroke={clicked === p.s.traceId ? '#fff' : 'none'} stroke-width="2"
                   onMouseEnter={() => setTooltip({ x: cx, y: cy, s: p.s })}
                   onMouseLeave={() => setTooltip(null)}
-                  onClick={() => setClicked(id => id === p.s.traceId ? null : p.s.traceId)}
+                  onClick={() => {
+                    const next = clicked === p.s.traceId ? null : p.s.traceId
+                    setClicked(next)
+                    if (next) { focusedSessionId.value = p.s.sessionId; activeTab.value = 'sessions' }
+                  }}
                 />
               )
             })}

--- a/media/src/tabs/Patterns.tsx
+++ b/media/src/tabs/Patterns.tsx
@@ -427,7 +427,7 @@ export function Patterns() {
   const divider = <div style="border-top:1px solid var(--border);margin:4px 0" />
 
   return (
-    <div id="patterns-content" style="display:flex;flex-direction:column;gap:20px">
+    <div id="patterns-content" style="display:flex;flex-direction:column;gap:20px;padding-top:8px">
       <section>
         <h3 style={sectionHead}>Efficiency Map</h3>
         <EfficiencyMap sessions={sessions} />

--- a/media/src/tabs/Patterns.tsx
+++ b/media/src/tabs/Patterns.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef } from 'preact/hooks'
-import { filteredSessions, activeTab, focusedSessionId } from '../state'
+import { filteredSessions, activeTab, focusedSessionId, sessionTextFilter } from '../state'
 import { getAgentSourceLabel, formatSessionTime } from '../utils'
 import { calcSessionCost } from '../sessionMetrics'
 import { fmtUsd } from './Cost'
@@ -29,7 +29,7 @@ const sectionHead = 'font-size:11px;font-weight:600;text-transform:uppercase;let
 type MatchSort = 'time' | 'prompt' | 'cost' | 'turns' | 'cache'
 
 function EfficiencyMap({ sessions }: { sessions: SessionSummaryCard[] }) {
-  const [filter, setFilter] = useState('')
+  const filter = sessionTextFilter.value
   const [tooltip, setTooltip] = useState<{ x: number; y: number; s: SessionSummaryCard } | null>(null)
   const [sort, setSort] = useState<{ col: MatchSort; dir: 'asc' | 'desc' }>({ col: 'cost', dir: 'desc' })
   const [clicked, setClicked] = useState<string | null>(null)
@@ -42,13 +42,11 @@ function EfficiencyMap({ sessions }: { sessions: SessionSummaryCard[] }) {
       cost: sessionCost(s),
       turns: s.totalLlmCalls,
       cacheHitRate: s.cacheHitRate ?? 0,
-      matches: filter ? (s.userRequest ?? '').toLowerCase().includes(filter.toLowerCase()) : true,
     }))
 
   if (points.length === 0) return <div class="empty-state" style="padding:20px">No sessions with turn data yet.</div>
 
-  const matched = points.filter(p => p.matches)
-  const axisPoints = filter.trim() && matched.length > 0 ? matched : points
+  const axisPoints = points
 
   const W = 560, H = 240, PAD = { top: 12, right: 16, bottom: 32, left: 52 }
   const cw = W - PAD.left - PAD.right
@@ -63,8 +61,8 @@ function EfficiencyMap({ sessions }: { sessions: SessionSummaryCard[] }) {
   const xTicks = [0, 0.25, 0.5, 0.75, 1].map(f => ({ v: f * maxCost, x: PAD.left + f * cw }))
   const yTicks = [0, 0.25, 0.5, 0.75, 1].map(f => ({ v: Math.round(f * maxTurns), y: PAD.top + ch - f * ch }))
 
-  const sortedMatches = filter.trim() ? (() => {
-    const m = [...matched]
+  const sortedMatches = (() => {
+    const m = [...points]
     const d = sort.dir === 'asc' ? 1 : -1
     if (sort.col === 'time')   m.sort((a, b) => d * (new Date(a.s.startTime).getTime() - new Date(b.s.startTime).getTime()))
     if (sort.col === 'prompt') m.sort((a, b) => d * (a.s.userRequest ?? '').localeCompare(b.s.userRequest ?? ''))
@@ -72,7 +70,7 @@ function EfficiencyMap({ sessions }: { sessions: SessionSummaryCard[] }) {
     if (sort.col === 'turns')  m.sort((a, b) => d * (a.turns - b.turns))
     if (sort.col === 'cache')  m.sort((a, b) => d * (a.cacheHitRate - b.cacheHitRate))
     return m.slice(0, 10)
-  })() : []
+  })()
 
   const toggleSort = (col: MatchSort) =>
     setSort(s => s.col === col ? { col, dir: s.dir === 'desc' ? 'asc' : 'desc' } : { col, dir: 'desc' })
@@ -85,14 +83,7 @@ function EfficiencyMap({ sessions }: { sessions: SessionSummaryCard[] }) {
         Each dot is one session. <strong style="color:var(--fg)">Right</strong> = more expensive. <strong style="color:var(--fg)">Up</strong> = more model calls. <strong style="color:var(--fg)">Top-right</strong> dots cost the most and required the most back-and-forth — start there. <strong style="color:#81c784">Green</strong> = model reused cached context between calls (efficient). <strong style="color:#f44747">Red</strong> = model reprocessed everything from scratch on every call (wasteful).
       </div>
       <div style="margin-bottom:8px;display:flex;align-items:center;gap:8px">
-        <input
-          type="text"
-          placeholder="Filter by prompt keyword…"
-          value={filter}
-          onInput={e => { setFilter((e.target as HTMLInputElement).value); setClicked(null) }}
-          style="flex:1;max-width:240px;padding:3px 7px;font-size:11px;background:var(--vscode-input-background,#3c3c3c);color:var(--vscode-input-foreground,#ccc);border:1px solid var(--vscode-input-border,#555);border-radius:3px;outline:none"
-        />
-        <span style="font-size:10px;color:var(--muted)">{matched.length} sessions</span>
+        <span style="font-size:10px;color:var(--muted)">{points.length} session{points.length !== 1 ? 's' : ''}{filter.trim() ? ' matching filter' : ''}</span>
         <span style="display:flex;align-items:center;gap:4px;font-size:10px;color:var(--muted)">
           <span style="display:inline-block;width:8px;height:8px;border-radius:50%;background:#81c784" /> cache ≥60%
           <span style="display:inline-block;width:8px;height:8px;border-radius:50%;background:#f6a623;margin-left:6px" /> 20–60%
@@ -130,13 +121,12 @@ function EfficiencyMap({ sessions }: { sessions: SessionSummaryCard[] }) {
           ))}
           <g clip-path="url(#plot-area)">
             {points.map((p, i) => {
-              const inTop = filter.trim() ? topMatchIds.has(p.s.traceId) : false
-              if (filter.trim() && !inTop) return null
+              const inTop = topMatchIds.has(p.s.traceId)
               const cx = xPos(p.cost), cy = yPos(p.turns)
               const color = p.cacheHitRate >= 0.6 ? '#81c784' : p.cacheHitRate >= 0.2 ? '#f6a623' : '#f44747'
               return (
-                <circle key={i} cx={cx} cy={cy} r={filter.trim() ? 6 : 4}
-                  fill={color} opacity={0.85} style="cursor:pointer"
+                <circle key={i} cx={cx} cy={cy} r={inTop ? 5 : 4}
+                  fill={color} opacity={inTop ? 1 : 0.6} style="cursor:pointer"
                   stroke={clicked === p.s.traceId ? '#fff' : 'none'} stroke-width="2"
                   onMouseEnter={() => setTooltip({ x: cx, y: cy, s: p.s })}
                   onMouseLeave={() => setTooltip(null)}
@@ -169,6 +159,7 @@ function EfficiencyMap({ sessions }: { sessions: SessionSummaryCard[] }) {
         })()}
       </div>
 
+      {sortedMatches.length > 0 && <div style="margin-top:8px;font-size:10px;color:var(--muted)">Top {sortedMatches.length} sessions</div>}
       {sortedMatches.length > 0 && (() => {
         const thStyle = (col: MatchSort) =>
           `padding:4px 8px 4px 0;color:${sort.col === col ? 'var(--fg)' : 'var(--muted)'};font-weight:500;white-space:nowrap;cursor:pointer;user-select:none;font-size:11px`

--- a/media/src/tabs/Patterns.tsx
+++ b/media/src/tabs/Patterns.tsx
@@ -22,7 +22,7 @@ function basename(p: string): string {
   return p.replace(/\\/g, '/').split('/').pop() ?? p
 }
 
-const sectionHead = 'font-size:11px;font-weight:600;text-transform:uppercase;letter-spacing:.4px;color:var(--muted);margin:0 0 10px'
+const sectionHead = 'font-size:12px;color:var(--muted);margin:16px 0 6px'
 
 // ── Efficiency Map ────────────────────────────────────────────────────────────
 

--- a/media/src/tabs/Patterns.tsx
+++ b/media/src/tabs/Patterns.tsx
@@ -429,7 +429,7 @@ export function Patterns() {
   return (
     <div id="patterns-content" style="display:flex;flex-direction:column;gap:20px;padding-top:8px">
       <section>
-        <h3 style={sectionHead}>Efficiency Map</h3>
+        <h3 style={sectionHead + ';margin-top:0'}>Efficiency Map</h3>
         <EfficiencyMap sessions={sessions} />
       </section>
 

--- a/media/src/tabs/SessionCharts.tsx
+++ b/media/src/tabs/SessionCharts.tsx
@@ -50,6 +50,7 @@ export function ContextGrowthChart({ sessions, timelines }: { sessions: SessionS
 
   const [paused, setPaused] = useState(false)
   const [hasData, setHasData] = useState(false)
+  const [seriesCount, setSeriesCount] = useState(0)
   const [speed, setSpeed] = useState(1)
   const pausedRef = useRef(false)
   const speedRef = useRef(1)
@@ -109,6 +110,7 @@ export function ContextGrowthChart({ sessions, timelines }: { sessions: SessionS
     }
     canvas.style.display = 'block'
     setHasData(true)
+    setSeriesCount(seriesData.length)
     seriesCountRef.current = seriesData.length
 
     const maxTurns = Math.max(...seriesData.map(s => s.points.length), 2)
@@ -306,6 +308,7 @@ export function ContextGrowthChart({ sessions, timelines }: { sessions: SessionS
             <button style={btnStyle} onClick={stepPrev} title="Previous session">◀</button>
             <button style={btnStyle} onClick={stepNext} title="Next session">▶</button>
           </div>
+          <span style="font-size:10px;color:var(--muted)">{seriesCount} of {sessions.length} session{sessions.length !== 1 ? 's' : ''}</span>
         </div>
       )}
       <div style="text-align:center;font-size:9px;color:var(--muted);margin-top:4px">

--- a/media/src/tabs/SessionCharts.tsx
+++ b/media/src/tabs/SessionCharts.tsx
@@ -296,8 +296,6 @@ export function ContextGrowthChart({ sessions, timelines }: { sessions: SessionS
                 title={`${s}× speed`}
               >{s === 0.5 ? '½×' : `${s}×`}</button>
             ))}
-          </div>
-          <div style="display:flex;align-items:center;gap:6px">
             <button style={btnStyle} onClick={stepPrev} title="Previous session">◀</button>
             <button style={btnStyle} onClick={stepNext} title="Next session">▶</button>
           </div>

--- a/media/src/tabs/SessionCharts.tsx
+++ b/media/src/tabs/SessionCharts.tsx
@@ -250,12 +250,14 @@ export function ContextGrowthChart({ sessions, timelines }: { sessions: SessionS
 
   function stepPrev() {
     clearTimer(); pausedRef.current = true; setPaused(true)
+    focusedSessionId.value = null
     activeIdxRef.current = Math.max(0, activeIdxRef.current - 1)
     drawFnRef.current?.(activeIdxRef.current)
   }
 
   function stepNext() {
     clearTimer(); pausedRef.current = true; setPaused(true)
+    focusedSessionId.value = null
     activeIdxRef.current = Math.min(seriesCountRef.current - 1, activeIdxRef.current + 1)
     drawFnRef.current?.(activeIdxRef.current)
   }

--- a/media/src/tabs/SessionCharts.tsx
+++ b/media/src/tabs/SessionCharts.tsx
@@ -308,7 +308,7 @@ export function ContextGrowthChart({ sessions, timelines }: { sessions: SessionS
             <button style={btnStyle} onClick={stepPrev} title="Previous session">◀</button>
             <button style={btnStyle} onClick={stepNext} title="Next session">▶</button>
           </div>
-          <span style="font-size:10px;color:var(--muted)">{seriesCount} of {sessions.length} session{sessions.length !== 1 ? 's' : ''}</span>
+          <span style="font-size:10px;color:var(--muted)">most recent {seriesCount} of {sessions.length} session{sessions.length !== 1 ? 's' : ''}</span>
         </div>
       )}
       <div style="text-align:center;font-size:9px;color:var(--muted);margin-top:4px">

--- a/media/src/tabs/SessionCharts.tsx
+++ b/media/src/tabs/SessionCharts.tsx
@@ -85,8 +85,11 @@ export function ContextGrowthChart({ sessions, timelines }: { sessions: SessionS
 
     const seriesData: GrowthSeries[] = []
     sessions.forEach(sess => {
+      // Accept 'tool' entries with inputTokens too: log-sourced sessions classify
+      // tool-using turns as type:'tool' even though they represent LLM calls with tokens.
+      // OTel 'tool' entries never have inputTokens, so this doesn't double-count.
       const llmEntries = (timelines[sess.sessionId] ?? sess.timeline ?? [])
-        .filter(e => e.type === 'llm' && (e.inputTokens ?? 0) > 0)
+        .filter(e => (e.type === 'llm' || e.type === 'tool') && (e.inputTokens ?? 0) > 0)
       if (llmEntries.length < 1) return
       seriesData.push({
         sessionId: sess.sessionId,
@@ -281,10 +284,11 @@ export function ContextGrowthChart({ sessions, timelines }: { sessions: SessionS
       <canvas
         ref={canvasRef}
         id="context-growth-chart"
-        style="width:100%;height:200px;display:block;cursor:pointer"
+        style="width:100%;height:200px;cursor:pointer"
         onClick={handleCanvasClick}
         title="Click a line to select that session"
       />
+      {!hasData && <div class="empty-state" style="font-size:11px">No per-turn token data for these sessions. Context Growth requires sessions with per-turn input token counts — available for OTel-sourced sessions and Claude Code log sessions.</div>}
       {hasData && (
         <div style="display:flex;align-items:center;justify-content:space-between;margin-top:5px">
           <div style="display:flex;align-items:center;gap:6px">

--- a/media/src/tabs/SessionCharts.tsx
+++ b/media/src/tabs/SessionCharts.tsx
@@ -1,6 +1,6 @@
 import * as preact from 'preact'
 import { useEffect, useRef, useState } from 'preact/hooks'
-import { sessionSummary, displaySessions, rangedSessions, agentFilteredSessions, filteredSessions, sessionTimelines, burnRateData, focusedSessionId, CHART_MAX, COLORS, vscode, goToHelp, timeRange } from '../state'
+import { sessionSummary, displaySessions, rangedSessions, agentFilteredSessions, filteredSessions, sessionTimelines, burnRateData, focusedSessionId, activeTab, CHART_MAX, COLORS, vscode, goToHelp, timeRange } from '../state'
 import {
   getSessionGlobalNumber,
   formatMs, formatCompact, getAgentColor, getAgentSourceLabel, formatSessionTime, formatSessionTimeShort,
@@ -268,7 +268,10 @@ export function ContextGrowthChart({ sessions, timelines }: { sessions: SessionS
         if (dist < bestDist) { bestDist = dist; bestId = s.sessionId }
       })
     })
-    if (bestId) focusedSessionId.value = focusedSessionId.peek() === bestId ? null : bestId
+    if (bestId) {
+      focusedSessionId.value = focusedSessionId.peek() === bestId ? null : bestId
+      if (focusedSessionId.value) activeTab.value = 'sessions'
+    }
   }
 
   const btnStyle = 'padding:2px 8px;font-size:11px;cursor:pointer;background:transparent;border:1px solid var(--border);border-radius:3px;color:var(--muted);line-height:1.4'
@@ -414,6 +417,7 @@ function SessionRow({ sess, idx, heat, expanded, onToggle }: {
 
 export function SessionTokenChart({ sessions }: { sessions: SessionSummaryCard[] }) {
   const canvasRef = useRef<HTMLCanvasElement>(null)
+  const sessionDataRef = useRef<Array<{ sessionId: string; startTime: string; input: number; output: number; source: string; slotX: number; slotW: number }>>([])
 
   useEffect(() => {
     const canvas = canvasRef.current
@@ -426,10 +430,10 @@ export function SessionTokenChart({ sessions }: { sessions: SessionSummaryCard[]
       .map(sess => {
         const input = sess.inputTokens ?? 0, output = sess.outputTokens ?? 0
         return input + output > 0
-          ? { startTime: sess.startTime, input, output, source: sess.source }
+          ? { sessionId: sess.sessionId, startTime: sess.startTime, input, output, source: sess.source }
           : null
       })
-      .filter(Boolean) as Array<{ startTime: string; input: number; output: number; source: string }>
+      .filter(Boolean) as Array<{ sessionId: string; startTime: string; input: number; output: number; source: string }>
 
     if (sessionData.length === 0) { canvas.style.display = 'none'; return }
     canvas.style.display = 'block'
@@ -480,6 +484,8 @@ export function SessionTokenChart({ sessions }: { sessions: SessionSummaryCard[]
     let lastDayLabelX = -Infinity
     const MIN_DAY_LABEL_GAP = 30
 
+    sessionDataRef.current = sessionData.map((s, i) => ({ ...s, slotX: pad.left + i * slotW, slotW }))
+
     sessionData.forEach((s, i) => {
       const slotX = pad.left + i * slotW
       const inH = (s.input / maxIn) * chartH
@@ -506,12 +512,21 @@ export function SessionTokenChart({ sessions }: { sessions: SessionSummaryCard[]
     })
   })
 
+  function handleTokenChartClick(e: MouseEvent) {
+    const canvas = canvasRef.current; if (!canvas) return
+    const rect = canvas.getBoundingClientRect()
+    const mx = e.clientX - rect.left
+    const hit = sessionDataRef.current.find(s => mx >= s.slotX && mx < s.slotX + s.slotW)
+    if (hit) { focusedSessionId.value = hit.sessionId; activeTab.value = 'sessions' }
+  }
+
   const presentSources = new Set(sessions.map(s => s.source).filter(Boolean))
   const agentSources = (['copilot', 'claude_code', 'codex'] as const).filter(src => presentSources.has(src))
 
   return (
     <>
-      <canvas ref={canvasRef} style="width:100%;height:160px;display:block" />
+      <canvas ref={canvasRef} style="width:100%;height:160px;display:block;cursor:pointer"
+        onClick={handleTokenChartClick} title="Click a bar to open that session" />
       {agentSources.length > 0 && (
         <div style="display:flex;gap:10px;justify-content:center;margin-top:4px;flex-wrap:wrap">
           {agentSources.map(src => (

--- a/media/src/tabs/Sessions.tsx
+++ b/media/src/tabs/Sessions.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'preact/hooks'
+import { useState, useEffect, useRef } from 'preact/hooks'
 import {
   filteredSessions, sessionSummary, sessionTimelines, burnRateData,
   focusedSessionId, vscode, ignoredInsightKeys,
@@ -240,9 +240,17 @@ function SessionDetail({ sess }: { sess: SessionSummaryCard }) {
 function SessionRow({ sess }: { sess: SessionSummaryCard }) {
   const [expanded, setExpanded] = useState(false)
   const isFocused = focusedSessionId.value === sess.sessionId
+  const rowRef = useRef<HTMLTableRowElement>(null)
   const cost = calcSessionCost(sess, 'token')
   const color = getAgentColor(sess.source)
   const prompt = sess.userRequest ?? ''
+
+  useEffect(() => {
+    if (focusedSessionId.value === sess.sessionId) {
+      setExpanded(true)
+      rowRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+    }
+  }, [focusedSessionId.value])
 
   function toggle() {
     const next = !expanded
@@ -255,6 +263,7 @@ function SessionRow({ sess }: { sess: SessionSummaryCard }) {
   return (
     <>
       <tr
+        ref={rowRef}
         onClick={toggle}
         style={`cursor:pointer;background:${rowBg};border-bottom:1px solid var(--vscode-panel-border)`}
       >

--- a/media/src/tabs/Sessions.tsx
+++ b/media/src/tabs/Sessions.tsx
@@ -367,7 +367,7 @@ export function Sessions() {
   const thMuted = thBase + ';color:var(--muted);font-weight:500'
 
   return (
-    <div id="sessions-content">
+    <div id="sessions-content" style="padding-top:8px">
       <div style="overflow-x:auto">
       <table style="width:100%;border-collapse:collapse;font-size:11px">
         <thead>

--- a/src/dashboardPanel.ts
+++ b/src/dashboardPanel.ts
@@ -92,7 +92,8 @@ export class DashboardPanel {
         })
       } else if (msg.type === 'exportSessionData' || msg.type === 'exportSessionDataRedacted') {
         const redact = msg.type === 'exportSessionDataRedacted'
-        void this.exportSessions(redact)
+        const ids = Array.isArray(msg.sessionIds) ? new Set(msg.sessionIds as string[]) : null
+        void this.exportSessions(redact, ids)
       } else if (msg.type === 'openSidebar') {
         vscode.commands.executeCommand('workbench.view.extension.agent-lens')
       } else if (msg.type === 'closeSidebar') {
@@ -146,8 +147,9 @@ export class DashboardPanel {
     })
   }
 
-  private async exportSessions(redact: boolean): Promise<void> {
-    const sessions = this.repo.listSessions()
+  private async exportSessions(redact: boolean, ids: Set<string> | null = null): Promise<void> {
+    const all = this.repo.listSessions()
+    const sessions = ids ? all.filter(s => ids.has(s.sessionId)) : all
     if (sessions.length === 0) {
       vscode.window.showInformationMessage('AgentLens: No session data to export')
       return

--- a/standalone/cli.js
+++ b/standalone/cli.js
@@ -20430,6 +20430,12 @@ function getHtml() {
             var autoFull = '[' + (msg.label || 'Automation') + ']\\n\\n' + sessionLine + msg.prompt;
             var autoPreview = msg.prompt.length > 160 ? msg.prompt.slice(0, 160) + '\u2026' : msg.prompt;
             var autoLabel = 'Automation: ' + (msg.label || 'Automation');
+            var viewAutomations = {
+              label: 'View Automations',
+              onClick: function() {
+                window.dispatchEvent(new MessageEvent('message', { data: { type: 'switchTab', tab: 'settings-automation' } }));
+              }
+            };
             if (msg.writePromptsFile) {
               fetch('/api/write-prompts-file', {
                 method: 'POST',
@@ -20439,10 +20445,10 @@ function getHtml() {
                 var slug = msg.agent === 'claude_code' ? 'claude' : msg.agent === 'codex' ? 'codex' : 'copilot';
                 showToast('Prompt written to agentlens-prompts-' + slug + '.md');
               }).catch(function() {
-                showActionNotification(autoLabel, autoFull, '#f6a623', autoPreview);
+                showActionNotification(autoLabel, autoFull, '#f6a623', autoPreview, viewAutomations, 30000);
               });
             } else {
-              showActionNotification(autoLabel, autoFull, '#f6a623', autoPreview);
+              showActionNotification(autoLabel, autoFull, '#f6a623', autoPreview, viewAutomations, 30000);
             }
           } else if (msg.type === 'askAI' && msg.prompt) {
             navigator.clipboard.writeText(msg.prompt).then(function() {
@@ -20452,7 +20458,11 @@ function getHtml() {
             });
           } else if (msg.type === 'exportSessionData' || msg.type === 'exportSessionDataRedacted') {
             var redact = msg.type === 'exportSessionDataRedacted';
-            var exportable = (__latestSessions__ || []).map(function(s) {
+            var exportIds = Array.isArray(msg.sessionIds) ? new Set(msg.sessionIds) : null;
+            var exportSessions = exportIds
+              ? (__latestSessions__ || []).filter(function(s) { return exportIds.has(s.sessionId); })
+              : (__latestSessions__ || []);
+            var exportable = exportSessions.map(function(s) {
               return {
                 sessionId:         s.sessionId,
                 traceId:           s.traceId,

--- a/standalone/server.ts
+++ b/standalone/server.ts
@@ -747,7 +747,11 @@ function getHtml(): string {
             });
           } else if (msg.type === 'exportSessionData' || msg.type === 'exportSessionDataRedacted') {
             var redact = msg.type === 'exportSessionDataRedacted';
-            var exportable = (__latestSessions__ || []).map(function(s) {
+            var exportIds = Array.isArray(msg.sessionIds) ? new Set(msg.sessionIds) : null;
+            var exportSessions = exportIds
+              ? (__latestSessions__ || []).filter(function(s) { return exportIds.has(s.sessionId); })
+              : (__latestSessions__ || []);
+            var exportable = exportSessions.map(function(s) {
               return {
                 sessionId:         s.sessionId,
                 traceId:           s.traceId,

--- a/standalone/server.ts
+++ b/standalone/server.ts
@@ -719,6 +719,12 @@ function getHtml(): string {
             var autoFull = '[' + (msg.label || 'Automation') + ']\\n\\n' + sessionLine + msg.prompt;
             var autoPreview = msg.prompt.length > 160 ? msg.prompt.slice(0, 160) + '…' : msg.prompt;
             var autoLabel = 'Automation: ' + (msg.label || 'Automation');
+            var viewAutomations = {
+              label: 'View Automations',
+              onClick: function() {
+                window.dispatchEvent(new MessageEvent('message', { data: { type: 'switchTab', tab: 'settings-automation' } }));
+              }
+            };
             if (msg.writePromptsFile) {
               fetch('/api/write-prompts-file', {
                 method: 'POST',
@@ -728,10 +734,10 @@ function getHtml(): string {
                 var slug = msg.agent === 'claude_code' ? 'claude' : msg.agent === 'codex' ? 'codex' : 'copilot';
                 showToast('Prompt written to agentlens-prompts-' + slug + '.md');
               }).catch(function() {
-                showActionNotification(autoLabel, autoFull, '#f6a623', autoPreview);
+                showActionNotification(autoLabel, autoFull, '#f6a623', autoPreview, viewAutomations, 30000);
               });
             } else {
-              showActionNotification(autoLabel, autoFull, '#f6a623', autoPreview);
+              showActionNotification(autoLabel, autoFull, '#f6a623', autoPreview, viewAutomations, 30000);
             }
           } else if (msg.type === 'askAI' && msg.prompt) {
             navigator.clipboard.writeText(msg.prompt).then(function() {


### PR DESCRIPTION
Closes #96
Closes #97

## Summary

Post-merge polish following the initial Patterns tab. All changes build on the merged `feat/cross-session-patterns` work.

**Patterns tab**
- Efficiency Map dot click navigates to Sessions tab, expands session
- Table: agent colored dot before time, dot-click row highlight, time hyperlink to session
- Section headers all-caps with letter-spacing; first section spacing fixed; padding above content

**Analytics tab**  
- `SectionHead` gets all-caps + letter-spacing; first section top margin adjusted
- Context Growth: fixed missing chart for log-sourced sessions (type:'tool' entries with inputTokens now counted)
- Context Growth: shows most recent 25 (was oldest 25); ◀▶ step buttons fixed; session count label
- Clicking bars (Estimated Cost, Token Usage) or lines (Context Growth) navigates to session

**Shared filter bar**
- Full filter bar (text, From, Source, time range, reset) shown on Analytics, Patterns, and Export
- State retained across tab switches

**Export**
- Respects active filter — filtered session IDs sent to backend for both VS Code and standalone
- Session count header removed; padding added

**Docs**
- Help: new Patterns section with Efficiency Map and Hot Files descriptions
- README: Patterns feature bullet added; Export bullet updated

## Test plan
- [ ] Efficiency Map: click dot → Sessions tab opens, session expands and scrolls into view
- [ ] Efficiency Map: agent dot visible in table; time link navigates to session
- [ ] Context Growth: appears for Claude Code log sessions (tool-heavy sessions)
- [ ] Context Growth: shows most recent 25; step buttons highlight correct line
- [ ] Filter bar on Patterns/Analytics/Export — setting text filter updates all three tabs
- [ ] Export with agent filter → only filtered sessions in downloaded file
- [ ] Help → Patterns section visible in TOC and content

🤖 Generated with [Claude Code](https://claude.com/claude-code)