### PR TITLE
chore: release v0.7.2

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -17,7 +17,6 @@ media/sidebar.js.map
 demo/
 walkthrough/
 media/demo.gif
-media/help-mascot.png
 
 # Docs
 README.md

--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,5 @@
 # README-only media
 media/demo.gif
-media/help-mascot.png
 
 # Dev tooling
 .vscode/**

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -17,4 +17,3 @@ pnpm-lock.yaml
 **/*.ts
 **/.vscode-test.*
 media/demo.gif
-media/help-mascot.png

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to AgentLens are documented here.
 
+## [0.7.2] — 2026-06-08
+
+### Fixed
+
+- `media/help-mascot.png` removed from `.dockerignore`, `.vscodeignore`, and `.npmignore` — it is served by the VS Code webview, standalone server, and Docker image and must be included in all packages; only `media/demo.gif` is README-only
+
+---
+
 ## [0.7.1] — 2026-06-08
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "agentlens-dashboard",
   "displayName": "AgentLens - AI Agent Observability",
   "description": "Observability for AI agent sessions — OTEL traces and local log file ingestion. VS Code extension, npx, and Docker.",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "publisher": "agentlens",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Release 0.7.2

Hotfix for the 0.7.1 packaging changes.

`media/help-mascot.png` was incorrectly added to `.dockerignore`, `.vscodeignore`, and `.npmignore` in 0.7.1. It is actively served by the VS Code webview (`dashboardPanel.ts`), the standalone server, and Docker — not a README-only asset. This broke Docker builds immediately.

Only `media/demo.gif` is excluded (README-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)