### PR TITLE
fix: repair 3 pre-existing test failures in database suite

### DIFF
--- a/src/database/writer.ts
+++ b/src/database/writer.ts
@@ -16,12 +16,16 @@ export class DatabaseWriter {
   private drainPromise: Promise<void> = Promise.resolve()
   private writing = false
   private _generation = 0  // incremented by clearAll() to abort in-flight drains
+  private readonly vscodeFs: typeof vscode.workspace.fs
 
   constructor(
     private readonly db: WriteableDb,
     private readonly storageUri: vscode.Uri,
     private readonly log: (msg: string) => void,
-  ) {}
+    vscodeFs?: typeof vscode.workspace.fs,
+  ) {
+    this.vscodeFs = vscodeFs ?? vscode.workspace.fs
+  }
 
   enqueue(card: SessionSummaryCard, workspace: string): void {
     // OTEL always wins: if this is a log-sourced card and an OTEL record already
@@ -252,13 +256,13 @@ export class DatabaseWriter {
   private async _writeBlob(filename: string, content: string): Promise<void> {
     const fileUri = vscode.Uri.joinPath(this.storageUri, 'blobs', filename)
     try {
-      await vscode.workspace.fs.stat(fileUri)
+      await this.vscodeFs.stat(fileUri)
       return  // already exists; span content is immutable
     } catch {
       // file absent — proceed to write
     }
     try {
-      await vscode.workspace.fs.writeFile(fileUri, Buffer.from(content, 'utf8'))
+      await this.vscodeFs.writeFile(fileUri, Buffer.from(content, 'utf8'))
     } catch (err) {
       this.log(`DatabaseWriter: blob write failed for ${filename}: ${err}`)
     }

--- a/src/test/database/reader.test.ts
+++ b/src/test/database/reader.test.ts
@@ -25,7 +25,8 @@ async function openDb(): Promise<SqlDb> {
 }
 
 function makeStorageUri(): vscode.Uri {
-  return { scheme: 'file', path: '/tmp/agentlens-reader-test', fsPath: '/tmp/agentlens-reader-test' } as unknown as vscode.Uri
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  return require('vscode').Uri.file('/tmp/agentlens-reader-test')
 }
 
 function makeCard(overrides: Partial<SessionSummaryCard> = {}): SessionSummaryCard {

--- a/src/test/database/writer.test.ts
+++ b/src/test/database/writer.test.ts
@@ -59,7 +59,8 @@ function makeCard(overrides: Partial<SessionSummaryCard> = {}): SessionSummaryCa
 }
 
 function makeStorageUri(tag = 'test'): vscode.Uri {
-  return { scheme: 'file', path: `/tmp/agentlens-${tag}`, fsPath: `/tmp/agentlens-${tag}` } as unknown as vscode.Uri
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  return require('vscode').Uri.file(`/tmp/agentlens-${tag}`)
 }
 
 function queryInt(db: SqlDb, sql: string): number {
@@ -151,58 +152,44 @@ suite('DatabaseWriter', () => {
 
   test('blob files are written for string fields at or above the threshold', async () => {
     const written: string[] = []
-    const vscode = require('vscode')
-    const origWrite = vscode.workspace.fs.writeFile
-    const origStat  = vscode.workspace.fs.stat
-    vscode.workspace.fs.writeFile = (_uri: vscode.Uri) => { written.push(_uri.path); return Promise.resolve() }
-    vscode.workspace.fs.stat      = () => Promise.reject(new Error('not found'))
-
-    try {
-      const db = await openInMemoryDb()
-      const longText = 'x'.repeat(600)
-      const card = makeCard({
-        timeline: [{
-          type: 'llm', spanId: 'sp-blob', label: 'LLM', durationMs: 100,
-          isError: false, timestamp: '', responseText: longText,
-        }],
-      })
-      const w = new DatabaseWriter(db, makeStorageUri('blob'), () => {})
-      w.enqueue(card, 'ws')
-      await w.drain()
-      assert.ok(written.some(p => p.includes('sp-blob-response.txt')), 'response blob not written')
-      db.close()
-    } finally {
-      vscode.workspace.fs.writeFile = origWrite
-      vscode.workspace.fs.stat      = origStat
+    const fakeFs = {
+      stat:      () => Promise.reject(new Error('not found')),
+      writeFile: (_uri: vscode.Uri) => { written.push(_uri.path); return Promise.resolve() },
     }
+    const db = await openInMemoryDb()
+    const longText = 'x'.repeat(600)
+    const card = makeCard({
+      timeline: [{
+        type: 'llm', spanId: 'sp-blob', label: 'LLM', durationMs: 100,
+        isError: false, timestamp: '', responseText: longText,
+      }],
+    })
+    const w = new DatabaseWriter(db, makeStorageUri('blob'), () => {}, fakeFs as unknown as typeof import('vscode').workspace.fs)
+    w.enqueue(card, 'ws')
+    await w.drain()
+    assert.ok(written.some(p => p.includes('sp-blob-response.txt')), 'response blob not written')
+    db.close()
   })
 
   test('blob files are not re-written when they already exist', async () => {
     const writeCount = { n: 0 }
-    const vscode = require('vscode')
-    const origWrite = vscode.workspace.fs.writeFile
-    const origStat  = vscode.workspace.fs.stat
-    vscode.workspace.fs.writeFile = () => { writeCount.n++; return Promise.resolve() }
-    vscode.workspace.fs.stat      = () => Promise.resolve({})  // file exists
-
-    try {
-      const db = await openInMemoryDb()
-      const longText = 'x'.repeat(600)
-      const card = makeCard({
-        timeline: [{
-          type: 'llm', spanId: 'sp-exists', label: 'LLM', durationMs: 100,
-          isError: false, timestamp: '', responseText: longText,
-        }],
-      })
-      const w = new DatabaseWriter(db, makeStorageUri('exists'), () => {})
-      w.enqueue(card, 'ws')
-      await w.drain()
-      assert.strictEqual(writeCount.n, 0, 'should not write when file already exists')
-      db.close()
-    } finally {
-      vscode.workspace.fs.writeFile = origWrite
-      vscode.workspace.fs.stat      = origStat
+    const fakeFs = {
+      stat:      () => Promise.resolve({}),  // file exists
+      writeFile: () => { writeCount.n++; return Promise.resolve() },
     }
+    const db = await openInMemoryDb()
+    const longText = 'x'.repeat(600)
+    const card = makeCard({
+      timeline: [{
+        type: 'llm', spanId: 'sp-exists', label: 'LLM', durationMs: 100,
+        isError: false, timestamp: '', responseText: longText,
+      }],
+    })
+    const w = new DatabaseWriter(db, makeStorageUri('exists'), () => {}, fakeFs as unknown as typeof import('vscode').workspace.fs)
+    w.enqueue(card, 'ws')
+    await w.drain()
+    assert.strictEqual(writeCount.n, 0, 'should not write when file already exists')
+    db.close()
   })
 
   test('write failure is caught and does not throw from enqueue', async () => {


### PR DESCRIPTION
Closes #129

## Summary
- **Writer blob tests (×2)**: `vscode.workspace.fs` properties are non-configurable, so direct assignment and `Object.defineProperty` both fail. Fixed by adding an optional 4th `vscodeFs` parameter to `DatabaseWriter` (defaults to `vscode.workspace.fs`); tests now pass a plain fake object directly.
- **Reader `loadBlob` test**: `makeStorageUri()` returned a plain object stub without a `.with()` method, which `vscode.Uri.joinPath()` calls internally. Fixed by switching both `makeStorageUri()` helpers to `vscode.Uri.file()`, which returns a real URI instance with all methods.

## Test plan
- [ ] `pnpm test` shows 167 passing, 0 failing (was 165 passing, 3 failing before this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)