### PR TITLE
chore: release v0.7.1

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -16,6 +16,8 @@ media/sidebar.js.map
 # Demo / test artifacts
 demo/
 walkthrough/
+media/demo.gif
+media/help-mascot.png
 
 # Docs
 README.md

--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,7 @@
+# README-only media
+media/demo.gif
+media/help-mascot.png
+
 # Dev tooling
 .vscode/**
 .vscode-test/**

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -16,3 +16,5 @@ pnpm-lock.yaml
 **/*.map
 **/*.ts
 **/.vscode-test.*
+media/demo.gif
+media/help-mascot.png

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to AgentLens are documented here.
 
+## [0.7.1] — 2026-06-08
+
+### Added
+
+- **Ingestion toggles** — new Settings tab with per-source ingestion toggles (Claude Code logs, Copilot logs, OTEL spans); each source can be disabled independently without clearing data
+
+### Fixed
+
+- **Fast mode cost multiplier** — fast mode sessions now apply the 5× cost multiplier from the `usage.speed` field; was previously ignored, causing fast mode sessions to be underpriced (#124)
+- **Tiered pricing for claude-sonnet-4** — input tokens above 200 K now apply the correct surcharge tier; the `calcTokenCostUsd` calling convention was also corrected to pre-subtract cache tokens before tier lookup (#130)
+- **Copilot OTEL token convention** — GPT-model Copilot sessions use the OpenAI token convention (`input_tokens` = total context including cached); the summarizer no longer double-counts cached tokens when `cacheRead` is non-zero (#133)
+- **Unpriced sessions excluded from cost chart** — sessions with unrecognized model IDs (grey `?` markers) are now filtered out of the ESTIMATED COST bar chart; they contributed $0 to all calculations but consumed slots and created visual noise; a footnote reports how many were excluded (#135)
+- **"Clear All Data" visually confirms** — post-clear re-ingestion delay increased from 500 ms to 5 s so the cleared state is visible before sessions reload (#136)
+- **Dashboard picks up log scan results** — `DashboardPanel.update()` is now called after every `runLogScan` drain; previously the dashboard could lag up to 40 s behind the sidebar after a log scan (#136)
+
+### Chore
+
+- `media/demo.gif` and `media/help-mascot.png` (README-only assets) excluded from `.vscodeignore`, `.dockerignore`, and `.npmignore`
+- Updated demo GIF
+
+---
+
 ## [0.7.0] — 2026-06-07
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "agentlens-dashboard",
   "displayName": "AgentLens - AI Agent Observability",
   "description": "Observability for AI agent sessions — OTEL traces and local log file ingestion. VS Code extension, npx, and Docker.",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "publisher": "agentlens",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Release 0.7.1

Changelog, version bump, and packaging fixes.

### What's in this release

**Fixed**
- Fast mode cost multiplier (#124)
- Tiered pricing for claude-sonnet-4 >200K (#130)
- Copilot OTEL token convention for GPT models (#133)
- Unpriced sessions excluded from cost chart (#135)
- "Clear All Data" now visually confirms + dashboard picks up log scan results (#136, pending merge of #137)

**Added**
- Ingestion toggles on new Settings tab (#126)

**Chore**
- `media/demo.gif` and `media/help-mascot.png` excluded from `.vscodeignore`, `.dockerignore`, `.npmignore`
- Updated demo GIF

## Merge order

Merge #137 first, then this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)