### PR TITLE
fix: support tiered pricing for models with >200K token surcharge

### DIFF
--- a/PRICING_SOURCES.md
+++ b/PRICING_SOURCES.md
@@ -77,7 +77,7 @@ Claude Code CLI uses Anthropic API token-based pricing only — no request-multi
 
 **Who it applies to:** All Claude Code CLI users billed through the Anthropic API.
 
-**Source:** <https://www.anthropic.com/pricing> (verified 2026-05-28)
+**Source:** <https://platform.claude.com/docs/en/about-claude/pricing> (verified 2026-06-08)
 
 **Formula:**
 
@@ -106,7 +106,7 @@ On `claude_code.llm_request` spans (per-API-call):
 - `ttft_ms` — time to first token in ms
 - `stop_reason` — e.g. `tool_use`, `end_turn`
 
-**Rates (USD per 1M tokens, verified 2026-05-28):**
+**Rates (USD per 1M tokens, verified 2026-06-08):**
 
 | Model                          | Input   | Cache Write (5m) | Cache Write (1h) | Cache Read | Output   |
 | ------------------------------ | ------- | ---------------- | ---------------- | ---------- | -------- |
@@ -121,6 +121,19 @@ On `claude_code.llm_request` spans (per-API-call):
 | `claude-opus-4-8` (fast, 2x)   | $10.00  | $12.50           | $20.00           | $1.00      | $50.00   |
 | `claude-opus-4-7` (fast, 6x)   | $30.00  | $37.50           | $60.00           | $3.00      | $150.00  |
 | `claude-opus-4-6` (fast, 6x)   | $30.00  | $37.50           | $60.00           | $3.00      | $150.00  |
+
+**Tiered pricing — `claude-sonnet-4` only:**
+
+`claude-sonnet-4` has a two-tier rate structure where per-token rates increase once a single API call exceeds 200K tokens for a given token category. The tier is applied per-category (input, output, cache read, cache write each evaluated against the 200K threshold independently):
+
+| Token category | ≤200K rate | >200K rate |
+| -------------- | ---------- | ---------- |
+| Input          | $3.00/MTok | $6.00/MTok |
+| Output         | $15.00/MTok| $22.50/MTok|
+| Cache write    | $3.75/MTok | $7.50/MTok |
+| Cache read     | $0.30/MTok | $0.60/MTok |
+
+The threshold applies per API call, not cumulatively across a session. `calcTokenCostUsd` in `src/pricing.ts` applies this tiered rate per turn (which corresponds to one API call). The session-level `calcTokenCost` in `media/src/pricing.ts` uses flat rates as an approximation because it operates on session totals rather than per-call counts.
 
 **Deprecated models (for historical sessions):**
 

--- a/media/src/pricing.ts
+++ b/media/src/pricing.ts
@@ -2,7 +2,7 @@
 // Token rates (post Jun 1, 2026):        https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing
 // Request multipliers (pre Jun 1, 2026): https://docs.github.com/en/copilot/concepts/billing/copilot-requests
 // Annual-plan multipliers (post Jun 1):  https://docs.github.com/en/copilot/reference/copilot-billing/model-multipliers-for-annual-plans
-export const PRICING_LAST_UPDATED = '2026-05-28'
+export const PRICING_LAST_UPDATED = '2026-06-08'
 
 // Three billing modes:
 //   'token'          — new token-based AI Credits billing, effective Jun 1, 2026
@@ -18,6 +18,12 @@ export interface ModelRates {
   outputPerMTok: number             // USD per 1M output tokens (token mode)
   multiplier: number                // Pre-Jun 1 request multiplier × $0.04/prompt (0 = included/free)
   multiplierAnnualPostJun1: number  // Post-Jun 1 multiplier for annual plan holders staying on request billing
+  // Optional tiered rates for >200K tokens-per-call surcharge. Not applied in session-level calcTokenCost
+  // (which operates on session totals and can't reconstruct per-turn call sizes).
+  inputAbove200kPerMTok?: number
+  outputAbove200kPerMTok?: number
+  cacheReadAbove200kPerMTok?: number
+  cacheWriteAbove200kPerMTok?: number
 }
 
 // Keyed by normalized model ID (lowercase, no date suffix).
