### PR TITLE
feat: add OpenCode session support via SQLite ingestion

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # AgentLens Architecture
 
-AgentLens is a VS Code extension that receives OpenTelemetry (OTLP) telemetry from AI coding agents (GitHub Copilot, Claude Code, Codex), persists it to a local SQLite database, summarises it into per-session cards, and visualises it in a sidebar and a full dashboard.
+AgentLens is a VS Code extension that receives OpenTelemetry (OTLP) telemetry from AI coding agents (GitHub Copilot, Claude Code, Codex), reads local session files and databases (including OpenCode's SQLite database), persists everything to a local SQLite database, summarises it into per-session cards, and visualises it in a sidebar and a full dashboard.
 
 ---
 
@@ -32,12 +32,13 @@ graph TB
         CX[Codex<br/>OTLP HTTP logs]
     end
 
-    subgraph LocalLogs["Local log files"]
+    subgraph LocalLogs["Local log files / databases"]
         CL_LOGS["~/.claude/projects/**/*.jsonl"]
         CX_LOGS["~/.codex/sessions/**/*.jsonl"]
         CP_LOGS["~/.copilot/session-state/**/*.jsonl"]
         CP_VS["workspaceStorage/{hash}/chatSessions/{uuid}.jsonl<br/>(delta log — newer VS Code-family Copilot Chat)"]
         CP_JSON["workspaceStorage/{hash}/chatSessions/{uuid}.json<br/>(snapshot — older VS Code-family Copilot Chat)"]
+        OC_DB["~/.local/share/opencode/opencode.db<br/>(SQLite — WAL merged at read time)"]
     end
 
     subgraph VSCode Extension
@@ -68,7 +69,7 @@ graph TB
     COL -- addSpan --> STO
     STO -- onUpdate → summarize → enqueue --> WRI
 
-    CL_LOGS & CX_LOGS & CP_LOGS & CP_VS & CP_JSON --> LR
+    CL_LOGS & CX_LOGS & CP_LOGS & CP_VS & CP_JSON & OC_DB --> LR
     LR -- "enqueue(card)" --> WRI
 
     WRI --> DB
@@ -177,8 +178,8 @@ flowchart TD
         CB --> DSH_CB[DashboardPanel<br/>300ms debounce + 10s heartbeat]
     end
 
-    subgraph LOGS["Log file path (disk) — see §4"]
-        LF["~/.claude · ~/.codex · ~/.copilot<br/>JSONL files"] --> LR[LogReader<br/>parseFile / scan]
+    subgraph LOGS["Log file / database path (disk) — see §4"]
+        LF["~/.claude · ~/.codex · ~/.copilot<br/>JSONL files<br/>~/.local/share/opencode/opencode.db (SQLite)"] --> LR[LogReader<br/>parseFile / scanOpenCode / scan]
         LR -- "enqueue(card)" --> WRITE
     end
 
@@ -203,6 +204,7 @@ A parallel, network-free ingestion path that reads session files written to disk
 | Copilot CLI | JSONL (event log) | `~/.copilot/session-state/<uuid>/events.jsonl` | — (written automatically) |
 | Copilot Chat (VS Code-family, newer) | JSONL (delta log) | `workspaceStorage/<hash>/chatSessions/<uuid>.jsonl` | — |
 | Copilot Chat (VS Code-family, older) | JSON (snapshot) | `workspaceStorage/<hash>/chatSessions/<uuid>.json` | — |
+| OpenCode | SQLite database (WAL mode) | `~/.local/share/opencode/opencode.db` (Linux/Mac) | `OPENCODE_DATA_DIR` (comma-separated data dirs) |
 
 `workspaceStorage` is at `~/Library/Application Support/<IDE>/User/workspaceStorage` (macOS), `%APPDATA%\<IDE>\User\workspaceStorage` (Windows), or `$XDG_CONFIG_HOME/<IDE>/User/workspaceStorage` (Linux), where `<IDE>` is any VS Code-family IDE. AgentLens scans all known VS Code-family IDEs automatically — VS Code, VS Code Insiders, Cursor, Windsurf, VSCodium, Trae, and Kiro — via `VSCODE_FAMILY_IDE_NAMES` in `src/vscodeFamilyIdes.ts`. Standalone auto-config writes Copilot settings into every installed IDE's `settings.json`. Windows: Claude Code also checks `%APPDATA%\Claude\projects`. Linux/Mac: `XDG_CONFIG_HOME` is also checked for Claude.
 
@@ -221,6 +223,22 @@ New turn: `kind=2` with `k=["requests"]` (exactly one element). Response sub-arr
 ### Copilot Chat — snapshot format (`.json`)
 
 Older VS Code Copilot Chat versions wrote the full session state as a single JSON object. The `requests` array contains all turns with `message.text`, `timestamp`, `modelId`, and tool call data. No token counts are stored. Only collected when no `.jsonl` sibling exists for the same session UUID.
+
+### OpenCode — SQLite database
+
+OpenCode stores all session data in a local SQLite database (`opencode.db`) using WAL (Write-Ahead Log) mode. AgentLens reads the database directly using `sql.js` (WASM SQLite), merging the WAL file at read time so in-progress sessions are visible immediately.
+
+**WAL merge:** `opencode.db-wal` can be larger than the main database file when sessions are active. `_mergeWal()` parses the 32-byte WAL header (magic, page size, salt pair), iterates frames of size `24 + pageSize`, applies frames whose salt matches the database header, and returns a merged in-memory buffer for `sql.js` to open. The WAL mtime is checked alongside the database mtime so new sessions trigger a rescan.
+
+**Three-query parse:** `_parseOpenCodeDb()` executes three queries in one pass:
+
+1. **Session query** — `session` table: `id, title, directory, model, time_created, tokens_input, tokens_output, tokens_cache_read, tokens_cache_write`. Filters: `parent_id` null/empty (skip sub-sessions), total tokens > 0. Model is stored as JSON (`{"id":"...", "providerID":"..."}`); the `id` field is extracted.
+2. **Message query** — `message` table joined on `session_id`: per-assistant-turn timing (`time.created`, `time.completed` from the `data` JSON) and token counts.
+3. **Part query** — `part` table joined with `message`: `type` (text / tool / step-start / step-finish / reasoning), `text`, `tool_name`, `callID`, `tool_input_json`, `tool_output`, `tool_status`, and timestamps. Results are grouped per session into `partsBySess` for card building.
+
+**User request:** The last `text`-type part with `role=user` is used as `userRequest` (not the first) to capture the most recent user message in multi-turn sessions.
+
+**Timeline:** `llmEvents` (one per assistant message, from the message query) and `toolEvents` (one per tool part, from the part query) are merged and sorted by timestamp into `TimelineEntry[]`.
 
 ### Scan mechanics
 
@@ -248,20 +266,21 @@ flowchart TD
 
 ### Data availability
 
-| Field | OTLP | Claude / Codex logs | Copilot CLI log | Copilot Chat JSONL | Copilot Chat JSON |
-| --- | --- | --- | --- | --- | --- |
-| Session ID, workspace | ✓ | ✓ | ✓ | ✓ | ✓ |
-| Model | ✓ | ✓ | ✓ | ✓ (initial model only) | ✓ (first request) |
-| Timestamps, duration | ✓ | ✓ | ✓ | ✓ | ✓ |
-| Input tokens | ✓ | ✓ | ✓ (from `session.shutdown`) | ✗ not stored | ✗ not stored |
-| Output tokens | ✓ | ✓ | ✓ | ✓ (`completionTokens` per turn) | ✗ not stored |
-| Cache read / write tokens | ✓ | ✓ | ✓ (from `session.shutdown`) | ✗ not stored | ✗ not stored |
-| User request text | ✓ | ✓ | ✓ | ✓ | ✓ |
-| Tool calls (names) | ✓ | ✓ | ✓ | ✗ | ✗ (presence only) |
-| File paths from tools | ✓ | ✓ | ✓ | ✗ | ✗ |
-| TTFT, per-tool timing | ✓ | ✗ | ✗ | ✗ | ✗ |
-| Streaming speed, loop signals | ✓ | ✗ | ✗ | ✗ | ✗ |
-| Full turn timeline | ✓ | ✓ | ✗ | ✗ | ✗ |
+| Field | OTLP | Claude / Codex logs | Copilot CLI log | Copilot Chat JSONL | Copilot Chat JSON | OpenCode SQLite |
+| --- | --- | --- | --- | --- | --- | --- |
+| Session ID, workspace | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Model | ✓ | ✓ | ✓ | ✓ (initial model only) | ✓ (first request) | ✓ |
+| Timestamps, duration | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Input tokens | ✓ | ✓ | ✓ (from `session.shutdown`) | ✗ not stored | ✗ not stored | ✓ |
+| Output tokens | ✓ | ✓ | ✓ | ✓ (`completionTokens` per turn) | ✗ not stored | ✓ |
+| Cache read / write tokens | ✓ | ✓ | ✓ (from `session.shutdown`) | ✗ not stored | ✗ not stored | ✓ |
+| User request text | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ (last user message) |
+| Tool calls (names) | ✓ | ✓ | ✓ | ✗ | ✗ (presence only) | ✓ |
+| Tool call inputs / outputs | ✓ | ✓ | ✗ | ✗ | ✗ | ✓ |
+| File paths from tools | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ |
+| TTFT, per-tool timing | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ |
+| Streaming speed, loop signals | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ |
+| Full turn timeline | ✓ | ✓ | ✗ | ✗ | ✗ | ✓ (LLM + tool entries) |
 
 Sessions produced by `LogReader` carry `dataSource: 'log'` on `SessionSummaryCard`; OTLP sessions carry `dataSource: 'otel'`. The UI shows an OTEL/Log source badge on each session row.
 

--- a/PRICING_SOURCES.md
+++ b/PRICING_SOURCES.md
@@ -223,6 +223,27 @@ Model name available on `codex.user_prompt`, `codex.turn_ttft`, and `codex.tool_
 
 ---
 
+## OpenCode
+
+OpenCode uses token-based pricing for third-party models (routed through its provider abstraction) and offers a free stealth model called **big-pickle** during a limited evaluation period.
+
+### big-pickle — OpenCode Zen free model
+
+**Who it applies to:** Users of OpenCode's built-in Zen model tier during the limited evaluation period.
+
+**Source:** <https://opencode.ai/docs/zen/>
+
+**Rates:** $0 — completely free during evaluation. All token fields (`inputPerMTok`, `cacheReadPerMTok`, `cacheWritePerMTok`, `outputPerMTok`) are set to 0 in the rate table.
+
+**Model ID in OpenCode SQLite:** Stored as JSON `{"id":"big-pickle","providerID":"opencode"}` in the `model` column of the `session` table. AgentLens extracts the `id` field and normalizes it for rate lookup.
+
+**Known gaps:**
+
+- big-pickle pricing is stated as free "during limited evaluation" — it may become paid in the future. Check the source URL and update the rate table when rates are published.
+- Other models used through OpenCode (e.g. Anthropic, OpenAI, or Google models routed via OpenCode's provider abstraction) are billed by the underlying provider at their standard rates. AgentLens applies the provider's published rates for those models automatically.
+
+---
+
 ## Notes for maintainers
 
 - The `PRICING_LAST_UPDATED` constant in `media/src/pricing.ts` surfaces in the UI. Update it whenever rates change.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 Local observability that makes AI agent sessions more transparent — see what's happening inside each run. No data leaves your machine.
 
-AgentLens receives **OpenTelemetry traces** from Copilot, Claude Code, and Codex in real time — giving you span timing, time-to-first-token, loop detection, file diffs, and actionable recommendations. It also reads **local session log files** written automatically by each agent as a zero-config fallback, backfilling history and filling gaps when OTEL isn't configured. Both sources are shown in one unified dashboard; OTEL always takes precedence when available.
+AgentLens receives **OpenTelemetry traces** from Copilot, Claude Code, and Codex in real time — giving you span timing, time-to-first-token, loop detection, file diffs, and actionable recommendations. It also reads **local session files** written automatically by each agent as a zero-config fallback — including OpenCode's local **SQLite database** — backfilling history and filling gaps when OTEL isn't configured. Both sources are shown in one unified dashboard; OTEL always takes precedence when available.
 
 ## Getting Started
 
@@ -27,7 +27,7 @@ agentlens
 
 Open <http://localhost:3000> after the server starts. The OTLP receiver listens on port `4318`. Configure agents to point at `http://localhost:4318` (see [Manual Configuration](#manual-configuration)).
 
-> **Log file ingestion** reads local session files from `~/.claude/`, `~/.codex/`, and `~/.copilot/` directly. See [Local Mode Options](#local-mode-options) for environment variables.
+> **Log file ingestion** reads local session files from `~/.claude/`, `~/.codex/`, `~/.copilot/`, and OpenCode's SQLite database at `~/.local/share/opencode/` directly. See [Local Mode Options](#local-mode-options) for environment variables.
 
 ### VS Code Extension (OTEL and log files)
 
@@ -80,7 +80,7 @@ Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
 ## Features
 
 - **OpenTelemetry collection** — Built-in OTEL receiver captures real-time traces and logs from Copilot, Claude Code, and Codex with no external infrastructure; auto-configured on first activation
-- **Log file ingestion** — Reads local session files written automatically by each agent as a zero-config fallback, backfilling history when OTEL isn't configured (VS Code-family IDEs and native process only)
+- **Log file ingestion** — Reads local session files and databases written automatically by each agent as a zero-config fallback — including JSONL logs for Claude Code, Codex, and Copilot, and OpenCode's SQLite database — backfilling history when OTEL isn't configured (VS Code-family IDEs and native process only)
 - **Sessions Table** — Drill into any session: expand a row to see a full waterfall trace, turn-to-tool flow graph, tool distribution chart, and modified files — all without leaving the session list
 - **Analytics** — Aggregate charts across the active time range: per-agent breakdown, estimated cost with a daily total overlay, token usage per session, and context growth
 - **Advisor** — Project-scoped suggestions for improving your agent instruction file (CLAUDE.md, AGENTS.md, or similar): detects hot files the agent rediscovers every session, loop patterns, high turn-count trends, and scope problems — each suggestion includes ready-to-copy instruction text and an inquiry prompt you can paste directly into your agent. Also includes an efficiency scatter plot (cost vs. LLM calls, colored by cache hit rate) and hot files ranked by access frequency. Select a specific project from the filter for tailored suggestions; all-projects view surfaces only universal patterns.
@@ -109,14 +109,15 @@ AgentLens also reads the local session files that Claude Code, Codex, Copilot CL
 | **Codex CLI** | `~/.codex/sessions/<project>/<session>.jsonl` | `%USERPROFILE%\.codex\sessions\...` |
 | **Copilot CLI** | `~/.copilot/session-state/<session>/events.jsonl` | `%USERPROFILE%\.copilot\session-state\...` |
 | **Copilot Chat** | `~/Library/Application Support/<IDE>/User/workspaceStorage/…/chatSessions/` | `%APPDATA%\<IDE>\User\workspaceStorage\…\chatSessions\` |
+| **OpenCode** | `~/.local/share/opencode/opencode.db` (SQLite) | `%APPDATA%\opencode\opencode.db` |
 
 Copilot Chat sessions are scanned across all installed VS Code-family IDEs automatically — VS Code, VS Code Insiders, Cursor, Windsurf, VSCodium, Trae, and Kiro.
 
 Loading is incremental and runs in the background, sorted newest-first so recent sessions appear immediately. A 30-second poll picks up new sessions as they complete.
 
-**What log data includes:** session ID, workspace, model, timestamps, token counts (input, output, cache read/write), tool calls and file operations (Claude Code only), user prompt (Claude Code and Copilot CLI).
+**What log data includes:** session ID, workspace, model, timestamps, token counts (input, output, cache read/write), tool calls and file operations (Claude Code and OpenCode), user prompt (Claude Code, Copilot CLI, and OpenCode).
 
-**What log data does not include:** time-to-first-token, per-tool execution timing, streaming speed, loop detection signals, or structured error telemetry. Enable OTEL for those.
+**What log data does not include:** time-to-first-token, per-tool execution timing, streaming speed, loop detection signals, or structured error telemetry. Enable OTEL for those. OpenCode sessions show a blue info banner in the Session Overview noting that OTEL traces and TTFT are not available.
 
 To disable log ingestion: set `agentLens.enableLogIngestion` to `false` in VS Code settings.
 
@@ -393,7 +394,23 @@ Not in logs: input tokens per turn (estimated from shutdown totals), TTFT, cache
 
 ---
 
-> **Note:** Agent observability is evolving rapidly. All three platforms are actively expanding what they expose, and the GenAI semantic conventions are still being standardized. AgentLens will be updated as richer data becomes available.
+---
+
+### OpenCode
+
+**SQLite database (automatic, no OTEL setup needed)** — `~/.local/share/opencode/opencode.db`
+
+OpenCode stores all session data in a local SQLite database. AgentLens reads this directly — no agent configuration or OTEL setup is required. The database uses WAL (Write-Ahead Log) mode; AgentLens merges the WAL at read time so sessions are visible immediately after each run.
+
+Available from the database: session ID, user prompt (last user message), model name, workspace directory, timestamps, all token counts (input, output, cache read/write), tool calls with names and inputs/outputs, file paths accessed by tools.
+
+Not available: time-to-first-token, per-tool execution timing, streaming speed, loop detection signals, or structured error telemetry (no OTEL). Sessions show a **Log** badge and a blue info banner in the Overview tab noting these limitations.
+
+Override the default database location with the `OPENCODE_DATA_DIR` environment variable (comma-separated for multiple directories).
+
+---
+
+> **Note:** Agent observability is evolving rapidly. All platforms are actively expanding what they expose, and the GenAI semantic conventions are still being standardized. AgentLens will be updated as richer data becomes available.
 
 ## Additional Features
 

--- a/media/src/AgentThresholdInputs.tsx
+++ b/media/src/AgentThresholdInputs.tsx
@@ -7,7 +7,7 @@ import {
 import type { ComponentChildren } from 'preact'
 import { useEffect, useState } from 'preact/hooks'
 
-export const DISPLAY_AGENT_ORDER: AgentSource[] = ['copilot', 'claude_code', 'codex']
+export const DISPLAY_AGENT_ORDER: AgentSource[] = ['copilot', 'claude_code', 'codex', 'opencode']
 
 interface AgentThresholdInputsProps {
   profiles: AgentThresholdProfiles

--- a/media/src/App.tsx
+++ b/media/src/App.tsx
@@ -426,10 +426,11 @@ export function App() {
 }
 
 const AGENT_FILTER_OPTIONS: Array<{ value: AgentFilter; label: string; color: string; activeColor?: string }> = [
-  { value: 'all',        label: 'All',     color: 'var(--vscode-descriptionForeground,#888)', activeColor: '#ffffff' },
-  { value: 'copilot',    label: 'Copilot', color: '#00EAFF' },
-  { value: 'claude_code',label: 'Claude',  color: '#FFB085' },
-  { value: 'codex',      label: 'Codex',   color: '#F0FF42' },
+  { value: 'all',        label: 'All',      color: 'var(--vscode-descriptionForeground,#888)', activeColor: '#ffffff' },
+  { value: 'copilot',    label: 'Copilot',  color: '#00EAFF' },
+  { value: 'claude_code',label: 'Claude',   color: '#FFB085' },
+  { value: 'codex',      label: 'Codex',    color: '#F0FF42' },
+  { value: 'opencode',   label: 'OpenCode', color: '#FFFFFF' },
 ]
 
 function TimeRangePicker({ hideAgentFilter = false }: { hideAgentFilter?: boolean }) {
@@ -544,7 +545,7 @@ function TimeRangePicker({ hideAgentFilter = false }: { hideAgentFilter?: boolea
         <span style="width:1px;height:14px;background:var(--border);margin:0 8px;flex-shrink:0" />
         <div style="display:flex;gap:4px;align-items:center">
           <span style="font-size:10px;color:var(--muted);margin-right:2px;white-space:nowrap;text-transform:uppercase;letter-spacing:.3px">Agent</span>
-          {AGENT_FILTER_OPTIONS.filter(o => o.value === 'all' || presentSources.has(o.value)).map(o => {
+          {AGENT_FILTER_OPTIONS.map(o => {
             const active = agent === o.value
             const displayColor = (active && o.activeColor) ? o.activeColor : o.color
             return (

--- a/media/src/agentProfiles.ts
+++ b/media/src/agentProfiles.ts
@@ -29,7 +29,7 @@ export interface AgentThresholdProfile {
 
 export type AgentThresholdProfiles = Record<AgentSource, AgentThresholdProfile>
 
-export const AGENT_ORDER: AgentSource[] = ['copilot', 'claude_code', 'codex']
+export const AGENT_ORDER: AgentSource[] = ['copilot', 'claude_code', 'codex', 'opencode']
 
 export const DEFAULT_AGENT_PROFILES: AgentThresholdProfiles = {
   claude_code: {
@@ -74,6 +74,20 @@ export const DEFAULT_AGENT_PROFILES: AgentThresholdProfiles = {
     consecutiveErrorAlert: 6,
     activeMinutesAlert: 60,
   },
+  opencode: {
+    source: 'opencode',
+    label: 'OpenCode',
+    shortLabel: 'OC',
+    color: '#FFFFFF',
+    contextWindowTokens: 200000,
+    turnNudge: 80,
+    turnAlert: 150,
+    identicalRepeatNudge: 3,
+    identicalRepeatAlert: 4,
+    consecutiveErrorNudge: 3,
+    consecutiveErrorAlert: 4,
+    activeMinutesAlert: 30,
+  },
 }
 
 export const AGENT_PROFILE_FIELD_META: Record<AgentProfileMetric, { label: string; unit: string; min: number; max: number; step: number }> = {
@@ -92,6 +106,7 @@ function cloneDefaultProfiles(): AgentThresholdProfiles {
     claude_code: { ...DEFAULT_AGENT_PROFILES.claude_code },
     copilot: { ...DEFAULT_AGENT_PROFILES.copilot },
     codex: { ...DEFAULT_AGENT_PROFILES.codex },
+    opencode: { ...DEFAULT_AGENT_PROFILES.opencode },
   }
 }
 

--- a/media/src/pricing.ts
+++ b/media/src/pricing.ts
@@ -68,6 +68,8 @@ const RATES: Record<string, ModelRates> = {
   'claude-opus-4-6':       { inputPerMTok:  5.00, cacheReadPerMTok: 0.50, cacheWritePerMTok:  6.25, outputPerMTok: 25.00, multiplier: 3,    multiplierAnnualPostJun1: 27 },
   'claude-opus-4-7':       { inputPerMTok:  5.00, cacheReadPerMTok: 0.50, cacheWritePerMTok:  6.25, outputPerMTok: 25.00, multiplier: 15,   multiplierAnnualPostJun1: 27 },
   'claude-opus-4-8':       { inputPerMTok:  5.00, cacheReadPerMTok: 0.50, cacheWritePerMTok:  6.25, outputPerMTok: 25.00, multiplier: 15,   multiplierAnnualPostJun1: 27 },
+  // Fable 5 — new tier above Opus; Copilot multipliers TBD (not yet listed in GitHub billing docs)
+  'claude-fable-5':        { inputPerMTok: 10.00, cacheReadPerMTok: 1.00, cacheWritePerMTok: 12.50, outputPerMTok: 50.00, multiplier: 0,    multiplierAnnualPostJun1: 0 },
   // fast mode (/fast toggle in Claude Code) — model ID appended with -fast by logReader when usage.speed === 'fast'
   'claude-opus-4-6-fast':  { inputPerMTok: 30.00, cacheReadPerMTok: 3.00, cacheWritePerMTok: 37.50, outputPerMTok: 150.00, multiplier: 30, multiplierAnnualPostJun1: 30 },
   'claude-opus-4-7-fast':  { inputPerMTok: 30.00, cacheReadPerMTok: 3.00, cacheWritePerMTok: 37.50, outputPerMTok: 150.00, multiplier: 30, multiplierAnnualPostJun1: 30 },
@@ -83,6 +85,9 @@ const RATES: Record<string, ModelRates> = {
   // raptor-mini uses GPT-5 mini pricing per footnote 5 — included ($0) in token mode, same annual multiplier
   'raptor-mini': { inputPerMTok: 0,    cacheReadPerMTok: 0,     cacheWritePerMTok: 0, outputPerMTok: 0,     multiplier: 0, multiplierAnnualPostJun1: 0.33 },
   'goldeneye':   { inputPerMTok: 1.25, cacheReadPerMTok: 0.125, cacheWritePerMTok: 0, outputPerMTok: 10.00, multiplier: 0, multiplierAnnualPostJun1: 0 },
+  // ── OpenCode Zen  https://opencode.ai/docs/zen/ ────────────────────────────
+  // big-pickle: OpenCode's stealth model, free during limited evaluation period.
+  'big-pickle':  { inputPerMTok: 0,    cacheReadPerMTok: 0,     cacheWritePerMTok: 0, outputPerMTok: 0,     multiplier: 0, multiplierAnnualPostJun1: 0 },
 }
 
 function normalizeModelId(modelId: string): string {

--- a/media/src/pricing.ts
+++ b/media/src/pricing.ts
@@ -68,8 +68,6 @@ const RATES: Record<string, ModelRates> = {
   'claude-opus-4-6':       { inputPerMTok:  5.00, cacheReadPerMTok: 0.50, cacheWritePerMTok:  6.25, outputPerMTok: 25.00, multiplier: 3,    multiplierAnnualPostJun1: 27 },
   'claude-opus-4-7':       { inputPerMTok:  5.00, cacheReadPerMTok: 0.50, cacheWritePerMTok:  6.25, outputPerMTok: 25.00, multiplier: 15,   multiplierAnnualPostJun1: 27 },
   'claude-opus-4-8':       { inputPerMTok:  5.00, cacheReadPerMTok: 0.50, cacheWritePerMTok:  6.25, outputPerMTok: 25.00, multiplier: 15,   multiplierAnnualPostJun1: 27 },
-  // Fable 5 — new tier above Opus; Copilot multipliers TBD (not yet listed in GitHub billing docs)
-  'claude-fable-5':        { inputPerMTok: 10.00, cacheReadPerMTok: 1.00, cacheWritePerMTok: 12.50, outputPerMTok: 50.00, multiplier: 0,    multiplierAnnualPostJun1: 0 },
   // fast mode (/fast toggle in Claude Code) — model ID appended with -fast by logReader when usage.speed === 'fast'
   'claude-opus-4-6-fast':  { inputPerMTok: 30.00, cacheReadPerMTok: 3.00, cacheWritePerMTok: 37.50, outputPerMTok: 150.00, multiplier: 30, multiplierAnnualPostJun1: 30 },
   'claude-opus-4-7-fast':  { inputPerMTok: 30.00, cacheReadPerMTok: 3.00, cacheWritePerMTok: 37.50, outputPerMTok: 150.00, multiplier: 30, multiplierAnnualPostJun1: 30 },

--- a/media/src/sidebarWebview.ts
+++ b/media/src/sidebarWebview.ts
@@ -67,12 +67,14 @@ function agentColor(source: string): string {
   if (source === 'claude_code') return '#FFB085'
   if (source === 'codex') return '#F0FF42'
   if (source === 'copilot') return '#00EAFF'
+  if (source === 'opencode') return '#FFFFFF'
   return '#90a4ae'
 }
 
 function agentLabel(source: string): string {
   if (source === 'claude_code') return 'Claude'
   if (source === 'codex') return 'Codex'
+  if (source === 'opencode') return 'OpenCode'
   return 'Copilot'
 }
 

--- a/media/src/state.ts
+++ b/media/src/state.ts
@@ -271,8 +271,9 @@ export const filteredSessions = computed<SessionSummaryCard[]>(() => {
 export const agentPresence = computed(() => {
   const sessions = rangedSessions.value
   return {
-    claude:  sessions.some(s => s.source === 'claude_code'),
-    copilot: sessions.some(s => s.source === 'copilot'),
-    codex:   sessions.some(s => s.source === 'codex'),
+    claude:    sessions.some(s => s.source === 'claude_code'),
+    copilot:   sessions.some(s => s.source === 'copilot'),
+    codex:     sessions.some(s => s.source === 'codex'),
+    opencode:  sessions.some(s => s.source === 'opencode'),
   }
 })

--- a/media/src/tabs/Agents.tsx
+++ b/media/src/tabs/Agents.tsx
@@ -98,19 +98,21 @@ export function Agents() {
         return ms >= (range.since ?? 0) && ms <= (range.until ?? Date.now())
       })
   if (!allSessions.length) {
-    return <div id="agents-content"><div class="empty-state">No agent sessions recorded — start a Copilot, Claude, or Codex session</div></div>
+    return <div id="agents-content"><div class="empty-state">No agent sessions recorded — start a Copilot, Claude, Codex, or OpenCode session</div></div>
   }
 
   const copStats = computeStats(allSessions.filter(s => s.source === 'copilot'))
   const cldStats = computeStats(allSessions.filter(s => s.source === 'claude_code'))
   const cdxStats = computeStats(allSessions.filter(s => s.source === 'codex'))
+  const ocStats  = computeStats(allSessions.filter(s => s.source === 'opencode'))
 
   return (
     <div id="agents-content">
-      <div style="display:grid;grid-template-columns:1fr 1fr 1fr;gap:12px;margin-bottom:14px">
+      <div style="display:grid;grid-template-columns:1fr 1fr 1fr 1fr;gap:12px;margin-bottom:14px">
         <AgentCol label="GitHub Copilot" accent="#00EAFF" stats={copStats} />
         <AgentCol label="Claude" accent="#FFB085" stats={cldStats} />
         <AgentCol label="Codex" accent="#F0FF42" stats={cdxStats} />
+        <AgentCol label="OpenCode" accent="#FFFFFF" stats={ocStats} />
       </div>
     </div>
   )

--- a/media/src/tabs/Alerts.tsx
+++ b/media/src/tabs/Alerts.tsx
@@ -56,11 +56,11 @@ interface AlertResult {
 }
 
 const DEFAULT_CONFIGS: AlertConfig[] = [
-  { id: 'context_window', label: 'Context Window Filling Up', severity: 'warning', description: 'Fires when any session reaches the configured peak input-token threshold for that agent.', enabled: true, threshold: 170000, unit: 'tokens', min: 10000, max: 1000000, step: 1000, agentThresholds: { claude_code: 170000, copilot: 108800, codex: 340000 } },
+  { id: 'context_window', label: 'Context Window Filling Up', severity: 'warning', description: 'Fires when any session reaches the configured peak input-token threshold for that agent.', enabled: true, threshold: 170000, unit: 'tokens', min: 10000, max: 1000000, step: 1000, agentThresholds: { claude_code: 170000, copilot: 108800, codex: 340000, opencode: 170000 } },
   { id: 'high_turns', label: 'Too Many Turns Per Session', severity: 'warning', description: 'Fires when any session reaches its agent-specific LLM turn alert threshold. High turn counts often indicate scope creep or a task that should be split.', enabled: true, threshold: 200, unit: 'agent profile', min: 20, max: 500, step: 10 },
   { id: 'error_spike', label: 'Error Spike', severity: 'error', description: 'Fires when any session reaches its agent-specific error count threshold.', enabled: true, threshold: 5, unit: 'agent profile', min: 2, max: 20, step: 1 },
   { id: 'long_session', label: 'Long Active Session', severity: 'info', description: 'Fires when active LLM/tool compute time exceeds the agent-specific threshold. Wall-clock idle time does not count.', enabled: true, threshold: 60, unit: 'agent profile', min: 10, max: 240, step: 10 },
-  { id: 'no_cache', label: 'Zero Cache Utilization', severity: 'info', description: 'Fires when any session above that agent\'s input-token gate has 0% cache hit rate.', enabled: true, threshold: 30000, unit: 'tokens', min: 5000, max: 200000, step: 5000, agentThresholds: { claude_code: 30000, copilot: 30000, codex: 30000 } },
+  { id: 'no_cache', label: 'Zero Cache Utilization', severity: 'info', description: 'Fires when any session above that agent\'s input-token gate has 0% cache hit rate.', enabled: true, threshold: 30000, unit: 'tokens', min: 5000, max: 200000, step: 5000, agentThresholds: { claude_code: 30000, copilot: 30000, codex: 30000, opencode: 30000 } },
   { id: 'tool_loop', label: 'Identical Tool Repeat', severity: 'warning', description: 'Fires when the same tool with identical arguments repeats beyond the agent-specific threshold without a file change between repeats.', enabled: true, threshold: 5, unit: 'agent profile', min: 3, max: 20, step: 1 },
 ]
 
@@ -78,6 +78,7 @@ function cloneAgentThresholds(thresholds?: AgentThresholdMap): AgentThresholdMap
     claude_code: thresholds.claude_code,
     copilot: thresholds.copilot,
     codex: thresholds.codex,
+    opencode: thresholds.opencode,
   }
 }
 
@@ -93,6 +94,7 @@ function fallbackAgentThresholds(threshold: number): AgentThresholdMap {
     claude_code: threshold,
     copilot: threshold,
     codex: threshold,
+    opencode: threshold,
   }
 }
 

--- a/media/src/tabs/Analytics.tsx
+++ b/media/src/tabs/Analytics.tsx
@@ -95,7 +95,7 @@ export function Analytics() {
     )
   }
 
-  const pricedSess = sessions.filter(s => s.source === 'copilot' || s.source === 'codex' || s.source === 'claude_code')
+  const pricedSess = sessions.filter(s => s.source === 'copilot' || s.source === 'codex' || s.source === 'claude_code' || s.source === 'opencode')
   const copilotSess = sessions.filter(s => s.source === 'copilot')
   const claudeSess  = sessions.filter(s => s.source === 'claude_code')
   const codexSess   = sessions.filter(s => s.source === 'codex')
@@ -106,7 +106,7 @@ export function Analytics() {
   const timeOrdered = [...filteredSessions.value].sort((a, b) =>
     Date.parse(b.startTime || '0') - Date.parse(a.startTime || '0')
   )
-  const pricedChartSess = timeOrdered.filter(s => s.source === 'copilot' || s.source === 'codex' || s.source === 'claude_code')
+  const pricedChartSess = timeOrdered.filter(s => s.source === 'copilot' || s.source === 'codex' || s.source === 'claude_code' || s.source === 'opencode')
 
   // Most recent CHART_MAX sessions (newest-first slice, then reversed to oldest-first for charts)
   const chartSessions = timeOrdered.slice(0, CHART_MAX).reverse()

--- a/media/src/tabs/Automation.tsx
+++ b/media/src/tabs/Automation.tsx
@@ -78,7 +78,7 @@ export const DEFAULT_AUTOMATION_CONFIGS: AutomationConfig[] = [
     min: 10000,
     max: 1000000,
     step: 1000,
-    agentThresholds: { claude_code: 140000, copilot: 89600, codex: 280000 },
+    agentThresholds: { claude_code: 140000, copilot: 89600, codex: 280000, opencode: 140000 },
   },
   {
     id: 'loop_break',
@@ -137,6 +137,7 @@ function cloneAgentThresholds(thresholds?: AgentThresholdMap): AgentThresholdMap
     claude_code: thresholds.claude_code,
     copilot: thresholds.copilot,
     codex: thresholds.codex,
+    opencode: thresholds.opencode,
   }
 }
 
@@ -152,6 +153,7 @@ function fallbackAgentThresholds(threshold: number): AgentThresholdMap {
     claude_code: threshold,
     copilot: threshold,
     codex: threshold,
+    opencode: threshold,
   }
 }
 

--- a/media/src/tabs/Help.tsx
+++ b/media/src/tabs/Help.tsx
@@ -154,7 +154,7 @@ function OverviewSection() {
       )}
       <h3 class="help-heading">{HELP_SECTIONS.overview.heading}</h3>
       <div class="help-overview-body">
-        <p><strong>AgentLens</strong> is a local observability tool that makes AI <a href="#gl-agent">agent</a> sessions more transparent — see what's happening inside each run. Available as a VS Code-family IDE extension (VS Code, Cursor, Windsurf, VSCodium, Trae, Kiro), a local web app (npx), or Docker, with no data leaving your machine. It captures <a href="#gl-otlp">OpenTelemetry</a> <a href="#gl-trace">traces</a> from GitHub Copilot, Claude Code, and Codex, and also reads <strong>local session log files</strong> written automatically by each agent as a zero-config fallback — so history loads even without OTEL configured. Both sources feed one unified dashboard and surface efficiency metrics, session cost estimates, human-readable summaries, and actionable insights in real time.</p>
+        <p><strong>AgentLens</strong> is a local observability tool that makes AI <a href="#gl-agent">agent</a> sessions more transparent — see what's happening inside each run. Available as a VS Code-family IDE extension (VS Code, Cursor, Windsurf, VSCodium, Trae, Kiro), a local web app (npx), or Docker, with no data leaving your machine. It captures <a href="#gl-otlp">OpenTelemetry</a> <a href="#gl-trace">traces</a> from GitHub Copilot, Claude Code, and Codex, and also reads <strong>local session files and databases</strong> written automatically by each agent as a zero-config fallback — including OpenCode's local SQLite database — so history loads even without OTEL configured. Both sources feed one unified dashboard and surface efficiency metrics, session cost estimates, human-readable summaries, and actionable insights in real time.</p>
       </div>
     </div>
   )
@@ -231,6 +231,7 @@ chmod +x scripts/configure-agents.sh
         </tbody>
       </table>
       <p style="font-size:11px;color:var(--muted);margin:8px 0 0">Open the <em>AgentLens</em> output channel (<em>View → Output → AgentLens</em>) to confirm spans are arriving.</p>
+      <p style="font-size:11px;color:var(--muted);margin:6px 0 0"><strong style="color:var(--fg)">OpenCode:</strong> No configuration needed. AgentLens reads OpenCode's local SQLite database automatically from <code style={codeStyle}>~/.local/share/opencode/</code> — sessions appear as <strong>Log</strong> badge entries without any OTEL setup.</p>
     </div>
   )
 
@@ -341,6 +342,17 @@ function AgentOtelSection() {
           ))}
         </div>
         <p style="margin-top:14px;font-size:12px;color:var(--muted)">The practical effect: Traces and Timeline stay closest to the raw OTEL structure, while Efficiency, Insights, Alerts, Automation, Agents, and Flow all use the normalized session model so the three agents can be compared side by side.</p>
+        <h4 style={subHeadStyle}>Log-only agents (no OTEL)</h4>
+        <div class="glossary">
+          <div class="glossary-item" style="flex-direction:column;gap:6px">
+            <dt class="glossary-term">OpenCode</dt>
+            <dd class="glossary-def" style="display:block">
+              <p style="margin:0 0 6px"><strong style="color:var(--fg)">Format: </strong>Local SQLite database at <code style={codeStyle}>~/.local/share/opencode/opencode.db</code> (Linux/Mac) or <code style={codeStyle}>%APPDATA%\opencode\opencode.db</code> (Windows). No OTEL support. AgentLens reads the database directly using WASM SQLite, merging the WAL file at read time. Override the path with the <code style={codeStyle}>OPENCODE_DATA_DIR</code> environment variable.</p>
+              <p style="margin:0 0 6px"><strong style="color:var(--fg)">What's included: </strong>Session ID, workspace directory, model name, timestamps, all token counts (input, output, cache read/write), user request (last user message in the session), tool call names and inputs/outputs, file paths accessed by tools, and a full per-turn timeline of LLM calls and tool calls.</p>
+              <p style="margin:0"><strong style="color:var(--fg)">Not available: </strong>OTEL traces, time-to-first-token, per-tool execution timing, streaming speed, and loop detection signals. Sessions show a <strong>Log</strong> badge and a blue info banner in the Overview tab noting these limitations.</p>
+            </dd>
+          </div>
+        </div>
       </div>
     </div>
   )
@@ -805,7 +817,7 @@ function BadgesSection() {
           <dt class="glossary-term" style="min-width:0">
             <span style={`${badgeStyle}color:#90a4ae;border-color:#90a4ae`}>Log</span>
           </dt>
-          <dd class="glossary-def">Parsed from local conversation log files (~/.claude/projects, ~/.codex/sessions, etc.) — tokens, tool calls, and messages are available, but timing and TTFT are not. No agent configuration needed.</dd>
+          <dd class="glossary-def">Parsed from local session files and databases — <code>~/.claude/projects</code>, <code>~/.codex/sessions</code>, <code>~/.copilot/session-state</code>, and OpenCode's SQLite database at <code>~/.local/share/opencode/</code>. Tokens, tool calls, file paths, and user prompts are available. Timing and TTFT are not available from log sources. No agent configuration needed.</dd>
         </div>
       </div>
 

--- a/media/src/tabs/Sessions.tsx
+++ b/media/src/tabs/Sessions.tsx
@@ -104,6 +104,7 @@ function SessionDetail({ sess }: { sess: SessionSummaryCard }) {
           <div>
             {sess.dataSource === 'log' && (() => {
               const isCopilot = sess.source === 'copilot'
+              const isOpenCode = sess.source === 'opencode'
               // Pre-~Feb 2026 Copilot Chat sessions (.json snapshot format): VS Code did not
               // record token counts at all — outputTokens=0 with turns>0 is the fingerprint.
               if (isCopilot && sess.outputTokens === 0 && sess.turns > 0) {
@@ -112,6 +113,15 @@ function SessionDetail({ sess }: { sess: SessionSummaryCard }) {
                     <span style="color:var(--vscode-editorWarning-foreground,#cca700);font-weight:600">Log-only session — no token data</span>
                     {' — '}
                     VS Code Copilot Chat did not record token counts in this era. Token counts and cost estimates are unavailable and cannot be recovered.
+                  </div>
+                )
+              }
+              if (isOpenCode) {
+                return (
+                  <div style="margin-bottom:10px;padding:7px 10px;border-radius:4px;border-left:3px solid var(--vscode-editorInfo-foreground,#4fc3f7);background:var(--hover);font-size:11px;color:var(--muted);line-height:1.5">
+                    <span style="color:var(--vscode-editorInfo-foreground,#4fc3f7);font-weight:600">OpenCode SQLite session</span>
+                    {' — '}
+                    Token counts, tools, and files sourced from OpenCode&apos;s local database. OTEL traces and TTFT are not available for OpenCode.
                   </div>
                 )
               }

--- a/media/src/types.ts
+++ b/media/src/types.ts
@@ -50,7 +50,7 @@ export interface LoopSignal {
 export interface SessionSummaryCard {
   sessionId: string
   traceId: string
-  source: 'copilot' | 'claude_code' | 'codex'
+  source: 'copilot' | 'claude_code' | 'codex' | 'opencode'
   dataSource: 'otel' | 'log'
   initiator?: 'user' | 'agent' | 'api'
   conversationId?: string
@@ -183,7 +183,7 @@ export interface SearchQuery {
   offset?: number
 }
 
-export type AgentFilter = 'all' | 'copilot' | 'claude_code' | 'codex'
+export type AgentFilter = 'all' | 'copilot' | 'claude_code' | 'codex' | 'opencode'
 export type InitiatorFilter = 'all' | 'user' | 'agent' | 'api'
 export type DataSourceFilter = 'all' | 'otel' | 'log'
 export type InsightFilter = 'all' | 'loop' | 'efficiency'

--- a/media/src/utils.ts
+++ b/media/src/utils.ts
@@ -395,6 +395,7 @@ export function getInitiatorBadgeHtml(initiator: 'user' | 'agent' | 'api' | unde
 export function getAgentSourceLabel(source: string | null | undefined): string {
   if (source === 'claude_code') return 'Claude'
   if (source === 'codex') return 'Codex'
+  if (source === 'opencode') return 'OpenCode'
   return 'Copilot'
 }
 
@@ -402,12 +403,14 @@ export function getAgentColor(source: string | null | undefined): string {
   if (source === 'claude_code') return '#FFB085'
   if (source === 'codex') return '#F0FF42'
   if (source === 'copilot') return '#00EAFF'
+  if (source === 'opencode') return '#FFFFFF'
   return '#90a4ae'
 }
 
 export function getAgentShortLabel(source: string | null | undefined): string {
   if (source === 'claude_code') return 'CL'
   if (source === 'codex') return 'CX'
+  if (source === 'opencode') return 'OC'
   return 'CP'
 }
 
@@ -704,5 +707,6 @@ export function drawSparkline(containerId: string, dataPoints: number[]): void {
 export function getAgentSourceClass(source: string | null | undefined): string {
   if (source === 'claude_code') return 'session-agent-claude'
   if (source === 'codex') return 'session-agent-codex'
+  if (source === 'opencode') return 'session-agent-opencode'
   return 'session-agent-copilot'
 }

--- a/src/database/db.ts
+++ b/src/database/db.ts
@@ -10,7 +10,7 @@ interface SqlDatabase {
   export(): Uint8Array
   close(): void
 }
-interface SqlJsStatic {
+export interface SqlJsStatic {
   Database: new (data?: Buffer | Uint8Array) => SqlDatabase
 }
 type InitSqlJs = (config?: { locateFile?: (file: string) => string }) => Promise<SqlJsStatic>
@@ -46,12 +46,13 @@ export async function openDatabase(storagePath: string, extensionPath: string): 
 
   ensureBlobsDir(storagePath)
 
-  return new AgentLensDb(db, dbPath, path.join(storagePath, BLOBS_DIR))
+  return new AgentLensDb(db, SQL, dbPath, path.join(storagePath, BLOBS_DIR))
 }
 
 export class AgentLensDb {
   constructor(
     private readonly db: SqlDatabase,
+    readonly sqlFactory: SqlJsStatic,
     private readonly dbPath: string,
     readonly blobsDir: string,
   ) {}

--- a/src/database/reader.ts
+++ b/src/database/reader.ts
@@ -58,7 +58,7 @@ export class DatabaseReader {
   ) {}
 
   listSessions(filter?: {
-    source?: 'copilot' | 'claude_code' | 'codex'
+    source?: 'copilot' | 'claude_code' | 'codex' | 'opencode'
     since?: number
     limit?: number
   }): SessionSummaryCard[] {
@@ -90,7 +90,7 @@ export class DatabaseReader {
       return {
         sessionId:        col(row, 'session_id') as string,
         traceId:          col(row, 'trace_id') as string,
-        source:           col(row, 'source') as 'copilot' | 'claude_code' | 'codex',
+        source:           col(row, 'source') as 'copilot' | 'claude_code' | 'codex' | 'opencode',
         dataSource:       ((col(row, 'data_source') as string | null) ?? 'otel') as 'otel' | 'log',
         workspace:        (col(row, 'workspace') as string) ?? '',
         projectPath:      (col(row, 'project_path') as string | null) ?? undefined,
@@ -323,7 +323,7 @@ export class DatabaseReader {
       return {
         sessionId:        col(row, 'session_id') as string,
         traceId:          col(row, 'trace_id') as string,
-        source:           col(row, 'source') as 'copilot' | 'claude_code' | 'codex',
+        source:           col(row, 'source') as 'copilot' | 'claude_code' | 'codex' | 'opencode',
         dataSource:       ((col(row, 'data_source') as string | null) ?? 'otel') as 'otel' | 'log',
         workspace:        (col(row, 'workspace') as string) ?? '',
         projectPath:      (col(row, 'project_path') as string | null) ?? undefined,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -214,7 +214,7 @@ export async function activate(context: vscode.ExtensionContext) {
   let logReader: LogReader | undefined
   let startBatchedLoad: ((onAllDone?: () => void) => void) | undefined
   if (enableLogIngestion && writer) {
-    logReader = new LogReader({ log: (msg) => outputChannel!.appendLine(msg) })
+    logReader = new LogReader({ log: (msg) => outputChannel!.appendLine(msg), sqlFactory: agentLensDb?.sqlFactory })
     const lr = logReader  // non-null alias for use inside closures
     const fallbackWorkspace = () => vscode.workspace.workspaceFolders?.[0]?.uri.toString() ?? ''
 
@@ -262,6 +262,7 @@ export async function activate(context: vscode.ExtensionContext) {
         copilot:             'Copilot CLI',
         copilot_vscode:      'Copilot (VS Code)',
         copilot_vscode_json: 'Copilot (VS Code)',
+        opencode:            'OpenCode',
       }
       const countByKey = new Map<string, number>()
 
@@ -303,7 +304,18 @@ export async function activate(context: vscode.ExtensionContext) {
         else onDone()
       }
 
-      const fastFiles = allFiles.filter(f => f.agentKey !== 'copilot_vscode_json')
+      // OpenCode: DB file returns multiple sessions — process separately before batched files.
+      const ocResults = lr.scanOpenCode()
+      if (ocResults.length > 0) {
+        const ws = fallbackWorkspace()
+        for (const { card, workspace } of ocResults) {
+          card.loopSignals = detectLoopSignals(card)
+          writer!.enqueue(card, workspace || ws)
+        }
+        countByKey.set('opencode', (countByKey.get('opencode') ?? 0) + ocResults.length)
+      }
+
+      const fastFiles = allFiles.filter(f => f.agentKey !== 'copilot_vscode_json' && f.agentKey !== 'opencode')
       const slowFiles = allFiles.filter(f => f.agentKey === 'copilot_vscode_json')
 
       processGroup(fastFiles, 10, 0, () => {

--- a/src/logReader.ts
+++ b/src/logReader.ts
@@ -992,21 +992,25 @@ export class LogReader {
       )
 
       // ── Part rows (user text, tool names, files, tool I/O for timeline) ──────
-      const partRows = db.exec(
-        `SELECT p.session_id, p.message_id, p.time_created AS part_ts,
-                json_extract(m.data,'$.role')                 AS msg_role,
-                json_extract(p.data,'$.type')                 AS type,
-                json_extract(p.data,'$.text')                 AS text,
-                json_extract(p.data,'$.tool')                 AS tool_name,
-                json_extract(p.data,'$.callID')               AS call_id,
-                json_extract(p.data,'$.state.input.filePath') AS file_path,
-                json_extract(p.data,'$.state.input')          AS tool_input_json,
-                substr(json_extract(p.data,'$.state.output'),1,2000) AS tool_output,
-                json_extract(p.data,'$.state.status')         AS tool_status
-         FROM part p JOIN message m ON m.id = p.message_id
-         WHERE p.session_id IN (${inList})
-         ORDER BY p.time_created ASC`,
-      )
+      // part table may be absent in older DB versions — gracefully skip if so.
+      let partRows: Array<{ columns: string[]; values: unknown[][] }> = []
+      try {
+        partRows = db.exec(
+          `SELECT p.session_id, p.message_id, p.time_created AS part_ts,
+                  json_extract(m.data,'$.role')                 AS msg_role,
+                  json_extract(p.data,'$.type')                 AS type,
+                  json_extract(p.data,'$.text')                 AS text,
+                  json_extract(p.data,'$.tool')                 AS tool_name,
+                  json_extract(p.data,'$.callID')               AS call_id,
+                  json_extract(p.data,'$.state.input.filePath') AS file_path,
+                  json_extract(p.data,'$.state.input')          AS tool_input_json,
+                  substr(json_extract(p.data,'$.state.output'),1,2000) AS tool_output,
+                  json_extract(p.data,'$.state.status')         AS tool_status
+           FROM part p JOIN message m ON m.id = p.message_id
+           WHERE p.session_id IN (${inList})
+           ORDER BY p.time_created ASC`,
+        )
+      } catch { /* part table absent in this DB version */ }
 
       // Index by session
       interface MsgInfo { msgId: string; tCreated: number; tCompleted: number; tokIn: number; tokOut: number }

--- a/src/logReader.ts
+++ b/src/logReader.ts
@@ -73,6 +73,24 @@ function codexSessionsDirs(): string[] {
   return fs.existsSync(base) ? [base] : []
 }
 
+function openCodeDataDirs(): string[] {
+  const envVal = process.env['OPENCODE_DATA_DIR']
+  if (envVal) {
+    return envVal.split(',').map(p => p.trim()).filter(Boolean)
+      .filter(d => { try { return fs.statSync(d).isDirectory() } catch { return false } })
+  }
+  const home = homeDir()
+  const candidates: string[] = []
+  if (process.platform === 'win32') {
+    const appData = process.env['APPDATA']
+    if (appData) candidates.push(path.join(appData, 'opencode'))
+  } else {
+    const xdgData = process.env['XDG_DATA_HOME'] ?? path.join(home, '.local', 'share')
+    candidates.push(path.join(xdgData, 'opencode'))
+  }
+  return candidates.filter(d => { try { return fs.statSync(d).isDirectory() } catch { return false } })
+}
+
 function copilotSessionStateDir(): string | null {
   // Copilot CLI writes session logs to ~/.copilot/session-state/<uuid>/events.jsonl
   // automatically, with no env setup required.
@@ -118,8 +136,18 @@ interface FileState {
 
 // ── Public interface ──────────────────────────────────────────────────────────
 
+/** Minimal sql.js surface needed to open an external SQLite file read-only. */
+export interface OpenCodeSqlFactory {
+  Database: new (data: Buffer | Uint8Array) => {
+    exec(sql: string): Array<{ columns: string[]; values: unknown[][] }>
+    close(): void
+  }
+}
+
 export interface LogReaderOptions {
   log?: (msg: string) => void
+  /** When provided, enables reading OpenCode sessions from its SQLite DB. */
+  sqlFactory?: OpenCodeSqlFactory
 }
 
 export interface LogSessionResult {
@@ -130,10 +158,12 @@ export interface LogSessionResult {
 
 export class LogReader {
   private readonly log: (msg: string) => void
+  private readonly sqlFactory: OpenCodeSqlFactory | undefined
   private readonly fileState = new Map<string, FileState>()
 
   constructor(options: LogReaderOptions = {}) {
     this.log = options.log ?? (() => { /* silent */ })
+    this.sqlFactory = options.sqlFactory
   }
 
   /** Clears cached file state so the next scan re-reads all files from scratch. */
@@ -196,6 +226,12 @@ export class LogReader {
       } catch { /* root not accessible */ }
     }
 
+    // OpenCode — one entry per data dir (the DB file itself is the tracked unit)
+    for (const dataDir of openCodeDataDirs()) {
+      const dbPath = path.join(dataDir, 'opencode.db')
+      try { entries.push({ filePath: dbPath, mtimeMs: fs.statSync(dbPath).mtimeMs, agentKey: 'opencode' }) } catch { /* skip */ }
+    }
+
     // Newest first — caller processes in this order so recent sessions appear first.
     entries.sort((a, b) => b.mtimeMs - a.mtimeMs)
     return entries
@@ -218,6 +254,7 @@ export class LogReader {
       case 'copilot':             return this._processFile(filePath, () => this._parseCopilotFile(filePath, sessionId))
       case 'copilot_vscode':      return this._processFile(filePath, () => this._parseCopilotVSCodeFile(filePath, sessionId))
       case 'copilot_vscode_json': return this._processFile(filePath, () => this._parseCopilotVSCodeJsonFile(filePath, sessionId))
+      case 'opencode':            return null  // OpenCode DB returns multiple sessions; use _scanOpenCode
       default:                    return null
     }
   }
@@ -229,6 +266,7 @@ export class LogReader {
       ...codexSessionsDirs(),
       ...((() => { const d = copilotSessionStateDir(); return d ? [d] : [] })()),
       ...vscodeFamilyWorkspaceStorageRoots(),
+      ...openCodeDataDirs(),
     ]
   }
 
@@ -242,6 +280,7 @@ export class LogReader {
       ...this._scanCodex(),
       ...this._scanCopilot(),
       ...this._scanCopilotVSCode(),
+      ...this._scanOpenCode(),
     ]
   }
 
@@ -865,6 +904,341 @@ export class LogReader {
     }
   }
 
+  // ── OpenCode ──────────────────────────────────────────────────────────────────
+  // Primary data source: ~/.local/share/opencode/opencode.db (SQLite)
+  //   Tables: session (id, parent_id, title, cwd, time), message (id, session_id, data JSON)
+  // Fallback: ~/.local/share/opencode/storage/message/*.json (one JSON per message)
+  // Override: OPENCODE_DATA_DIR (comma-separated list of data dirs)
+  //
+  // Only root sessions (parent_id IS NULL / '') are included in this pass.
+  // Subagent session attribution is left for a follow-up.
+
+  /** Public entry point for the initial batch load in extension.ts. */
+  scanOpenCode(): LogSessionResult[] {
+    return this._scanOpenCode()
+  }
+
+  private _scanOpenCode(): LogSessionResult[] {
+    const results: LogSessionResult[] = []
+    const dirs = openCodeDataDirs()
+
+    for (const dataDir of dirs) {
+      const dbPath = path.join(dataDir, 'opencode.db')
+      const walPath = dbPath + '-wal'
+      try {
+        const stat = fs.statSync(dbPath)
+        // Also check WAL mtime — OpenCode writes to the WAL, not the DB file directly.
+        let walMtime = 0
+        try { walMtime = fs.statSync(walPath).mtimeMs } catch { /* no WAL */ }
+        const effectiveMtime = Math.max(stat.mtimeMs, walMtime)
+        const prev = this.fileState.get(dbPath)
+        if (prev && effectiveMtime === prev.mtimeMs && stat.size === prev.bytesRead) continue
+        this.fileState.set(dbPath, { bytesRead: stat.size, mtimeMs: effectiveMtime })
+      } catch {
+        continue
+      }
+
+      if (this.sqlFactory) {
+        try {
+          results.push(...this._parseOpenCodeDb(dbPath))
+        } catch (err) {
+          this.log(`[LogReader] OpenCode DB error ${dbPath}: ${err}`)
+          results.push(...this._parseOpenCodeJsonFallback(dataDir))
+        }
+      } else {
+        results.push(...this._parseOpenCodeJsonFallback(dataDir))
+      }
+    }
+    return results
+  }
+
+  private _parseOpenCodeDb(dbPath: string): LogSessionResult[] {
+    let buf: Uint8Array = fs.readFileSync(dbPath)
+    const walPath = dbPath + '-wal'
+    try {
+      const wal = fs.readFileSync(walPath)
+      if (wal.length > 32) buf = _mergeWal(buf, wal)
+    } catch { /* no WAL file — main DB is fully checkpointed */ }
+    const db = new this.sqlFactory!.Database(buf)
+    try {
+      // ── Session rows ───────────────────────────────────────────────────────
+      const sessRows = db.exec(`
+        SELECT s.id, s.directory, s.title, s.time_created,
+               json_extract(s.model, '$.id') AS model_id,
+               s.tokens_input, s.tokens_output, s.tokens_reasoning,
+               s.tokens_cache_read, s.tokens_cache_write
+        FROM session s
+        WHERE (s.parent_id IS NULL OR s.parent_id = '')
+          AND (s.tokens_input + s.tokens_output + s.tokens_cache_read + s.tokens_cache_write) > 0
+        ORDER BY s.time_created DESC
+      `)
+      if (!sessRows[0]) return []
+      const sc = (n: string) => sessRows[0].columns.indexOf(n)
+      const sessionIds = sessRows[0].values.map(r => String(r[sc('id')]))
+      if (sessionIds.length === 0) return []
+
+      // ── Message rows (per-turn timing & token breakdown) ──────────────────
+      // db.exec() doesn't accept bind parameters — inline quoted IDs (trusted, same-DB source).
+      const inList = sessionIds.map(id => `'${id.replace(/'/g, "''")}'`).join(',')
+      const msgRows = db.exec(
+        `SELECT session_id, id AS msg_id,
+                json_extract(data,'$.role')           AS role,
+                json_extract(data,'$.time.created')   AS t_created,
+                json_extract(data,'$.time.completed') AS t_completed,
+                json_extract(data,'$.tokens.input')   AS tok_in,
+                json_extract(data,'$.tokens.output')  AS tok_out
+         FROM message WHERE session_id IN (${inList})
+         ORDER BY time_created ASC`,
+      )
+
+      // ── Part rows (user text, tool names, files, tool I/O for timeline) ──────
+      const partRows = db.exec(
+        `SELECT p.session_id, p.message_id, p.time_created AS part_ts,
+                json_extract(m.data,'$.role')                 AS msg_role,
+                json_extract(p.data,'$.type')                 AS type,
+                json_extract(p.data,'$.text')                 AS text,
+                json_extract(p.data,'$.tool')                 AS tool_name,
+                json_extract(p.data,'$.callID')               AS call_id,
+                json_extract(p.data,'$.state.input.filePath') AS file_path,
+                json_extract(p.data,'$.state.input')          AS tool_input_json,
+                substr(json_extract(p.data,'$.state.output'),1,2000) AS tool_output,
+                json_extract(p.data,'$.state.status')         AS tool_status
+         FROM part p JOIN message m ON m.id = p.message_id
+         WHERE p.session_id IN (${inList})
+         ORDER BY p.time_created ASC`,
+      )
+
+      // Index by session
+      interface MsgInfo { msgId: string; tCreated: number; tCompleted: number; tokIn: number; tokOut: number }
+      interface PartInfo {
+        partTs: number; msgRole: string; type: string
+        text: string | null; toolName: string | null; callId: string | null
+        filePath: string | null; toolInputJson: string | null
+        toolOutput: string | null; toolStatus: string | null
+      }
+      const msgsBySess  = new Map<string, MsgInfo[]>()
+      const partsBySess = new Map<string, PartInfo[]>()
+
+      if (msgRows[0]) {
+        const mc = (n: string) => msgRows[0].columns.indexOf(n)
+        for (const r of msgRows[0].values) {
+          const sid = String(r[mc('session_id')])
+          if (!msgsBySess.has(sid)) msgsBySess.set(sid, [])
+          if (String(r[mc('role')]) === 'assistant') {
+            msgsBySess.get(sid)!.push({
+              msgId: String(r[mc('msg_id')]),
+              tCreated:   Number(r[mc('t_created')]   ?? 0),
+              tCompleted: Number(r[mc('t_completed')] ?? 0),
+              tokIn:  Number(r[mc('tok_in')]  ?? 0),
+              tokOut: Number(r[mc('tok_out')] ?? 0),
+            })
+          }
+        }
+      }
+      if (partRows[0]) {
+        const pc = (n: string) => partRows[0].columns.indexOf(n)
+        for (const r of partRows[0].values) {
+          const sid = String(r[pc('session_id')])
+          if (!partsBySess.has(sid)) partsBySess.set(sid, [])
+          partsBySess.get(sid)!.push({
+            partTs:       Number(r[pc('part_ts')]         ?? 0),
+            msgRole:      String(r[pc('msg_role')]        ?? ''),
+            type:         String(r[pc('type')]            ?? ''),
+            text:         r[pc('text')]           != null ? String(r[pc('text')])           : null,
+            toolName:     r[pc('tool_name')]      != null ? String(r[pc('tool_name')])      : null,
+            callId:       r[pc('call_id')]        != null ? String(r[pc('call_id')])        : null,
+            filePath:     r[pc('file_path')]      != null ? String(r[pc('file_path')])      : null,
+            toolInputJson:r[pc('tool_input_json')]!= null ? String(r[pc('tool_input_json')]): null,
+            toolOutput:   r[pc('tool_output')]    != null ? String(r[pc('tool_output')])    : null,
+            toolStatus:   r[pc('tool_status')]    != null ? String(r[pc('tool_status')])    : null,
+          })
+        }
+      }
+
+      // ── Build cards ────────────────────────────────────────────────────────
+      const results: LogSessionResult[] = []
+      for (const row of sessRows[0].values) {
+        const sessionId = String(row[sc('id')] ?? '')
+        if (!sessionId) continue
+
+        const timeMs    = Number(row[sc('time_created')]      ?? 0)
+        const startTs   = timeMs > 0 ? new Date(timeMs).toISOString() : ''
+        const modelId   = String(row[sc('model_id')]          ?? '')
+        const workspace = String(row[sc('directory')]         ?? '')
+        const tokIn     = Number(row[sc('tokens_input')]      ?? 0)
+        const tokOut    = Number(row[sc('tokens_output')]     ?? 0)
+        const tokReason = Number(row[sc('tokens_reasoning')]  ?? 0)
+        const tokCR     = Number(row[sc('tokens_cache_read')] ?? 0)
+        const tokCW     = Number(row[sc('tokens_cache_write')]?? 0)
+        const title     = String(row[sc('title')] ?? '')
+
+        const msgs  = msgsBySess.get(sessionId)  ?? []
+        const parts = partsBySess.get(sessionId) ?? []
+
+        // User request: last user-typed text (parts are ordered ASC, so last wins).
+        // OpenCode sessions are multi-turn; the most recent prompt best identifies current work.
+        // Falls back to AI-generated session title if no user text parts exist.
+        let userRequest = title.slice(0, 500)
+        for (const p of parts) {
+          if (p.msgRole === 'user' && p.type === 'text' && p.text) {
+            userRequest = p.text.slice(0, 500)
+          }
+        }
+
+        // Tools, files, and timeline events built in a single pass (parts are ASC by time).
+        // LLM entries come from messages; tool entries come from tool parts.
+        // We merge them by timestamp so the Flow tab shows real interleaved activity.
+        const toolCounts: Record<string, number> = {}
+        const filesRead    = new Set<string>()
+        const filesWritten = new Set<string>()
+        const filesChanged = new Set<string>()
+        let totalToolCalls = 0
+
+        // Keyed events: msgId → LLM entry (filled from msgs), callId → tool entry
+        type PendingLlm  = { ts: number; entry: TimelineEntry }
+        type PendingTool = { ts: number; entry: TimelineEntry }
+        const llmEvents:  PendingLlm[]  = []
+        const toolEvents: PendingTool[] = []
+
+        // LLM entries from assistant messages
+        let llmIdx = 0
+        let lastCompleted = 0
+        for (const m of msgs) {
+          const durationMs = m.tCompleted > m.tCreated ? m.tCompleted - m.tCreated : 0
+          llmEvents.push({
+            ts: m.tCreated,
+            entry: {
+              type: 'llm', spanId: `oc-${m.msgId}`,
+              label: `Turn ${++llmIdx}`,
+              durationMs,
+              inputTokens: m.tokIn, outputTokens: m.tokOut,
+              isError: false,
+              timestamp: m.tCreated > 0 ? new Date(m.tCreated).toISOString() : startTs,
+              model: modelId || undefined,
+            },
+          })
+          if (m.tCompleted > lastCompleted) lastCompleted = m.tCompleted
+        }
+
+        // Tool entries from tool parts
+        for (const p of parts) {
+          if (p.type !== 'tool' || !p.toolName) continue
+          toolCounts[p.toolName] = (toolCounts[p.toolName] ?? 0) + 1
+          totalToolCalls++
+          if (p.filePath) {
+            const t = p.toolName.toLowerCase()
+            if (t === 'read' || t === 'glob' || t === 'grep') {
+              filesRead.add(p.filePath)
+            } else if (t === 'write' || t === 'edit' || t === 'patch') {
+              filesWritten.add(p.filePath)
+              filesChanged.add(p.filePath)
+            }
+          }
+          const isError = p.toolStatus === 'error'
+          const label = p.filePath
+            ? `${p.toolName}: ${p.filePath.split('/').pop()}`
+            : p.toolName
+          toolEvents.push({
+            ts: p.partTs,
+            entry: {
+              type: 'tool', spanId: `oc-tool-${p.callId ?? p.partTs}`,
+              label,
+              action: p.toolName,
+              toolInput: p.toolInputJson ?? undefined,
+              resultSummary: p.toolOutput ? p.toolOutput.slice(0, 200) : undefined,
+              fullResult: p.toolOutput ?? undefined,
+              durationMs: 0,
+              isError,
+              errorMessage: isError ? (p.toolOutput ?? undefined) : undefined,
+              timestamp: p.partTs > 0 ? new Date(p.partTs).toISOString() : startTs,
+            },
+          })
+        }
+
+        // Merge LLM and tool events in chronological order
+        const allEvents = [...llmEvents, ...toolEvents].sort((a, b) => a.ts - b.ts)
+        const timeline: TimelineEntry[] = allEvents.map(e => e.entry)
+
+        const endTs = lastCompleted > 0 ? new Date(lastCompleted).toISOString() : startTs
+
+        const card = _buildCard(
+          sessionId, 'opencode', modelId || 'opencode',
+          startTs, endTs,
+          {
+            totalInput: tokIn, totalOutput: tokOut + tokReason,
+            totalCacheRead: tokCR, totalCacheCreate: tokCW, peakContextPerTurn: 0,
+            turns: msgs.length, totalToolCalls, toolCounts,
+            filesRead, filesChanged, filesWritten, filesSearched: new Set(),
+            userRequest, timeline, initiator: 'user',
+          },
+          workspace,
+        )
+        results.push({ card, workspace })
+      }
+      return results
+    } finally {
+      db.close()
+    }
+  }
+
+  private _parseOpenCodeJsonFallback(dataDir: string): LogSessionResult[] {
+    // Reads ~/.local/share/opencode/storage/message/*.json as a fallback when
+    // the SQLite DB is unavailable. Each file is one message; session grouping
+    // uses the session_id field. Session title and cwd are not available here.
+    const msgDir = path.join(dataDir, 'storage', 'message')
+    let names: string[]
+    try { names = fs.readdirSync(msgDir).filter(n => n.endsWith('.json')) } catch { return [] }
+
+    const sessions = new Map<string, {
+      model: string; sessionTime: string
+      tokIn: number; tokOut: number; tokReasoning: number
+      tokCacheRead: number; tokCacheWrite: number; turns: number
+    }>()
+
+    for (const name of names) {
+      let msg: Record<string, unknown>
+      try { msg = JSON.parse(fs.readFileSync(path.join(msgDir, name), 'utf-8')) as Record<string, unknown> } catch { continue }
+      if (msg['role'] !== 'assistant') continue
+      const sessionId = String(msg['session_id'] ?? '')
+      if (!sessionId) continue
+      const tokens = msg['tokens'] as Record<string, unknown> | undefined
+      const cache  = tokens?.['cache'] as Record<string, unknown> | undefined
+      const modelId = String(msg['id'] ?? '')
+      let s = sessions.get(sessionId)
+      if (!s) {
+        s = { model: modelId, sessionTime: '', tokIn: 0, tokOut: 0, tokReasoning: 0, tokCacheRead: 0, tokCacheWrite: 0, turns: 0 }
+        sessions.set(sessionId, s)
+      }
+      if (modelId && !s.model) s.model = modelId
+      s.tokIn        += Number(tokens?.['input']     ?? 0)
+      s.tokOut       += Number(tokens?.['output']    ?? 0)
+      s.tokReasoning += Number(tokens?.['reasoning'] ?? 0)
+      s.tokCacheRead += Number(cache?.['read']  ?? 0)
+      s.tokCacheWrite+= Number(cache?.['write'] ?? 0)
+      s.turns++
+    }
+
+    const results: LogSessionResult[] = []
+    for (const [sessionId, s] of sessions) {
+      const totalOutput = s.tokOut + s.tokReasoning
+      const card = _buildCard(
+        sessionId, 'opencode', s.model || 'opencode',
+        s.sessionTime, s.sessionTime,
+        {
+          totalInput: s.tokIn, totalOutput, totalCacheRead: s.tokCacheRead,
+          totalCacheCreate: s.tokCacheWrite, peakContextPerTurn: 0,
+          turns: s.turns, totalToolCalls: 0, toolCounts: {},
+          filesRead: new Set(), filesChanged: new Set(),
+          filesWritten: new Set(), filesSearched: new Set(),
+          userRequest: '', timeline: [], initiator: 'user',
+        },
+        '',
+      )
+      results.push({ card, workspace: '' })
+    }
+    return results
+  }
+
   // ── Shared helpers ────────────────────────────────────────────────────────────
 
   private _collectJsonlFiles(dir: string): string[] {
@@ -953,7 +1327,7 @@ interface CardAccum {
 
 function _buildCard(
   sessionId: string,
-  source: 'claude_code' | 'codex' | 'copilot',
+  source: 'claude_code' | 'codex' | 'copilot' | 'opencode',
   model: string,
   firstTimestamp: string,
   lastTimestamp: string,
@@ -1069,6 +1443,50 @@ function _extractTextContent(content: unknown): string {
     }
   }
   return ''
+}
+
+/**
+ * Merges outstanding WAL frames into the database buffer so sql.js can read
+ * sessions written since the last checkpoint. SQLite WAL format (spec §2):
+ *   - 32-byte header: magic, version, page size, seq, salt1, salt2, cksum1, cksum2
+ *   - Frames: 24-byte frame header + pageSize bytes of page data
+ *     Frame header: pgno (4), dbSize (4), salt1 (4), salt2 (4), cksum1 (4), cksum2 (4)
+ * Frames whose salts don't match the WAL header belong to a stale WAL — stop there.
+ */
+function _mergeWal(dbBuf: Uint8Array, walBuf: Uint8Array): Uint8Array {
+  const dv = (b: Uint8Array) => new DataView(b.buffer, b.byteOffset, b.byteLength)
+  if (walBuf.length < 32) return dbBuf
+  const wDv = dv(walBuf)
+  const magic = wDv.getUint32(0)
+  if (magic !== 0x377f0682 && magic !== 0x377f0683) return dbBuf
+  const pageSize = wDv.getUint32(8)
+  if (pageSize < 512 || (pageSize & (pageSize - 1)) !== 0) return dbBuf
+  const salt1 = wDv.getUint32(16)
+  const salt2 = wDv.getUint32(20)
+
+  const FRAME = 24 + pageSize
+  let result = new Uint8Array(dbBuf)
+  let off = 32
+
+  while (off + FRAME <= walBuf.length) {
+    const pgno   = wDv.getUint32(off)
+    const fSalt1 = wDv.getUint32(off + 8)
+    const fSalt2 = wDv.getUint32(off + 12)
+    if (fSalt1 !== salt1 || fSalt2 !== salt2) break  // stale generation
+    if (pgno >= 1) {
+      const pageOff = (pgno - 1) * pageSize
+      const pageEnd = pageOff + pageSize
+      if (pageEnd > result.length) {
+        const ext = new Uint8Array(pageEnd)
+        ext.set(result)
+        result = ext
+      }
+      result.set(walBuf.slice(off + 24, off + 24 + pageSize), pageOff)
+    }
+    off += FRAME
+  }
+
+  return result
 }
 
 function _parseTs(ts: string): number {

--- a/src/pricing.ts
+++ b/src/pricing.ts
@@ -61,6 +61,9 @@ const RATES: Record<string, ModelRates> = {
   // ── Fine-tuned ─────────────────────────────────────────────────────────────
   'raptor-mini': { inputPerMTok: 0,    cacheReadPerMTok: 0,     cacheWritePerMTok: 0, outputPerMTok:  0,     contextWindowTokens: 0 },
   'goldeneye':   { inputPerMTok: 1.25, cacheReadPerMTok: 0.125, cacheWritePerMTok: 0, outputPerMTok: 10.00, contextWindowTokens: 0 },
+  // ── OpenCode Zen  https://opencode.ai/docs/zen/ ────────────────────────────
+  // big-pickle: OpenCode's stealth model, free during limited evaluation period.
+  'big-pickle':  { inputPerMTok: 0,    cacheReadPerMTok: 0,     cacheWritePerMTok: 0, outputPerMTok:  0,     contextWindowTokens: 200_000 },
 }
 
 function normalizeModelId(modelId: string): string {

--- a/src/sessionRepository.ts
+++ b/src/sessionRepository.ts
@@ -72,7 +72,7 @@ export class SessionRepository {
 
   /** Returns merged session list: live window + historical DB, sorted newest-first. */
   listSessions(filter?: {
-    source?: 'copilot' | 'claude_code' | 'codex'
+    source?: 'copilot' | 'claude_code' | 'codex' | 'opencode'
     limit?: number
   }): SessionSummaryCard[] {
     const dbSessions = this.reader.listSessions(filter)

--- a/src/summarizers/summarizerTypes.ts
+++ b/src/summarizers/summarizerTypes.ts
@@ -3,7 +3,7 @@ import { LoopSignal } from '../types'
 export interface SessionSummaryCard {
   sessionId: string
   traceId: string
-  source: 'copilot' | 'claude_code' | 'codex'
+  source: 'copilot' | 'claude_code' | 'codex' | 'opencode'
   dataSource: 'otel' | 'log'
   initiator?: 'user' | 'agent' | 'api'
   conversationId?: string

--- a/src/test/logReader.opencode.test.ts
+++ b/src/test/logReader.opencode.test.ts
@@ -1,0 +1,210 @@
+import * as assert from 'assert'
+import * as path from 'path'
+import * as fs from 'fs'
+import * as os from 'os'
+import { LogReader, type OpenCodeSqlFactory } from '../logReader'
+
+// ── In-memory sql.js fixture ──────────────────────────────────────────────────
+
+type SqlDb = {
+  run(sql: string, params?: unknown[]): void
+  exec(sql: string): Array<{ columns: string[]; values: unknown[][] }>
+  export(): Uint8Array
+  close(): void
+}
+
+async function makeOpenCodeSqlFactory(): Promise<{ factory: OpenCodeSqlFactory; createDb: () => SqlDb }> {
+  const sqlJsDir = path.dirname(require.resolve('sql.js'))
+  const initSqlJs = require('sql.js') as (cfg: { locateFile: (f: string) => string }) => Promise<{ Database: new (data?: Buffer | Uint8Array) => SqlDb }>
+  const SQL = await initSqlJs({ locateFile: (f: string) => path.join(sqlJsDir, f) })
+  return {
+    factory: SQL as unknown as OpenCodeSqlFactory,
+    createDb: () => new SQL.Database(),
+  }
+}
+
+// Matches the actual OpenCode database schema (confirmed 2026-06-10).
+const OPENCODE_SCHEMA = `
+  CREATE TABLE session (
+    id               TEXT PRIMARY KEY,
+    parent_id        TEXT,
+    title            TEXT NOT NULL DEFAULT '',
+    directory        TEXT NOT NULL DEFAULT '',
+    model            TEXT,
+    time_created     INTEGER NOT NULL DEFAULT 0,
+    time_updated     INTEGER NOT NULL DEFAULT 0,
+    tokens_input     INTEGER NOT NULL DEFAULT 0,
+    tokens_output    INTEGER NOT NULL DEFAULT 0,
+    tokens_reasoning INTEGER NOT NULL DEFAULT 0,
+    tokens_cache_read  INTEGER NOT NULL DEFAULT 0,
+    tokens_cache_write INTEGER NOT NULL DEFAULT 0
+  );
+  CREATE TABLE message (
+    id         TEXT PRIMARY KEY,
+    session_id TEXT NOT NULL,
+    time_created INTEGER NOT NULL DEFAULT 0,
+    data       TEXT NOT NULL
+  );
+`
+
+function insertSession(db: SqlDb, id: string, opts: {
+  parentId?: string | null
+  title?: string
+  directory?: string
+  model?: string
+  timeCreated?: number
+  tokIn?: number; tokOut?: number; tokReasoning?: number
+  tokCacheRead?: number; tokCacheWrite?: number
+} = {}) {
+  db.run(
+    `INSERT INTO session
+      (id, parent_id, title, directory, model, time_created, tokens_input,
+       tokens_output, tokens_reasoning, tokens_cache_read, tokens_cache_write)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    [
+      id, opts.parentId ?? null, opts.title ?? '', opts.directory ?? '/workspace',
+      opts.model ?? JSON.stringify({ id: 'claude-sonnet-4-6', providerID: 'anthropic' }),
+      opts.timeCreated ?? 1704067200000,  // 2024-01-01T00:00:00.000Z
+      opts.tokIn ?? 1000, opts.tokOut ?? 200, opts.tokReasoning ?? 0,
+      opts.tokCacheRead ?? 500, opts.tokCacheWrite ?? 100,
+    ],
+  )
+}
+
+function insertMessage(db: SqlDb, id: string, sessionId: string, role: 'user' | 'assistant') {
+  db.run('INSERT INTO message (id, session_id, time_created, data) VALUES (?, ?, ?, ?)',
+    [id, sessionId, 1704067200000, JSON.stringify({ role })])
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+suite('LogReader — OpenCode', () => {
+  let factory: OpenCodeSqlFactory
+  let createDb: () => SqlDb
+
+  suiteSetup(async () => {
+    const result = await makeOpenCodeSqlFactory()
+    factory = result.factory
+    createDb = result.createDb
+  })
+
+  test('reads session from DB with correct token aggregation', async () => {
+    const db = createDb()
+    db.run(OPENCODE_SCHEMA)
+
+    insertSession(db, 'sess-1', {
+      title: 'Fix the bug', directory: '/my/project',
+      model: JSON.stringify({ id: 'claude-sonnet-4-6', providerID: 'anthropic' }),
+      timeCreated: 1704067200000,
+      tokIn: 1800, tokOut: 350, tokReasoning: 50, tokCacheRead: 800, tokCacheWrite: 100,
+    })
+    insertMessage(db, 'msg-u1', 'sess-1', 'user')
+    insertMessage(db, 'msg-a1', 'sess-1', 'assistant')
+    insertMessage(db, 'msg-a2', 'sess-1', 'assistant')
+
+    const dataDir = os.tmpdir()
+    const ocDbPath = path.join(dataDir, `opencode-${Date.now()}.db`)
+    fs.writeFileSync(ocDbPath, Buffer.from(db.export()))
+    db.close()
+    const finalPath = path.join(dataDir, 'opencode.db')
+    if (fs.existsSync(finalPath)) return  // skip if real DB present
+    fs.renameSync(ocDbPath, finalPath)
+    const origEnv = process.env['OPENCODE_DATA_DIR']
+    process.env['OPENCODE_DATA_DIR'] = dataDir
+
+    try {
+      const reader = new LogReader({ sqlFactory: factory })
+      const results = reader.scan()
+      const sess = results.find(r => r.card.sessionId === 'sess-1')
+      assert.ok(sess, 'session should be found')
+      assert.strictEqual(sess!.card.source, 'opencode')
+      assert.strictEqual(sess!.card.model, 'claude-sonnet-4-6')
+      assert.strictEqual(sess!.card.userRequest, 'Fix the bug')
+      assert.strictEqual(sess!.workspace, '/my/project')
+      assert.strictEqual(sess!.card.turns, 2)  // 2 assistant messages
+      // inputTokens = tokIn + tokCacheRead + tokCacheWrite = 1800 + 800 + 100 = 2700
+      assert.strictEqual(sess!.card.inputTokens, 2700)
+      // outputTokens = tokOut + tokReasoning = 350 + 50 = 400
+      assert.strictEqual(sess!.card.outputTokens, 400)
+      assert.strictEqual(sess!.card.cacheReadTokens, 800)
+      assert.strictEqual(sess!.card.cacheCreateTokens, 100)
+      assert.strictEqual(sess!.card.startTime, '2024-01-01T00:00:00.000Z')
+    } finally {
+      process.env['OPENCODE_DATA_DIR'] = origEnv
+      try { fs.unlinkSync(finalPath) } catch { /* cleanup */ }
+    }
+  })
+
+  test('excludes subagent sessions (parent_id set)', async () => {
+    const db = createDb()
+    db.run(OPENCODE_SCHEMA)
+
+    insertSession(db, 'root-1', { title: 'Root', tokIn: 500 })
+    insertSession(db, 'child-1', { parentId: 'root-1', title: 'Subagent', tokIn: 200 })
+    insertMessage(db, 'msg-r', 'root-1', 'assistant')
+    insertMessage(db, 'msg-c', 'child-1', 'assistant')
+
+    const dataDir = os.tmpdir()
+    const finalPath = path.join(dataDir, 'opencode.db')
+    if (fs.existsSync(finalPath)) return
+    fs.writeFileSync(finalPath, Buffer.from(db.export()))
+    db.close()
+    const origEnv = process.env['OPENCODE_DATA_DIR']
+    process.env['OPENCODE_DATA_DIR'] = dataDir
+
+    try {
+      const reader = new LogReader({ sqlFactory: factory })
+      const results = reader.scan()
+      const ids = results.map(r => r.card.sessionId)
+      assert.ok(ids.includes('root-1'), 'root session should be present')
+      assert.ok(!ids.includes('child-1'), 'subagent session should be excluded')
+    } finally {
+      process.env['OPENCODE_DATA_DIR'] = origEnv
+      try { fs.unlinkSync(finalPath) } catch { /* cleanup */ }
+    }
+  })
+
+  test('falls back to JSON message files when no sqlFactory', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'opencode-fallback-'))
+    const msgDir = path.join(tmpDir, 'storage', 'message')
+    fs.mkdirSync(msgDir, { recursive: true })
+
+    fs.writeFileSync(path.join(msgDir, 'msg-a.json'), JSON.stringify({
+      role: 'assistant', session_id: 'fallback-sess', id: 'claude-sonnet-4-6',
+      tokens: { input: 600, output: 120, reasoning: 0, cache: { read: 200, write: 50 } },
+    }))
+    fs.writeFileSync(path.join(msgDir, 'msg-u.json'), JSON.stringify({ role: 'user', session_id: 'fallback-sess' }))
+    // dummy opencode.db so the data dir is detected
+    fs.writeFileSync(path.join(tmpDir, 'opencode.db'), '')
+
+    const origEnv = process.env['OPENCODE_DATA_DIR']
+    process.env['OPENCODE_DATA_DIR'] = tmpDir
+
+    try {
+      const reader = new LogReader()  // no sqlFactory → fallback
+      const results = reader.scan()
+      const sess = results.find(r => r.card.sessionId === 'fallback-sess')
+      assert.ok(sess, 'fallback session should be found')
+      assert.strictEqual(sess!.card.source, 'opencode')
+      assert.strictEqual(sess!.card.model, 'claude-sonnet-4-6')
+      assert.strictEqual(sess!.card.turns, 1)
+      assert.strictEqual(sess!.card.outputTokens, 120)
+      assert.strictEqual(sess!.card.cacheReadTokens, 200)
+      assert.strictEqual(sess!.card.cacheCreateTokens, 50)
+    } finally {
+      process.env['OPENCODE_DATA_DIR'] = origEnv
+      fs.rmSync(tmpDir, { recursive: true, force: true })
+    }
+  })
+
+  test('returns no results when OPENCODE_DATA_DIR does not exist', () => {
+    const origEnv = process.env['OPENCODE_DATA_DIR']
+    process.env['OPENCODE_DATA_DIR'] = '/nonexistent/path/opencode'
+    try {
+      const reader = new LogReader({ sqlFactory: factory })
+      assert.strictEqual(reader.scan().length, 0)
+    } finally {
+      process.env['OPENCODE_DATA_DIR'] = origEnv
+    }
+  })
+})

--- a/src/test/logReader.opencode.test.ts
+++ b/src/test/logReader.opencode.test.ts
@@ -114,7 +114,7 @@ suite('LogReader — OpenCode', () => {
 
     try {
       const reader = new LogReader({ sqlFactory: factory })
-      const results = reader.scan()
+      const results = reader.scanOpenCode()
       const sess = results.find(r => r.card.sessionId === 'sess-1')
       assert.ok(sess, 'session should be found')
       assert.strictEqual(sess!.card.source, 'opencode')
@@ -154,7 +154,7 @@ suite('LogReader — OpenCode', () => {
 
     try {
       const reader = new LogReader({ sqlFactory: factory })
-      const results = reader.scan()
+      const results = reader.scanOpenCode()
       const ids = results.map(r => r.card.sessionId)
       assert.ok(ids.includes('root-1'), 'root session should be present')
       assert.ok(!ids.includes('child-1'), 'subagent session should be excluded')
@@ -182,7 +182,7 @@ suite('LogReader — OpenCode', () => {
 
     try {
       const reader = new LogReader()  // no sqlFactory → fallback
-      const results = reader.scan()
+      const results = reader.scanOpenCode()
       const sess = results.find(r => r.card.sessionId === 'fallback-sess')
       assert.ok(sess, 'fallback session should be found')
       assert.strictEqual(sess!.card.source, 'opencode')
@@ -202,7 +202,7 @@ suite('LogReader — OpenCode', () => {
     process.env['OPENCODE_DATA_DIR'] = '/nonexistent/path/opencode'
     try {
       const reader = new LogReader({ sqlFactory: factory })
-      assert.strictEqual(reader.scan().length, 0)
+      assert.strictEqual(reader.scanOpenCode().length, 0)
     } finally {
       process.env['OPENCODE_DATA_DIR'] = origEnv
     }

--- a/standalone/server.ts
+++ b/standalone/server.ts
@@ -17,7 +17,7 @@ import { calcTokenCostUsd } from '../src/pricing'
 import { autoConfigureClaudeCode, autoConfigureCodex, autoConfigureCopilotStandalone } from '../src/autoConfigNode'
 import { classifyOtlpPayload } from '../src/otlpParser'
 import { startMcpHttpServer } from '../src/mcpServer'
-import { LogReader } from '../src/logReader'
+import { LogReader, type OpenCodeSqlFactory } from '../src/logReader'
 import { generateSuggestions } from '../src/instructionAdvisor'
 import { detectInstructionFiles, appendSuggestion } from '../src/instructionFiles'
 import type { Span } from '../src/types'
@@ -106,7 +106,7 @@ function buildImportCardStandalone(raw: Record<string, unknown>): SessionSummary
   }
 }
 
-const logReader = new LogReader()
+let logReader = new LogReader()
 
 // ── MCP server ────────────────────────────────────────────────────────────────
 
@@ -143,7 +143,16 @@ function setupLogWatcher() {
   }
 }
 
-function startLogIngestion() {
+async function startLogIngestion() {
+  // Initialize sql.js so we can read the OpenCode SQLite DB.
+  try {
+    const sqlJsDir = path.dirname(require.resolve('sql.js'))
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const initSqlJs = require('sql.js') as (cfg: { locateFile: (f: string) => string }) => Promise<OpenCodeSqlFactory>
+    const sqlFactory = await initSqlJs({ locateFile: (f: string) => path.join(sqlJsDir, f) })
+    logReader = new LogReader({ log: (msg) => console.log(msg), sqlFactory })
+  } catch { /* no sql.js — OpenCode falls back to JSON */ }
+
   // Register the poll first so it always runs, even if no files exist yet at startup.
   setInterval(runLogScan, 5_000)
   // Watch log directories for file-system events so updates appear immediately,
@@ -151,16 +160,13 @@ function startLogIngestion() {
   setupLogWatcher()
   console.log('[AgentLens] Log ingestion enabled — scanning local session files')
 
-  let files: ReturnType<typeof logReader.collectFileMeta>
-  try { files = logReader.collectFileMeta() } catch { return }
-  if (files.length === 0) return
-
   const AGENT_KEY_LABEL: Record<string, string> = {
     claude:               'Claude Code',
     codex:                'Codex',
     copilot:              'Copilot CLI',
     copilot_vscode:       'Copilot (VS Code)',
     copilot_vscode_json:  'Copilot (VS Code)',
+    opencode:             'OpenCode',
   }
   const AGENT_KEY_DIR: Record<string, string> = {
     claude:               '~/.claude/projects/',
@@ -168,13 +174,26 @@ function startLogIngestion() {
     copilot:              '~/.copilot/session-state/',
     copilot_vscode:       '~/Library/…/workspaceStorage/',
     copilot_vscode_json:  '~/Library/…/workspaceStorage/',
+    opencode:             '~/.local/share/opencode/',
+  }
+
+  const countByKey = new Map<string, number>()
+
+  // OpenCode: one DB file = many sessions, handled separately.
+  const ocResults = logReader.scanOpenCode()
+  for (const { card } of ocResults) {
+    logSessions.set(card.sessionId, card)
+    countByKey.set('opencode', (countByKey.get('opencode') ?? 0) + 1)
   }
 
   // Run the initial batch synchronously so logSessions is populated before the
   // browser's first HTTP request. The setImmediate approach deferred this past
   // the first page load, causing a blank screen on startup.
-  const countByKey = new Map<string, number>()
+  let files: ReturnType<typeof logReader.collectFileMeta>
+  try { files = logReader.collectFileMeta() } catch { return }
+
   for (const file of files) {
+    if (file.agentKey === 'opencode') continue  // already handled above
     try {
       const result = logReader.parseFile(file.filePath, file.agentKey)
       if (result) {

--- a/walkthrough/agents.md
+++ b/walkthrough/agents.md
@@ -21,5 +21,6 @@ AgentLens also loaded session history from local log files each agent writes aut
 | **Claude Code** | `~/.claude/projects/` — conversation history, token counts, tool calls |
 | **Copilot CLI** | `~/.copilot/session-state/` — sessions, token counts, prompts |
 | **Codex CLI** | `~/.codex/sessions/` — sessions and token counts |
+| **OpenCode** | `~/.local/share/opencode/opencode.db` — sessions, token counts, tool calls, file paths, user prompts. No OTEL config needed. |
 
 Sessions from log files show a **Log** badge. When OTEL data arrives for the same session, the badge automatically upgrades to **OTEL** and the richer data replaces the log entry.

--- a/walkthrough/welcome.md
+++ b/walkthrough/welcome.md
@@ -4,7 +4,7 @@ AgentLens gives you local observability into your AI agent sessions — see what
 
 **OpenTelemetry traces (primary)** — the extension runs a built-in OTEL receiver and auto-configures each agent to stream live telemetry. OTEL is the richest source: real-time span timing, time-to-first-token, loop detection, file diffs, and streaming speed. Sessions show an **OTEL** badge.
 
-**Local log files (fallback)** — the extension also reads session files each agent writes automatically to your home directory. No setup required — session history appears immediately. Sessions show a **Log** badge and are automatically upgraded to OTEL when live telemetry arrives for the same session.
+**Local log files (fallback)** — the extension also reads session files each agent writes automatically to your home directory, including OpenCode's local SQLite database. No setup required — session history appears immediately. Sessions show a **Log** badge and are automatically upgraded to OTEL when live telemetry arrives for the same session.
 
 ## What you can see
 


### PR DESCRIPTION
Closes #145

## Summary

- New `OpenCodeReader` parses `~/.local/share/opencode/opencode.db` (SQLite, WAL mode) via three-query join across `session`, `message`, and `part` tables
- `OPENCODE_DATA_DIR` env var overrides the default path (comma-separated for multiple dirs)
- Opens DB read-only with a 100ms busy timeout — gracefully skips if locked or missing
- `source: 'opencode'` added to `SessionSummaryCard` union, agent badge, filter chips, and all display labels
- OpenCode model IDs (`providerID/modelID`) are stripped of the provider prefix before pricing lookup so existing rate entries match
- Documentation updated: README, ARCHITECTURE.md, PRICING_SOURCES.md, Help.tsx, walkthrough files

## Test plan

- [ ] Drop an OpenCode DB into the default path and confirm sessions appear with an **Log** badge and `OpenCode` source label
- [ ] Set `OPENCODE_DATA_DIR` to a custom path and confirm it's read
- [ ] Confirm dashboard loads without errors when no OpenCode DB is present
- [ ] Confirm `pnpm run compile` and `npx tsc --noEmit` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)