### PR TITLE
fix: correct Copilot OTEL token convention for OpenAI models

### DIFF
--- a/src/summarizers/copilot.ts
+++ b/src/summarizers/copilot.ts
@@ -21,7 +21,12 @@ export function buildCopilotSessions(
     const conversationId = chatSpan ? getAttrStr(chatSpan, 'gen_ai.conversation.id') : undefined
     const turns = getAttrInt(agent, 'copilot_chat.turn_count')
     const { input: inputTokens, output: outputTokens, cacheRead, cacheCreate } = extractTokenCounts(agent)
-    const totalInput = inputTokens + cacheRead + cacheCreate
+    // OpenAI convention: input_tokens = total context (cached tokens already included).
+    // Anthropic convention: input_tokens = new non-cached only; add cacheRead + cacheCreate to reconstruct total.
+    const isOpenAIModel = /^gpt-|^o\d/i.test(model ?? '')
+    const totalInput = isOpenAIModel
+      ? inputTokens
+      : inputTokens + cacheRead + cacheCreate
     const cacheHitRate = totalInput > 0 ? cacheRead / totalInput : 0
 
     const startMs = nanoToMs(agent.startTime)

--- a/src/test/spanSummarizer.test.ts
+++ b/src/test/spanSummarizer.test.ts
@@ -120,6 +120,26 @@ suite('SpanSummarizer', () => {
       assert.strictEqual(result.sessions[0].outputTokens, 1000)
     })
 
+    test('Anthropic model: reconstructs totalInput from parts (input + cacheRead + cacheCreate)', () => {
+      const agent = makeAgentSpan({ spanId: 'a-anthropic', model: 'claude-sonnet-4-6', inputTokens: 20000 })
+      agent.attributes.push(makeAttr('gen_ai.usage.cache_read.input_tokens', 80000))
+      const result = summarizeSpans([agent])
+      const session = result.sessions[0]
+      // totalInput = 20000 + 80000 = 100000; cacheHitRate = 80000/100000 = 0.8
+      assert.strictEqual(session.inputTokens, 100000)
+      assert.ok(Math.abs(session.cacheHitRate - 0.8) < 0.001)
+    })
+
+    test('OpenAI model: does not double-count cached tokens in totalInput', () => {
+      const agent = makeAgentSpan({ spanId: 'a-openai', model: 'gpt-5.5', inputTokens: 100000 })
+      agent.attributes.push(makeAttr('gen_ai.usage.cache_read.input_tokens', 80000))
+      const result = summarizeSpans([agent])
+      const session = result.sessions[0]
+      // totalInput = 100000 (input already includes cached); cacheHitRate = 80000/100000 = 0.8
+      assert.strictEqual(session.inputTokens, 100000)
+      assert.ok(Math.abs(session.cacheHitRate - 0.8) < 0.001)
+    })
+
     test('associates child spans with parent session', () => {
       const agent = makeAgentSpan({ spanId: 'a1' })
       const child = makeChildSpan('a1', {


### PR DESCRIPTION
Closes #132

## Summary
- GPT models report `gen_ai.usage.input_tokens` as total context (cached tokens already included); Anthropic models report only new non-cached tokens
- The Copilot summarizer was always using the Anthropic formula (`input + cacheRead + cacheCreate`), which would double-count cached tokens for GPT models if Copilot ever starts emitting cache breakdowns in OTEL spans
- Fix: detect convention by model ID prefix (`/^gpt-|^o\d/i`) and use `inputTokens` as-is for OpenAI models

## Test plan
- [ ] New test: Anthropic model reconstructs `totalInput` from parts (input + cacheRead), cacheHitRate correct
- [ ] New test: OpenAI model does not double-count cached tokens, cacheHitRate still correct
- [ ] 173 tests pass, 0 failing

🤖 Generated with [Claude Code](https://claude.com/claude-code)