### PR TITLE
ux: generic restart message on MCP toggle

### DIFF
--- a/media/src/App.tsx
+++ b/media/src/App.tsx
@@ -130,7 +130,7 @@ function McpToggle() {
           Listening at <code style="font-size:10px;background:var(--card-bg);padding:1px 4px;border-radius:3px">http://localhost:{port}/mcp</code>
         </div>
       )}
-      <div style="font-size:10px;color:var(--muted);margin-top:4px">{vscode ? 'Restart VS Code to apply changes.' : 'Restart the server to apply changes.'}</div>
+      <div style="font-size:10px;color:var(--muted);margin-top:4px">Restart to apply changes.</div>
     </div>
   )
 }


### PR DESCRIPTION
Closes the issue above.

The MCP toggle previously showed different text depending on context:
- VS Code: "Restart VS Code to apply changes."
- Standalone: "Restart the server to apply changes."

Simplified to "Restart to apply changes." — works for both contexts and is shorter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)