### PR TITLE
fix: friendly EADDRINUSE errors for MCP and UI ports

### DIFF
--- a/src/mcpServer.ts
+++ b/src/mcpServer.ts
@@ -528,6 +528,13 @@ export function startMcpHttpServer(
     if (req.method === 'OPTIONS') { res.writeHead(204); res.end(); return }
     handleMcpRequest(server, req, res)
   })
+  httpServer.on('error', (err: NodeJS.ErrnoException) => {
+    if (err.code === 'EADDRINUSE') {
+      console.error(`[AgentLens] Port ${port} (MCP) already in use — stop the process using it or set MCP_PORT=<other> to use a different port.`)
+      process.exit(1)
+    }
+    throw err
+  })
   httpServer.listen(port, bindHost)
   return httpServer
 }

--- a/standalone/server.ts
+++ b/standalone/server.ts
@@ -1163,7 +1163,7 @@ const otlpServer = http.createServer((req, res) => {
 
 otlpServer.on('error', (err: NodeJS.ErrnoException) => {
   if (err.code === 'EADDRINUSE') {
-    console.error(`[AgentLens] Port ${OTLP_PORT} already in use — is the VS Code extension running? Stop it or set OTLP_PORT=<other> to use a different port.`)
+    console.error(`[AgentLens] Port ${OTLP_PORT} (OTLP) already in use — stop the process using it or set OTLP_PORT=<other> to use a different port.`)
     process.exit(1)
   }
   console.error('[AgentLens] OTLP server error:', err)
@@ -1197,6 +1197,14 @@ Promise.all([
 
 otlpServer.listen(OTLP_PORT, BIND_HOST, () => {
   console.log(`[AgentLens] OTLP receiver → http://localhost:${OTLP_PORT}`)
+})
+
+uiServer.on('error', (err: NodeJS.ErrnoException) => {
+  if (err.code === 'EADDRINUSE') {
+    console.error(`[AgentLens] Port ${UI_PORT} (UI) already in use — set UI_PORT=<other> to use a different port.`)
+    process.exit(1)
+  }
+  console.error('[AgentLens] UI server error:', err)
 })
 
 uiServer.listen(UI_PORT, BIND_HOST, () => {


### PR DESCRIPTION
Closes #140

## Summary

- MCP server (port 4316) now prints a friendly message and exits cleanly on `EADDRINUSE` instead of crashing with a raw Node stack trace
- UI server (port 3000) gets the same treatment
- Both match the existing OTLP server handler pattern

## Test plan

- [ ] Start the standalone server, then run `npx agentlens-dashboard` again — should print a clear message and exit instead of throwing
- [ ] Same test for UI port (set `UI_PORT` to a port already in use)

🤖 Generated with [Claude Code](https://claude.com/claude-code)