@@ -54,7 +60,8 @@ const RATES: Record<string, ModelRates> = {
   'claude-haiku-3-5':      { inputPerMTok:  0.80, cacheReadPerMTok: 0.08, cacheWritePerMTok:  1.00, outputPerMTok:  4.00, multiplier: 0, multiplierAnnualPostJun1: 0 },
   // current
   'claude-haiku-4-5':      { inputPerMTok:  1.00, cacheReadPerMTok: 0.10, cacheWritePerMTok:  1.25, outputPerMTok:  5.00, multiplier: 0.33, multiplierAnnualPostJun1: 0.33 },
-  'claude-sonnet-4':       { inputPerMTok:  3.00, cacheReadPerMTok: 0.30, cacheWritePerMTok:  3.75, outputPerMTok: 15.00, multiplier: 1,    multiplierAnnualPostJun1: 1 },
+  'claude-sonnet-4':       { inputPerMTok:  3.00, cacheReadPerMTok: 0.30, cacheWritePerMTok:  3.75, outputPerMTok: 15.00, multiplier: 1,    multiplierAnnualPostJun1: 1,
+                             inputAbove200kPerMTok: 6.00, outputAbove200kPerMTok: 22.50, cacheReadAbove200kPerMTok: 0.60, cacheWriteAbove200kPerMTok: 7.50 },
   'claude-sonnet-4-5':     { inputPerMTok:  3.00, cacheReadPerMTok: 0.30, cacheWritePerMTok:  3.75, outputPerMTok: 15.00, multiplier: 1,    multiplierAnnualPostJun1: 6 },
   'claude-sonnet-4-6':     { inputPerMTok:  3.00, cacheReadPerMTok: 0.30, cacheWritePerMTok:  3.75, outputPerMTok: 15.00, multiplier: 1,    multiplierAnnualPostJun1: 9 },
   'claude-opus-4-5':       { inputPerMTok:  5.00, cacheReadPerMTok: 0.50, cacheWritePerMTok:  6.25, outputPerMTok: 25.00, multiplier: 3,    multiplierAnnualPostJun1: 15 },

--- a/src/pricing.ts
+++ b/src/pricing.ts
@@ -1,6 +1,6 @@
 // Pricing data for extension-host cost computation (cost_usd stored in sessions table).
 // Rate table is kept in sync with media/src/pricing.ts — update both when rates change.
-// PRICING_LAST_UPDATED: 2026-05-28
+// PRICING_LAST_UPDATED: 2026-06-08
 
 export interface ModelRates {
   inputPerMTok: number
@@ -8,6 +8,11 @@ export interface ModelRates {
   cacheWritePerMTok: number
   outputPerMTok: number
   contextWindowTokens: number   // max context window for Projection estimates; 0 = unknown
+  // Optional tiered rates for the >200K tokens-per-call surcharge. When absent, flat rates apply.
+  inputAbove200kPerMTok?: number
+  outputAbove200kPerMTok?: number
+  cacheReadAbove200kPerMTok?: number
+  cacheWriteAbove200kPerMTok?: number
 }
 
 const RATES: Record<string, ModelRates> = {
@@ -35,7 +40,8 @@ const RATES: Record<string, ModelRates> = {
   'claude-opus-4-1':    { inputPerMTok: 15.00, cacheReadPerMTok: 1.50,  cacheWritePerMTok: 18.75, outputPerMTok: 75.00, contextWindowTokens: 200_000 },
   'claude-haiku-3-5':   { inputPerMTok:  0.80, cacheReadPerMTok: 0.08,  cacheWritePerMTok:  1.00, outputPerMTok:  4.00, contextWindowTokens: 200_000 },
   'claude-haiku-4-5':   { inputPerMTok:  1.00, cacheReadPerMTok: 0.10,  cacheWritePerMTok:  1.25, outputPerMTok:  5.00, contextWindowTokens: 200_000 },
-  'claude-sonnet-4':    { inputPerMTok:  3.00, cacheReadPerMTok: 0.30,  cacheWritePerMTok:  3.75, outputPerMTok: 15.00, contextWindowTokens: 200_000 },
+  'claude-sonnet-4':    { inputPerMTok:  3.00, cacheReadPerMTok: 0.30,  cacheWritePerMTok:  3.75, outputPerMTok: 15.00, contextWindowTokens: 200_000,
+                          inputAbove200kPerMTok: 6.00, outputAbove200kPerMTok: 22.50, cacheReadAbove200kPerMTok: 0.60, cacheWriteAbove200kPerMTok: 7.50 },
   'claude-sonnet-4-5':  { inputPerMTok:  3.00, cacheReadPerMTok: 0.30,  cacheWritePerMTok:  3.75, outputPerMTok: 15.00, contextWindowTokens: 200_000 },
   'claude-sonnet-4-6':  { inputPerMTok:  3.00, cacheReadPerMTok: 0.30,  cacheWritePerMTok:  3.75, outputPerMTok: 15.00, contextWindowTokens: 200_000 },
   'claude-opus-4-5':    { inputPerMTok:  5.00, cacheReadPerMTok: 0.50,  cacheWritePerMTok:  6.25, outputPerMTok: 25.00, contextWindowTokens: 200_000 },
@@ -74,6 +80,14 @@ export function lookupRates(modelId: string): ModelRates | null {
   return null
 }
 
+// Applies two-tier pricing: tokens up to the threshold at baseRate, remainder at aboveRate.
+function tieredCost(tokens: number, baseRatePerMTok: number, aboveRatePerMTok: number): number {
+  const THRESHOLD = 200_000
+  if (tokens <= THRESHOLD) return (tokens / 1_000_000) * baseRatePerMTok
+  return (THRESHOLD / 1_000_000) * baseRatePerMTok
+       + ((tokens - THRESHOLD) / 1_000_000) * aboveRatePerMTok
+}
+
 export function calcTokenCostUsd(
   inputTokens: number,
   cacheReadTokens: number,
@@ -83,6 +97,12 @@ export function calcTokenCostUsd(
 ): number {
   const rates = lookupRates(modelId)
   if (!rates) return 0
+  if (rates.inputAbove200kPerMTok !== undefined) {
+    return tieredCost(inputTokens,     rates.inputPerMTok,      rates.inputAbove200kPerMTok)
+         + tieredCost(cacheReadTokens,  rates.cacheReadPerMTok,  rates.cacheReadAbove200kPerMTok!)
+         + tieredCost(cacheWriteTokens, rates.cacheWritePerMTok, rates.cacheWriteAbove200kPerMTok!)
+         + tieredCost(outputTokens,     rates.outputPerMTok,     rates.outputAbove200kPerMTok!)
+  }
   return (inputTokens     / 1_000_000) * rates.inputPerMTok
        + (cacheReadTokens / 1_000_000) * rates.cacheReadPerMTok
        + (cacheWriteTokens/ 1_000_000) * rates.cacheWritePerMTok

--- a/src/test/pricing.test.ts
+++ b/src/test/pricing.test.ts
@@ -44,4 +44,32 @@ suite('pricing', () => {
     const cost = calcTokenCostUsd(100_000, 0, 0, 10_000, 'gpt-4.1')
     assert.strictEqual(cost, 0)
   })
+
+  test('calcTokenCostUsd uses flat rate for claude-sonnet-4 under threshold', () => {
+    // 100K input + 50K output — all below 200K, so same as flat rate
+    const cost = calcTokenCostUsd(100_000, 0, 0, 50_000, 'claude-sonnet-4')
+    const expected = (100_000 / 1_000_000) * 3.00 + (50_000 / 1_000_000) * 15.00
+    assert.ok(Math.abs(cost - expected) < 0.0001, `Expected $${expected}, got $${cost}`)
+  })
+
+  test('calcTokenCostUsd applies tiered rate for claude-sonnet-4 above 200K input', () => {
+    // 300K input, 0 output: first 200K at $3, next 100K at $6
+    const cost = calcTokenCostUsd(300_000, 0, 0, 0, 'claude-sonnet-4')
+    const expected = (200_000 / 1_000_000) * 3.00 + (100_000 / 1_000_000) * 6.00
+    assert.ok(Math.abs(cost - expected) < 0.0001, `Expected $${expected}, got $${cost}`)
+  })
+
+  test('calcTokenCostUsd tiered output for claude-sonnet-4', () => {
+    // 0 input, 250K output: first 200K at $15, next 50K at $22.50
+    const cost = calcTokenCostUsd(0, 0, 0, 250_000, 'claude-sonnet-4')
+    const expected = (200_000 / 1_000_000) * 15.00 + (50_000 / 1_000_000) * 22.50
+    assert.ok(Math.abs(cost - expected) < 0.0001, `Expected $${expected}, got $${cost}`)
+  })
+
+  test('calcTokenCostUsd flat rate for claude-sonnet-4-5 (no tiered rates)', () => {
+    // claude-sonnet-4-5 has no above-200K rates; 300K input uses flat $3/MTok
+    const cost = calcTokenCostUsd(300_000, 0, 0, 0, 'claude-sonnet-4-5')
+    const expected = (300_000 / 1_000_000) * 3.00
+    assert.ok(Math.abs(cost - expected) < 0.0001, `Expected $${expected}, got $${cost}`)
+  })
 })


### PR DESCRIPTION
Closes #128

## Summary
- Adds optional `inputAbove200kPerMTok`, `outputAbove200kPerMTok`, `cacheReadAbove200kPerMTok`, `cacheWriteAbove200kPerMTok` fields to `ModelRates` in both pricing files
- Implements a `tieredCost()` helper in `src/pricing.ts` (first 200K at base rate, remainder at above rate)
- `calcTokenCostUsd` now applies per-category tiered rates for `claude-sonnet-4`, the only model with published above-200K rates
- `media/src/pricing.ts` carries the interface fields for type consistency; `calcTokenCost` continues using flat rates (session-level totals can't reconstruct per-call sizes)
- Bumps `PRICING_LAST_UPDATED` to 2026-06-08 in both files; updates `PRICING_SOURCES.md` with source URL and tiered rate table

## Test plan
- [ ] 4 new tests in `src/test/pricing.test.ts`: flat rate below threshold, tiered input above 200K, tiered output above 200K, flat rate for `claude-sonnet-4-5` (no tiered rates defined)
- [ ] All 167 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)