### PR TITLE
fix: clear-all visible + dashboard picks up log scan results

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -230,6 +230,7 @@ export async function activate(context: vscode.ExtensionContext) {
       void writer!.drain().then(() => {
         agentLensDb?.save()
         provider.refresh()
+        DashboardPanel.currentPanel?.update()
         writeLastWriteSignal(context.globalStorageUri)
       }).catch(err => outputChannel!.appendLine(`[AgentLens] log ingestion drain error: ${err}`))
     }
@@ -472,13 +473,13 @@ export async function activate(context: vscode.ExtensionContext) {
       if (repository) DashboardPanel.setRepository(repository)
       if (logReader && startBatchedLoad) {
         logReader.clearFileState()
-        // Delay so the cleared state renders before log sessions flow back in.
+        // 5 s delay so the cleared state is visible before log sessions flow back in.
         // When all files are loaded, do a final refresh so the dashboard reflects
         // the fully re-ingested state.
         setTimeout(() => startBatchedLoad!(() => {
           provider.refresh()
           if (repository) DashboardPanel.setRepository(repository)
-        }), 500)
+        }), 5000)
       }
       writeLastWriteSignal(context.globalStorageUri)
     })


### PR DESCRIPTION
Closes #136

## Summary

- Increase post-clear delay 500 ms → 5 s so the cleared state is visible before sessions reload
- Add `DashboardPanel.currentPanel?.update()` to the `runLogScan` drain callback so the dashboard reflects new log sessions without waiting for its internal timer

## Test plan

- [ ] Click "Clear All Data" in Settings — sessions should disappear and stay gone for ~5 seconds before reloading
- [ ] Trigger a log scan (wait up to 30 s or force one) — verify new sessions appear in the dashboard promptly, not only in the sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)