### PR TITLE
fix: Analytics charts now respect text and initiator filters

### DIFF
--- a/media/src/tabs/Analytics.tsx
+++ b/media/src/tabs/Analytics.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'preact/hooks'
 import {
-  filteredSessions, sessionSummary, agentFilteredSessions, rangedSessions,
+  filteredSessions, sessionSummary, agentFilteredSessions,
   sessionTimelines,
   CHART_MAX, vscode,
 } from '../state'
@@ -88,9 +88,12 @@ export function Analytics() {
   const claudeSess  = sessions.filter(s => s.source === 'claude_code')
   const codexSess   = sessions.filter(s => s.source === 'codex')
 
-  // Charts always use time-ordered (newest-first) sessions so internal .reverse() gives oldest-first.
-  // filteredSessions may be sorted by cost/model/etc — that's only for the Sessions table.
-  const timeOrdered = rangedSessions.value
+  // Charts need time-ordered sessions and must respect all active filters (text, initiator, source).
+  // filteredSessions applies all filters but may be sorted by cost/model for the Sessions table,
+  // so re-sort by time here. rangedSessions skips text + initiator — don't use it for charts.
+  const timeOrdered = [...filteredSessions.value].sort((a, b) =>
+    Date.parse(b.startTime || '0') - Date.parse(a.startTime || '0')
+  )
   const pricedChartSess = timeOrdered.filter(s => s.source === 'copilot' || s.source === 'codex' || s.source === 'claude_code')
 
   // Most recent CHART_MAX sessions (newest-first slice, then reversed to oldest-first for charts)


### PR DESCRIPTION
Closes #99

## Problem
Charts on the Analytics tab (Estimated Cost, Token Usage Per Session, Context Growth) were not updating when the text filter or From filter was changed. The cost table and Agent Breakdown cards updated correctly.

## Root cause
Charts used `rangedSessions` (agent + source + time range only) instead of `filteredSessions` (all filters including text and initiator).

## Fix
Re-sort `filteredSessions` by time for chart consumption. The sort is necessary because `filteredSessions` may be ordered by cost/model when the user sorts the Sessions table.

## Test plan
- [ ] Type text in filter box on Analytics tab → all three charts update to show only matching sessions
- [ ] Set From filter to "Agent" → charts update
- [ ] Set Source filter to "Log" → charts update (was already working via agentFilteredSessions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)