### PR TITLE
fix: apply fast mode cost multiplier from usage speed field

### DIFF
--- a/PRICING_SOURCES.md
+++ b/PRICING_SOURCES.md
@@ -110,6 +110,7 @@ On `claude_code.llm_request` spans (per-API-call):
 
 | Model                          | Input   | Cache Write (5m) | Cache Write (1h) | Cache Read | Output   |
 | ------------------------------ | ------- | ---------------- | ---------------- | ---------- | -------- |
+| `claude-opus-4-8`              | $5.00   | $6.25            | $10.00           | $0.50      | $25.00   |
 | `claude-opus-4-7`              | $5.00   | $6.25            | $10.00           | $0.50      | $25.00   |
 | `claude-opus-4-6`              | $5.00   | $6.25            | $10.00           | $0.50      | $25.00   |
 | `claude-opus-4-5`              | $5.00   | $6.25            | $10.00           | $0.50      | $25.00   |
@@ -117,8 +118,9 @@ On `claude_code.llm_request` spans (per-API-call):
 | `claude-sonnet-4-5`            | $3.00   | $3.75            | $6.00            | $0.30      | $15.00   |
 | `claude-sonnet-4`              | $3.00   | $3.75            | $6.00            | $0.30      | $15.00   |
 | `claude-haiku-4-5`             | $1.00   | $1.25            | $2.00            | $0.10      | $5.00    |
-| `claude-opus-4-7` (fast mode)  | $30.00  | $37.50           | $60.00           | $3.00      | $150.00  |
-| `claude-opus-4-6` (fast mode)  | $30.00  | $37.50           | $60.00           | $3.00      | $150.00  |
+| `claude-opus-4-8` (fast, 2x)   | $10.00  | $12.50           | $20.00           | $1.00      | $50.00   |
+| `claude-opus-4-7` (fast, 6x)   | $30.00  | $37.50           | $60.00           | $3.00      | $150.00  |
+| `claude-opus-4-6` (fast, 6x)   | $30.00  | $37.50           | $60.00           | $3.00      | $150.00  |
 
 **Deprecated models (for historical sessions):**
 
@@ -134,7 +136,7 @@ A new tokenizer was deployed for claude-opus-4-7 on April 16, 2026 that generate
 **Known gaps:**
 
 - **Cache write TTL**: Anthropic supports 5-minute and 1-hour cache TTLs at different rates. The `cache_creation_tokens` field in telemetry does not distinguish between them. Claude Code CLI uses 5-minute caches by default, so the 5-minute rate is used. If 1-hour caches are in use, cost will be underestimated by ~37%.
-- **Fast mode (`/fast`)**: When Claude Code's fast mode is active, Opus requests are billed at $30 input / $150 output per MTok — 6× the standard Opus rate. The model ID in telemetry does not carry a `-fast` suffix, so fast-mode sessions are costed at the standard Opus rate and will be significantly underestimated.
+- **Fast mode (`/fast`)**: When fast mode is active, `usage.speed` is `"fast"` in the log. AgentLens reads this and appends `-fast` to the stored model ID (e.g. `claude-opus-4-7-fast`) so the correct multiplied rates are applied: 6x for Opus 4.6/4.7, 2x for Opus 4.8.
 - **Deprecated models**: Models older than claude-opus-4 (e.g. claude-3-5-sonnet, claude-3-opus) may appear in historical sessions. Add them to `RATES` in `pricing.ts` if encountered; missing models show as `~$?`.
 
 ---

