### PR TITLE
feat: instruction effectiveness tracking — Apply button, before/after metrics, remove

### DIFF
--- a/media/src/tabs/Instructions.tsx
+++ b/media/src/tabs/Instructions.tsx
@@ -470,7 +470,7 @@ function TextBlock({ label, text }: { label: string; text: string }) {
 }
 
 function SuggestionCardView({
-  card, dismissed, applied, onDismiss,
+  card, dismissed, applied, files, onApply, onDismiss,
 }: {
   card: SuggestionCard
   dismissed: boolean
@@ -479,9 +479,19 @@ function SuggestionCardView({
   onApply: (id: string, targetFile: string, text: string) => void
   onDismiss: (id: string) => void
 }) {
+  const defaultFile = files.find(f => f.exists)?.relativePath ?? files[0]?.relativePath ?? ''
+  const [targetFile, setTargetFile] = useState(defaultFile)
+  const [applying, setApplying] = useState(false)
+
   if (dismissed || applied) return null
 
   const catColor = CAT_COLOR[card.category]
+
+  function handleApplyClick() {
+    setApplying(true)
+    onApply(card.id, targetFile || defaultFile, card.suggestedText)
+    setTimeout(() => setApplying(false), 1500)
+  }
 
   return (
     <div style="border:1px solid var(--border);border-radius:6px;margin-bottom:10px;overflow:hidden">
@@ -510,7 +520,7 @@ function SuggestionCardView({
       <div style="padding:10px 12px;border-top:1px solid var(--border);background:var(--card-bg);display:flex;flex-direction:column;gap:10px">
         <TextBlock label="Recommended addition:" text={card.suggestedText} />
         <TextBlock label="Ask your agent:" text={card.inquiryText} />
-        <div>
+        <div style="display:flex;align-items:center;gap:6px;flex-wrap:wrap">
           <button
             onClick={() => {
               evidenceSessionIds.value = new Set(card.evidenceSessions)
@@ -519,6 +529,26 @@ function SuggestionCardView({
             style="padding:2px 8px;font-size:10px;border-radius:3px;cursor:pointer;border:1px solid var(--border);background:transparent;color:var(--muted);white-space:nowrap"
             title="View the sessions that triggered this suggestion"
           >View sessions ↗</button>
+          {files.length > 0 && (
+            <div style="display:flex;align-items:center;gap:4px;margin-left:auto">
+              <select
+                value={targetFile}
+                onChange={e => setTargetFile((e.target as HTMLSelectElement).value)}
+                style="padding:2px 4px;font-size:10px;border-radius:3px;border:1px solid var(--border);background:var(--vscode-input-background,#3c3c3c);color:var(--muted);cursor:pointer;max-width:160px"
+              >
+                {files.map(f => (
+                  <option key={f.relativePath} value={f.relativePath}>
+                    {f.relativePath}{f.exists ? '' : ' (create)'}
+                  </option>
+                ))}
+              </select>
+              <button
+                onClick={handleApplyClick}
+                disabled={applying}
+                style={`padding:2px 10px;font-size:10px;border-radius:3px;cursor:pointer;border:1px solid var(--accent,#4fc3f7);background:transparent;color:var(--accent,#4fc3f7);white-space:nowrap;opacity:${applying ? 0.6 : 1}`}
+              >{applying ? '✓ Applied' : 'Apply to file'}</button>
+            </div>
+          )}
         </div>
       </div>
     </div>
@@ -672,7 +702,11 @@ export function Instructions() {
 
   // Request instruction files from extension when workspace changes
   useEffect(() => {
-    if (workspace !== 'all' && vscode) {
+    if (workspace === 'all') {
+      instructionFiles.value = []
+      return
+    }
+    if (vscode) {
       vscode.postMessage({ type: 'getInstructionFiles', workspace })
       vscode.postMessage({ type: 'getAppliedSuggestions', workspace })
       vscode.postMessage({ type: 'getDismissedSuggestions', workspace })
@@ -682,6 +716,13 @@ export function Instructions() {
   function handleApply(id: string, targetFile: string, text: string) {
     const card = suggestions.find(s => s.id === id)
     if (!card) return
+    const nowMs = Date.now()
+    const record: AppliedRecord = {
+      id, workspace, category: card.category, title: card.title,
+      suggestedText: card.suggestedText, appliedTo: targetFile,
+      appliedText: text, appliedAt: new Date().toISOString(), appliedAtMs: nowMs,
+      baselineCostAvg: 0, baselineTurnsAvg: 0, baselineInsufficient: true,
+    }
     if (vscode) {
       vscode.postMessage({
         type: 'applyInstructionSuggestion',
@@ -689,17 +730,13 @@ export function Instructions() {
         category: card.category, title: card.title, suggestedText: card.suggestedText,
       })
     } else {
-      // Standalone: optimistically add to applied list
-      const nowMs = Date.now()
-      appliedSuggestions.value = [
-        ...appliedSuggestions.value,
-        {
-          id, workspace, category: card.category, title: card.title,
-          suggestedText: card.suggestedText, appliedTo: targetFile,
-          appliedText: text, appliedAt: new Date().toISOString(), appliedAtMs: nowMs,
-          baselineCostAvg: 0, baselineTurnsAvg: 0, baselineInsufficient: true,
-        },
-      ]
+      // Standalone: write to file via server, then optimistically update UI
+      fetch('/api/instructions/apply', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ workspace, targetFile, appliedText: text, id }),
+      }).catch(() => { /* non-fatal — UI already updated */ })
+      appliedSuggestions.value = [...appliedSuggestions.value, record]
     }
   }
 
@@ -710,7 +747,12 @@ export function Instructions() {
 
   function handleRemove(id: string) {
     appliedSuggestions.value = appliedSuggestions.value.filter(a => a.id !== id)
-    if (vscode) vscode.postMessage({ type: 'removeInstructionSuggestion', id, workspace })
+    if (vscode) {
+      vscode.postMessage({ type: 'removeInstructionSuggestion', id, workspace })
+    } else {
+      fetch(`/api/instructions/applied/${encodeURIComponent(id)}`, { method: 'DELETE' })
+        .catch(() => { /* non-fatal */ })
+    }
   }
 
   if (wsSessions.length < 3) {

--- a/standalone/server.ts
+++ b/standalone/server.ts
@@ -1092,6 +1092,30 @@ const uiServer = http.createServer((req, res) => {
     return
   }
 
+  const removeMatch = req.method === 'DELETE' && url?.match(/^\/api\/instructions\/applied\/(.+)$/)
+  if (removeMatch) {
+    const id = decodeURIComponent(removeMatch[1])
+    try {
+      const { removeSuggestion } = require('../src/instructionFiles') as typeof import('../src/instructionFiles')
+      // Best-effort file removal: workspace+targetFile not known in standalone, so scan all workspaces
+      // The client-side signal is already updated; this is for file cleanup only.
+      const sessionWorkspaces = [...new Set((buildSessionSummary()?.sessions ?? []).map(s => s.workspace ?? '').filter(Boolean))]
+      for (const ws of sessionWorkspaces) {
+        const files = detectInstructionFiles(ws)
+        for (const f of files.filter(f => f.exists)) {
+          removeSuggestion(f.filePath, id)
+        }
+      }
+      res.writeHead(200, { 'Content-Type': 'application/json' })
+      res.end(JSON.stringify({ ok: true }))
+    } catch (e) {
+      console.warn('[AgentLens] DELETE /api/instructions/applied error:', e)
+      res.writeHead(500, { 'Content-Type': 'application/json' })
+      res.end(JSON.stringify({ error: String(e) }))
+    }
+    return
+  }
+
   if (req.method === 'POST' && url === '/action') {
     const chunks: Buffer[] = []
     req.on('data', (c: Buffer) => chunks.push(c))


### PR DESCRIPTION
## Summary

- Re-adds **Apply to file** affordance to each suggestion card: a file-picker dropdown + "Apply to file" button. Selecting a target instruction file and clicking Apply writes the suggested text with an `<!-- AgentLens suggestion applied -->` marker, records a baseline snapshot of the last 20 sessions (cost/turns/errors/loop rate), and moves the card to the **Applied** section.
- **AppliedCard** (already implemented) now has a live entry point — shows before/after cost, turns, errors, and loop rate with trend arrows and a confidence bar (low/medium/high based on post-application session count).
- **Impact summary** at the top of the Applied section aggregates across all applied suggestions with enough data (avg cost change, avg turns change, improving/flat/worse counts).
- **Remove**: removes the marker block from the instruction file and moves the suggestion back to Pending.
- Standalone: Apply now calls `POST /api/instructions/apply` to write the file; Remove calls `DELETE /api/instructions/applied/:id`.
- Clears `instructionFiles` signal when switching to "All projects" so stale file options don't appear in the picker.

Closes #118

## What was already implemented (not changed here)

The backend stack was already in place from the previous branch:
- `instructionEffectiveness.ts` — `computeBaseline`, `computePostMetrics`, `computeEffectiveness`, `computeImpactSummary`
- `instructionRepository.ts` — SQLite CRUD for applied/dismissed suggestions
- `schema.ts` — `instruction_applied` and `instruction_dismissed` tables
- `instructionFiles.ts` — `appendSuggestion`, `removeSuggestion`
- `dashboardPanel.ts` — all message handlers (apply, remove, dismiss)
- `AppliedCard`, `ConfidenceBar`, impact summary aggregate UI — already rendered, just had no data because Apply button was missing

## Test plan

- [ ] Select a workspace with ≥ 3 sessions — suggestion cards appear
- [ ] File picker shows all three instruction files (✓ existing, ✗ not found with "(create)" label)
- [ ] Click "Apply to file" — card moves to Applied section; file gains the suggestion block with comment marker
- [ ] Applied card shows "Collecting data…" until 3 post-application sessions accumulate
- [ ] After enough sessions: before/after cost and turns appear with ↓/↑ trend arrows
- [ ] Confidence bar advances: low → medium → high at session thresholds 3/8/15
- [ ] Click Remove — card returns to Pending; marker block removed from instruction file
- [ ] Impact summary appears at top of Applied when ≥ 2 suggestions have data
- [ ] Switch to "All projects" — Apply button disappears (no stale file options)

🤖 Generated with [Claude Code](https://claude.com/claude-code)