### PR TITLE
fix: sql.js not resolvable in packaged extension

### DIFF
--- a/esbuild.js
+++ b/esbuild.js
@@ -6,10 +6,11 @@ const production = process.argv.includes('--production');
 const watch = process.argv.includes('--watch');
 
 function copySqlWasm() {
-  const src = path.join(__dirname, 'node_modules', 'sql.js', 'dist', 'sql-wasm.wasm');
-  const dest = path.join(__dirname, 'dist', 'sql-wasm.wasm');
-  fs.mkdirSync(path.join(__dirname, 'dist'), { recursive: true });
-  fs.copyFileSync(src, dest);
+  const sqlJsDir = path.join(__dirname, 'node_modules', 'sql.js', 'dist');
+  const distDir  = path.join(__dirname, 'dist');
+  fs.mkdirSync(distDir, { recursive: true });
+  fs.copyFileSync(path.join(sqlJsDir, 'sql-wasm.wasm'), path.join(distDir, 'sql-wasm.wasm'));
+  fs.copyFileSync(path.join(sqlJsDir, 'sql-wasm.js'),   path.join(distDir, 'sql-wasm.js'));
 }
 
 /**

--- a/src/database/db.ts
+++ b/src/database/db.ts
@@ -25,7 +25,8 @@ const BLOBS_DIR = 'blobs'
  */
 export async function openDatabase(storagePath: string, extensionPath: string): Promise<AgentLensDb> {
   // sql.js is loaded dynamically to keep it out of the main extension bundle.
-  const initSqlJs = require('sql.js') as InitSqlJs
+  // Require by path so the packaged extension can resolve it from dist/.
+  const initSqlJs = require(path.join(extensionPath, 'dist', 'sql-wasm.js')) as InitSqlJs
   const SQL = await initSqlJs({
     locateFile: (file: string) => path.join(extensionPath, 'dist', file),
   })

--- a/src/database/reader.ts
+++ b/src/database/reader.ts
@@ -453,12 +453,13 @@ export class DatabaseReader {
 export function openReadonlySnapshot(
   storagePath: string,
   storageUri: vscode.Uri,
+  extensionPath: string,
 ): DatabaseReader | null {
   const dbPath = path.join(storagePath, 'agentlens.db')
   try {
     // sql.js has no bundled types; require is intentional (no ESM build available)
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const SQL = require('sql.js') as any
+    const SQL = require(path.join(extensionPath, 'dist', 'sql-wasm.js')) as any
     const fileBuffer = fs.readFileSync(dbPath)
     const db = new SQL.Database(fileBuffer)
     return new DatabaseReader(db, storageUri)

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -342,6 +342,7 @@ export async function activate(context: vscode.ExtensionContext) {
         const snapshotReader = openReadonlySnapshot(
           context.globalStorageUri.fsPath,
           context.globalStorageUri,
+          context.extensionUri.fsPath,
         )
         if (snapshotReader && store) {
           const snapshotWriter = writer ?? new DatabaseWriter(agentLensDb!.raw, context.globalStorageUri, () => {})


### PR DESCRIPTION
Closes #141

## Summary

- Copy `sql-wasm.js` to `dist/` at build time alongside the existing `sql-wasm.wasm` copy
- Change `require('sql.js')` in `db.ts` and `reader.ts` to require by path (`extensionPath/dist/sql-wasm.js`) so the packaged extension can resolve it without `node_modules`
- Add `extensionPath` parameter to `openReadonlySnapshot` so secondary (sync) windows are also covered

## Root cause

`sql.js` was marked `external` in esbuild (not bundled) but `node_modules/**` is excluded by `.vscodeignore`. In development this works because `node_modules` is present; in the installed extension `require('sql.js')` fails with `Cannot find module`.

## Test plan

- [ ] Build with `--production`, install the `.vsix`, open VS Code with multiple windows — database should initialize successfully in all windows
- [ ] Confirm `dist/sql-wasm.js` is present after build

🤖 Generated with [Claude Code](https://claude.com/claude-code)