### PR TITLE
chore: release v0.7.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to AgentLens are documented here.
 
+## [0.7.3] — 2026-06-09
+
+### Fixed
+
+- **sql.js not resolvable in packaged extension** — `require('sql.js')` failed with `Cannot find module` in installed extensions because `sql.js` was marked external in esbuild but `node_modules` is excluded from the `.vsix`. `sql-wasm.js` is now copied to `dist/` at build time and required by path; covers both the primary window (`openDatabase`) and secondary sync windows (`openReadonlySnapshot`) (#141)
+- **Friendly EADDRINUSE errors** — MCP (port 4316) and UI (port 3000) servers now print an actionable message and exit cleanly on port conflict instead of crashing with a raw Node stack trace; all three servers (OTLP, MCP, UI) now use the same pattern (#140)
+
+---
+
 ## [0.7.2] — 2026-06-08
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "agentlens-dashboard",
   "displayName": "AgentLens - AI Agent Observability",
   "description": "Observability for AI agent sessions — OTEL traces and local log file ingestion. VS Code extension, npx, and Docker.",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "publisher": "agentlens",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Release 0.7.3

### Fixed
- **sql.js not resolvable in packaged extension** — `Cannot find module 'sql.js'` in installed extensions; `sql-wasm.js` now copied to `dist/` at build time and required by path; covers primary and sync windows (#141)
- **Friendly EADDRINUSE errors** — MCP and UI servers now print an actionable message and exit cleanly on port conflict instead of a raw stack trace (#140)

🤖 Generated with [Claude Code](https://claude.com/claude-code)