--- a/media/src/pricing.ts
+++ b/media/src/pricing.ts
@@ -60,9 +60,11 @@ const RATES: Record<string, ModelRates> = {
   'claude-opus-4-5':       { inputPerMTok:  5.00, cacheReadPerMTok: 0.50, cacheWritePerMTok:  6.25, outputPerMTok: 25.00, multiplier: 3,    multiplierAnnualPostJun1: 15 },
   'claude-opus-4-6':       { inputPerMTok:  5.00, cacheReadPerMTok: 0.50, cacheWritePerMTok:  6.25, outputPerMTok: 25.00, multiplier: 3,    multiplierAnnualPostJun1: 27 },
   'claude-opus-4-7':       { inputPerMTok:  5.00, cacheReadPerMTok: 0.50, cacheWritePerMTok:  6.25, outputPerMTok: 25.00, multiplier: 15,   multiplierAnnualPostJun1: 27 },
-  // fast mode (/fast toggle in Claude Code) — 6× standard Opus rates; model ID in telemetry does NOT include -fast suffix (known gap)
+  'claude-opus-4-8':       { inputPerMTok:  5.00, cacheReadPerMTok: 0.50, cacheWritePerMTok:  6.25, outputPerMTok: 25.00, multiplier: 15,   multiplierAnnualPostJun1: 27 },
+  // fast mode (/fast toggle in Claude Code) — model ID appended with -fast by logReader when usage.speed === 'fast'
   'claude-opus-4-6-fast':  { inputPerMTok: 30.00, cacheReadPerMTok: 3.00, cacheWritePerMTok: 37.50, outputPerMTok: 150.00, multiplier: 30, multiplierAnnualPostJun1: 30 },
   'claude-opus-4-7-fast':  { inputPerMTok: 30.00, cacheReadPerMTok: 3.00, cacheWritePerMTok: 37.50, outputPerMTok: 150.00, multiplier: 30, multiplierAnnualPostJun1: 30 },
+  'claude-opus-4-8-fast':  { inputPerMTok: 10.00, cacheReadPerMTok: 1.00, cacheWritePerMTok: 12.50, outputPerMTok:  50.00, multiplier: 30, multiplierAnnualPostJun1: 30 },
   // ── Google ─────────────────────────────────────────────────────────────────────────────────────
   'gemini-2.5-pro':   { inputPerMTok: 1.25, cacheReadPerMTok: 0.125, cacheWritePerMTok: 0, outputPerMTok: 10.00, multiplier: 1,    multiplierAnnualPostJun1: 1 },  // long-context surcharge (>200K tokens) not implemented
   'gemini-3-flash':   { inputPerMTok: 0.50, cacheReadPerMTok: 0.05,  cacheWritePerMTok: 0, outputPerMTok: 3.00,  multiplier: 0.33, multiplierAnnualPostJun1: 0.33 },

--- a/src/logReader.ts
+++ b/src/logReader.ts
@@ -272,6 +272,7 @@ export class LogReader {
     let totalInput = 0, totalOutput = 0, totalCacheRead = 0, totalCacheCreate = 0
     let peakContextPerTurn = 0
     let turns = 0, totalToolCalls = 0
+    let hasFastMode = false
     const filesChanged = new Set<string>()
     const filesWritten = new Set<string>()
     const filesRead    = new Set<string>()
@@ -307,7 +308,9 @@ export class LogReader {
       if (entry['type'] === 'assistant') {
         const msg = entry['message'] as Record<string, unknown> | undefined
         if (msg?.['model']) model = msg['model'] as string
-        const usage = msg?.['usage'] as Record<string, number> | undefined
+        const rawUsage = msg?.['usage'] as Record<string, unknown> | undefined
+        if (rawUsage?.['speed'] === 'fast') hasFastMode = true
+        const usage = rawUsage as Record<string, number> | undefined
         if (usage) {
           const inp  = usage['input_tokens']                ?? 0
           const cr   = usage['cache_read_input_tokens']     ?? 0
@@ -343,7 +346,8 @@ export class LogReader {
     }
 
     if (!firstTimestamp) return null
-    return { workspace, card: _buildCard(sessionId, 'claude_code', model || 'claude', firstTimestamp, lastTimestamp, { totalInput, totalOutput, totalCacheRead, totalCacheCreate, peakContextPerTurn, turns, totalToolCalls, toolCounts, filesRead, filesChanged, filesWritten, filesSearched: new Set(), userRequest, timeline, initiator }, workspace) }
+    const effectiveModel = (model && hasFastMode) ? `${model}-fast` : model
+    return { workspace, card: _buildCard(sessionId, 'claude_code', effectiveModel || 'claude', firstTimestamp, lastTimestamp, { totalInput, totalOutput, totalCacheRead, totalCacheCreate, peakContextPerTurn, turns, totalToolCalls, toolCounts, filesRead, filesChanged, filesWritten, filesSearched: new Set(), userRequest, timeline, initiator }, workspace) }
   }
 
   // ── Codex ───────────────────────────────────────────────────────────────────

--- a/src/pricing.ts
+++ b/src/pricing.ts
@@ -41,8 +41,10 @@ const RATES: Record<string, ModelRates> = {
   'claude-opus-4-5':    { inputPerMTok:  5.00, cacheReadPerMTok: 0.50,  cacheWritePerMTok:  6.25, outputPerMTok: 25.00, contextWindowTokens: 200_000 },
   'claude-opus-4-6':    { inputPerMTok:  5.00, cacheReadPerMTok: 0.50,  cacheWritePerMTok:  6.25, outputPerMTok: 25.00, contextWindowTokens: 200_000 },
   'claude-opus-4-7':    { inputPerMTok:  5.00, cacheReadPerMTok: 0.50,  cacheWritePerMTok:  6.25, outputPerMTok: 25.00, contextWindowTokens: 200_000 },
+  'claude-opus-4-8':    { inputPerMTok:  5.00, cacheReadPerMTok: 0.50,  cacheWritePerMTok:  6.25, outputPerMTok: 25.00, contextWindowTokens: 200_000 },
   'claude-opus-4-6-fast':{ inputPerMTok: 30.00, cacheReadPerMTok: 3.00, cacheWritePerMTok: 37.50, outputPerMTok: 150.00, contextWindowTokens: 200_000 },
   'claude-opus-4-7-fast':{ inputPerMTok: 30.00, cacheReadPerMTok: 3.00, cacheWritePerMTok: 37.50, outputPerMTok: 150.00, contextWindowTokens: 200_000 },
+  'claude-opus-4-8-fast':{ inputPerMTok: 10.00, cacheReadPerMTok: 1.00, cacheWritePerMTok: 12.50, outputPerMTok:  50.00, contextWindowTokens: 200_000 },
   // ── Google ─────────────────────────────────────────────────────────────────
   'gemini-2.5-pro':  { inputPerMTok: 1.25, cacheReadPerMTok: 0.125, cacheWritePerMTok: 0, outputPerMTok: 10.00, contextWindowTokens: 1_000_000 },
   'gemini-3-flash':  { inputPerMTok: 0.50, cacheReadPerMTok: 0.05,  cacheWritePerMTok: 0, outputPerMTok:  3.00, contextWindowTokens: 1_000_000 },


### PR DESCRIPTION
Closes #123

## Summary

- `_parseClaudeFile` in `src/logReader.ts` now reads `usage.speed` on each assistant turn; when any turn has `speed === "fast"`, the session model is stored as `${model}-fast` (e.g. `claude-opus-4-7-fast`) so the existing multiplied rate entries are matched at cost calculation time
- Adds `claude-opus-4-8` and `claude-opus-4-8-fast` (2×) to both pricing files — Opus 4.8 has a lower fast multiplier than 4.6/4.7 (2× vs 6×)
- Updates `PRICING_SOURCES.md` rates table and converts the fast-mode known gap into a description of how it now works

## Test plan

- [ ] Existing sessions (all `speed: standard`) produce identical costs before and after
- [ ] A synthetic log entry with `usage.speed === "fast"` on a `claude-opus-4-7` session stores the model as `claude-opus-4-7-fast` and costs 6× the standard rate

🤖 Generated with [Claude Code](https://claude.com/claude-code)