### PR TITLE
feat: add Import tab for session data

### DIFF
--- a/media/dashboard.css
+++ b/media/dashboard.css
@@ -1082,6 +1082,183 @@ body {
   opacity: 0.6;
   cursor: default;
 }
+#import-content {
+  padding: 8px 0 20px;
+  max-width: 600px;
+}
+.import-drop-zone {
+  border: 2px dashed var(--border);
+  border-radius: 8px;
+  padding: 40px 24px;
+  text-align: center;
+  cursor: pointer;
+  transition: border-color 0.15s, background 0.15s;
+  background: var(--card-bg);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  user-select: none;
+}
+.import-drop-zone:hover,
+.import-drop-zone-hover {
+  border-color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 5%, transparent);
+}
+.import-drop-icon {
+  width: 36px;
+  height: 36px;
+  color: var(--muted);
+  margin-bottom: 4px;
+}
+.import-drop-primary {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--fg);
+  margin: 0;
+}
+.import-drop-secondary {
+  font-size: 12px;
+  color: var(--muted);
+  margin: 0;
+}
+.import-drop-link {
+  color: var(--accent);
+  text-decoration: underline;
+  cursor: pointer;
+}
+.import-error {
+  font-size: 12px;
+  color: var(--vscode-errorForeground, #f48771);
+  margin: 10px 0 0;
+  padding: 8px 12px;
+  border: 1px solid var(--vscode-errorForeground, #f48771);
+  border-radius: 4px;
+  background: color-mix(in srgb, var(--vscode-errorForeground, #f48771) 10%, transparent);
+}
+.import-preview-card {
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 20px 22px;
+  background: var(--card-bg);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.import-preview-header {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+.import-preview-filename {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--fg);
+  word-break: break-all;
+}
+.import-preview-filesize {
+  font-size: 11px;
+  color: var(--muted);
+  white-space: nowrap;
+}
+.import-preview-stats {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+.import-preview-count {
+  font-size: 24px;
+  font-weight: 700;
+  color: var(--fg);
+}
+.import-preview-count-label {
+  font-size: 13px;
+  color: var(--muted);
+}
+.import-preview-dates {
+  font-size: 11px;
+  color: var(--muted);
+  margin-left: 6px;
+}
+.import-source-pills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+.import-source-pill {
+  font-size: 11px;
+  font-weight: 600;
+  padding: 2px 8px;
+  border-radius: 10px;
+  border: 1px solid;
+  opacity: 0.85;
+}
+.import-dedup-note {
+  font-size: 11px;
+  color: var(--muted);
+  margin: 0;
+}
+.import-large-warning {
+  font-size: 11px;
+  color: var(--warning, #ffb74d);
+  padding: 6px 10px;
+  border: 1px solid var(--warning, #ffb74d);
+  border-radius: 4px;
+  background: color-mix(in srgb, var(--warning, #ffb74d) 10%, transparent);
+}
+.import-preview-actions {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  margin-top: 4px;
+}
+.import-progress-label {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--fg);
+  margin: 0;
+}
+.import-progress-track {
+  height: 6px;
+  background: color-mix(in srgb, var(--accent) 20%, transparent);
+  border-radius: 3px;
+  overflow: hidden;
+}
+.import-progress-fill {
+  height: 100%;
+  background: var(--accent);
+  border-radius: 3px;
+  transition: width 0.2s ease;
+}
+.import-progress-text {
+  font-size: 12px;
+  color: var(--muted);
+  margin: 0;
+}
+.import-done-card {
+  align-items: flex-start;
+}
+.import-done-icon {
+  font-size: 20px;
+  color: var(--vscode-testing-iconPassed, #4caf50);
+  font-weight: 700;
+}
+.import-done-title {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--fg);
+  margin: 0;
+}
+.import-done-detail {
+  font-size: 12px;
+  color: var(--muted);
+  margin: 0;
+}
+.import-again-btn {
+  margin-top: 4px;
+}
 .export-replay-box {
   border: 1px solid var(--border);
   border-radius: 6px;

--- a/media/src/App.tsx
+++ b/media/src/App.tsx
@@ -19,6 +19,7 @@ import { Sessions } from './tabs/Sessions'
 import { Analytics } from './tabs/Analytics'
 import { Alerts, computeAlertCount, getTriggeredAlerts, checkAlerts, type TriggeredAlert } from './tabs/Alerts'
 import { Export } from './tabs/Export'
+import { Import } from './tabs/Import'
 import { Help } from './tabs/Help'
 import { Patterns } from './tabs/Patterns'
 import { Automation, checkAutomations } from './tabs/Automation'
@@ -34,7 +35,8 @@ const TABS = [
   { id: 'sessions',   label: 'Sessions',   title: 'Session list with expand-in-place detail — trace, files, cost, and flagged issues for each session.' },
   { id: 'analytics',  label: 'Analytics',  title: 'Aggregate charts and metrics: token/cost trends, agent comparison, tool distribution, and active insights.' },
   { id: 'patterns',   label: 'Advisor',    title: 'Cross-session behavioral patterns, efficiency map, hot files, and instruction file recommendations.' },
-  { id: 'export',     label: 'Export',     title: 'Export raw or redacted OTEL span data as JSON files.' },
+  { id: 'export',     label: 'Export',     title: 'Export raw or redacted session data as JSON files.' },
+  { id: 'import',     label: 'Import',     title: 'Import session data from an AgentLens export file.' },
 ]
 
 function ActivePanel() {
@@ -44,6 +46,7 @@ function ActivePanel() {
     case 'analytics': return <Analytics />
     case 'patterns':  return <Patterns />
     case 'export':    return <Export />
+    case 'import':    return <Import />
     case 'help':      return <Help />
     default:          return null
   }

--- a/media/src/styles/export.css
+++ b/media/src/styles/export.css
@@ -139,6 +139,214 @@
   cursor: default;
 }
 
+/* ── Import tab ──────────────────────────────────────────────────────────── */
+
+#import-content {
+  padding: 8px 0 20px;
+  max-width: 600px;
+}
+
+.import-drop-zone {
+  border: 2px dashed var(--border);
+  border-radius: 8px;
+  padding: 40px 24px;
+  text-align: center;
+  cursor: pointer;
+  transition: border-color 0.15s, background 0.15s;
+  background: var(--card-bg);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  user-select: none;
+}
+.import-drop-zone:hover,
+.import-drop-zone-hover {
+  border-color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 5%, transparent);
+}
+
+.import-drop-icon {
+  width: 36px;
+  height: 36px;
+  color: var(--muted);
+  margin-bottom: 4px;
+}
+
+.import-drop-primary {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--fg);
+  margin: 0;
+}
+
+.import-drop-secondary {
+  font-size: 12px;
+  color: var(--muted);
+  margin: 0;
+}
+
+.import-drop-link {
+  color: var(--accent);
+  text-decoration: underline;
+  cursor: pointer;
+}
+
+.import-error {
+  font-size: 12px;
+  color: var(--vscode-errorForeground, #f48771);
+  margin: 10px 0 0;
+  padding: 8px 12px;
+  border: 1px solid var(--vscode-errorForeground, #f48771);
+  border-radius: 4px;
+  background: color-mix(in srgb, var(--vscode-errorForeground, #f48771) 10%, transparent);
+}
+
+.import-preview-card {
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 20px 22px;
+  background: var(--card-bg);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.import-preview-header {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.import-preview-filename {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--fg);
+  word-break: break-all;
+}
+
+.import-preview-filesize {
+  font-size: 11px;
+  color: var(--muted);
+  white-space: nowrap;
+}
+
+.import-preview-stats {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.import-preview-count {
+  font-size: 24px;
+  font-weight: 700;
+  color: var(--fg);
+}
+
+.import-preview-count-label {
+  font-size: 13px;
+  color: var(--muted);
+}
+
+.import-preview-dates {
+  font-size: 11px;
+  color: var(--muted);
+  margin-left: 6px;
+}
+
+.import-source-pills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.import-source-pill {
+  font-size: 11px;
+  font-weight: 600;
+  padding: 2px 8px;
+  border-radius: 10px;
+  border: 1px solid;
+  opacity: 0.85;
+}
+
+.import-dedup-note {
+  font-size: 11px;
+  color: var(--muted);
+  margin: 0;
+}
+
+.import-large-warning {
+  font-size: 11px;
+  color: var(--warning, #ffb74d);
+  padding: 6px 10px;
+  border: 1px solid var(--warning, #ffb74d);
+  border-radius: 4px;
+  background: color-mix(in srgb, var(--warning, #ffb74d) 10%, transparent);
+}
+
+.import-preview-actions {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  margin-top: 4px;
+}
+
+.import-progress-label {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--fg);
+  margin: 0;
+}
+
+.import-progress-track {
+  height: 6px;
+  background: color-mix(in srgb, var(--accent) 20%, transparent);
+  border-radius: 3px;
+  overflow: hidden;
+}
+
+.import-progress-fill {
+  height: 100%;
+  background: var(--accent);
+  border-radius: 3px;
+  transition: width 0.2s ease;
+}
+
+.import-progress-text {
+  font-size: 12px;
+  color: var(--muted);
+  margin: 0;
+}
+
+.import-done-card {
+  align-items: flex-start;
+}
+
+.import-done-icon {
+  font-size: 20px;
+  color: var(--vscode-testing-iconPassed, #4caf50);
+  font-weight: 700;
+}
+
+.import-done-title {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--fg);
+  margin: 0;
+}
+
+.import-done-detail {
+  font-size: 12px;
+  color: var(--muted);
+  margin: 0;
+}
+
+.import-again-btn {
+  margin-top: 4px;
+}
+
 /* Replay box */
 .export-replay-box {
   border: 1px solid var(--border);

--- a/media/src/tabs/Export.tsx
+++ b/media/src/tabs/Export.tsx
@@ -91,12 +91,7 @@ export function Export() {
         <p class="export-replay-desc">
           These exports contain aggregated session summaries — token counts, tool usage,
           cost estimates, file changes, and efficiency signals. They are useful for
-          cost analysis, sharing with teammates, and offline review.
-        </p>
-        <p class="export-replay-note">
-          <strong>Note:</strong> Session summary exports cannot be replayed with
-          <code>pnpm run demo --file</code>. Replay requires raw OTEL span data,
-          which is not yet persisted to disk. See the open issue for raw span export support.
+          cost analysis, sharing with teammates, and offline review. Use the <strong>Import</strong> tab to bring exported files back into AgentLens on any machine.
         </p>
       </div>
     </div>

--- a/media/src/tabs/Import.tsx
+++ b/media/src/tabs/Import.tsx
@@ -1,0 +1,265 @@
+import { useEffect, useRef, useState } from 'preact/hooks'
+import { vscode } from '../state'
+import { getAgentColor, getAgentSourceLabel } from '../utils'
+
+type Phase = 'idle' | 'preview' | 'importing' | 'done'
+
+interface ParsedSession {
+  sessionId: string
+  source: string
+  startTime?: string
+  [key: string]: unknown
+}
+
+interface ImportPreview {
+  fileName: string
+  fileSize: number
+  sessions: ParsedSession[]
+  bySource: Record<string, number>
+  minDate: string
+  maxDate: string
+}
+
+interface ImportDoneState {
+  imported: number
+  skipped: number
+  failed: number
+  total: number
+}
+
+const VALID_SOURCES = new Set(['copilot', 'claude_code', 'codex', 'opencode'])
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)} KB`
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+}
+
+function formatDate(iso: string): string {
+  try {
+    return new Date(iso).toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' })
+  } catch { return iso }
+}
+
+export function Import() {
+  const [phase, setPhase] = useState<Phase>('idle')
+  const [preview, setPreview] = useState<ImportPreview | null>(null)
+  const [progress, setProgress] = useState<{ imported: number; total: number }>({ imported: 0, total: 0 })
+  const [doneState, setDoneState] = useState<ImportDoneState | null>(null)
+  const [dragOver, setDragOver] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const fileInputRef = useRef<HTMLInputElement>(null)
+
+  useEffect(() => {
+    function handler(event: MessageEvent) {
+      const msg = event.data as { type: string; imported?: number; total?: number; skipped?: number; failed?: number }
+      if (msg.type === 'importProgress') {
+        setProgress({ imported: msg.imported ?? 0, total: msg.total ?? 0 })
+      } else if (msg.type === 'importDone') {
+        setDoneState({ imported: msg.imported ?? 0, skipped: msg.skipped ?? 0, failed: msg.failed ?? 0, total: msg.total ?? 0 })
+        setPhase('done')
+      }
+    }
+    window.addEventListener('message', handler)
+    return () => window.removeEventListener('message', handler)
+  }, [])
+
+  function parseFile(file: File) {
+    setError(null)
+    const reader = new FileReader()
+    reader.onload = (e) => {
+      try {
+        const text = e.target?.result as string
+        const data = JSON.parse(text)
+        if (!Array.isArray(data)) throw new Error('Expected a JSON array — is this an AgentLens export file?')
+        if (data.length === 0) throw new Error('The file contains no sessions')
+
+        const sessions: ParsedSession[] = data.map((item: unknown, i: number) => {
+          if (typeof item !== 'object' || item === null) throw new Error(`Item ${i + 1} is not an object`)
+          const s = item as Record<string, unknown>
+          if (typeof s['sessionId'] !== 'string' || !s['sessionId']) throw new Error(`Item ${i + 1} is missing sessionId`)
+          if (typeof s['source'] !== 'string' || !VALID_SOURCES.has(s['source'])) throw new Error(`Item ${i + 1} has unrecognized source: "${s['source']}"`)
+          return s as ParsedSession
+        })
+
+        const bySource: Record<string, number> = {}
+        let minDate = ''
+        let maxDate = ''
+        for (const s of sessions) {
+          bySource[s.source] = (bySource[s.source] ?? 0) + 1
+          if (s.startTime) {
+            if (!minDate || s.startTime < minDate) minDate = s.startTime
+            if (!maxDate || s.startTime > maxDate) maxDate = s.startTime
+          }
+        }
+
+        setPreview({ fileName: file.name, fileSize: file.size, sessions, bySource, minDate, maxDate })
+        setPhase('preview')
+      } catch (err) {
+        setError(`Could not read file: ${(err as Error).message}`)
+      }
+    }
+    reader.readAsText(file)
+  }
+
+  function onFileInput(e: Event) {
+    const input = e.target as HTMLInputElement
+    if (input.files?.[0]) parseFile(input.files[0])
+    input.value = ''
+  }
+
+  function onDrop(e: DragEvent) {
+    e.preventDefault()
+    setDragOver(false)
+    const file = e.dataTransfer?.files[0]
+    if (file) parseFile(file)
+  }
+
+  function doImport() {
+    if (!preview) return
+    setPhase('importing')
+    setProgress({ imported: 0, total: preview.sessions.length })
+    if (vscode) {
+      vscode.postMessage({ type: 'importSessionData', sessions: preview.sessions })
+    } else {
+      fetch('/api/import', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ sessions: preview.sessions }),
+      })
+        .then(r => r.json())
+        .then((result: ImportDoneState) => {
+          setDoneState(result)
+          setPhase('done')
+        })
+        .catch(err => {
+          setError(`Import failed: ${(err as Error).message}`)
+          setPhase('preview')
+        })
+    }
+  }
+
+  function reset() {
+    setPhase('idle')
+    setPreview(null)
+    setDoneState(null)
+    setError(null)
+    setProgress({ imported: 0, total: 0 })
+  }
+
+  if (phase === 'idle') {
+    return (
+      <div id="import-content">
+        <div
+          class={'import-drop-zone' + (dragOver ? ' import-drop-zone-hover' : '')}
+          onDragOver={(e) => { e.preventDefault(); setDragOver(true) }}
+          onDragLeave={() => setDragOver(false)}
+          onDrop={onDrop}
+          onClick={() => fileInputRef.current?.click()}
+          role="button"
+          tabIndex={0}
+          onKeyDown={(e: KeyboardEvent) => { if (e.key === 'Enter' || e.key === ' ') fileInputRef.current?.click() }}
+        >
+          <svg class="import-drop-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5m-13.5-9L12 3m0 0l4.5 4.5M12 3v13.5" />
+          </svg>
+          <p class="import-drop-primary">Drop an AgentLens export file here</p>
+          <p class="import-drop-secondary">or <span class="import-drop-link">click to browse</span> — accepts <code>.json</code> export files</p>
+          <input ref={fileInputRef} type="file" accept=".json" style="display:none" onChange={onFileInput} />
+        </div>
+        {error && <p class="import-error">{error}</p>}
+      </div>
+    )
+  }
+
+  if (phase === 'preview' && preview) {
+    const isLarge = preview.sessions.length > 200
+    const dateRange = preview.minDate && preview.maxDate
+      ? preview.minDate.slice(0, 10) === preview.maxDate.slice(0, 10)
+        ? formatDate(preview.minDate)
+        : `${formatDate(preview.minDate)} – ${formatDate(preview.maxDate)}`
+      : null
+
+    return (
+      <div id="import-content">
+        <div class="import-preview-card">
+          <div class="import-preview-header">
+            <span class="import-preview-filename">{preview.fileName}</span>
+            <span class="import-preview-filesize">{formatBytes(preview.fileSize)}</span>
+          </div>
+
+          <div class="import-preview-stats">
+            <span class="import-preview-count">{preview.sessions.length}</span>
+            <span class="import-preview-count-label"> sessions</span>
+            {dateRange && <span class="import-preview-dates">{dateRange}</span>}
+          </div>
+
+          <div class="import-source-pills">
+            {Object.entries(preview.bySource).map(([source, count]) => (
+              <span
+                key={source}
+                class="import-source-pill"
+                style={`border-color:${getAgentColor(source)};color:${getAgentColor(source)}`}
+              >
+                {getAgentSourceLabel(source)} {count}
+              </span>
+            ))}
+          </div>
+
+          <p class="import-dedup-note">Sessions already in your database will be skipped.</p>
+
+          {isLarge && (
+            <div class="import-large-warning">
+              Large import — this will be processed in batches and may take a few seconds.
+            </div>
+          )}
+
+          <div class="import-preview-actions">
+            <button class="export-btn" onClick={doImport}>
+              Import {preview.sessions.length} session{preview.sessions.length !== 1 ? 's' : ''}
+            </button>
+            <button class="export-btn export-btn-secondary" onClick={reset}>Cancel</button>
+          </div>
+        </div>
+        {error && <p class="import-error" style="margin-top:12px">{error}</p>}
+      </div>
+    )
+  }
+
+  if (phase === 'importing') {
+    const total = progress.total
+    const done = progress.imported
+    const pct = total > 0 ? Math.round((done / total) * 100) : 0
+    return (
+      <div id="import-content">
+        <div class="import-preview-card">
+          <p class="import-progress-label">Importing…</p>
+          <div class="import-progress-track">
+            <div class="import-progress-fill" style={`width:${pct}%`} />
+          </div>
+          <p class="import-progress-text">{done} / {total}</p>
+        </div>
+      </div>
+    )
+  }
+
+  if (phase === 'done' && doneState) {
+    return (
+      <div id="import-content">
+        <div class="import-preview-card import-done-card">
+          <div class="import-done-icon">✓</div>
+          <p class="import-done-title">Import complete</p>
+          <p class="import-done-detail">
+            {doneState.imported} session{doneState.imported !== 1 ? 's' : ''} imported
+            {doneState.skipped > 0 ? `, ${doneState.skipped} already existed` : ''}
+            {doneState.failed > 0 ? `, ${doneState.failed} failed to write` : ''}
+          </p>
+          <button class="export-btn export-btn-secondary import-again-btn" onClick={reset}>
+            Import another file
+          </button>
+        </div>
+      </div>
+    )
+  }
+
+  return null
+}

--- a/media/src/tabs/Import.tsx
+++ b/media/src/tabs/Import.tsx
@@ -57,6 +57,9 @@ export function Import() {
       } else if (msg.type === 'importDone') {
         setDoneState({ imported: msg.imported ?? 0, skipped: msg.skipped ?? 0, failed: msg.failed ?? 0, total: msg.total ?? 0 })
         setPhase('done')
+      } else if (msg.type === 'importError') {
+        setError(`Import failed: ${(msg as { message?: string }).message ?? 'unknown error'}`)
+        setPhase('preview')
       }
     }
     window.addEventListener('message', handler)
@@ -114,27 +117,37 @@ export function Import() {
     if (file) parseFile(file)
   }
 
-  function doImport() {
+  async function doImport() {
     if (!preview) return
     setPhase('importing')
     setProgress({ imported: 0, total: preview.sessions.length })
-    if (vscode) {
+    if (vscode && !window.__STANDALONE__) {
       vscode.postMessage({ type: 'importSessionData', sessions: preview.sessions })
     } else {
-      fetch('/api/import', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ sessions: preview.sessions }),
-      })
-        .then(r => r.json())
-        .then((result: ImportDoneState) => {
-          setDoneState(result)
-          setPhase('done')
-        })
-        .catch(err => {
-          setError(`Import failed: ${(err as Error).message}`)
-          setPhase('preview')
-        })
+      try {
+        const BATCH = 50
+        const total = preview.sessions.length
+        let imported = 0
+        let skipped = 0
+        for (let i = 0; i < preview.sessions.length; i += BATCH) {
+          const batch = preview.sessions.slice(i, i + BATCH)
+          const r = await fetch('/api/import', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ sessions: batch }),
+          })
+          if (!r.ok) throw new Error(`Server responded ${r.status}`)
+          const result = await r.json() as { imported: number; skipped: number; failed: number }
+          imported += result.imported
+          skipped += result.skipped
+          setProgress({ imported, total })
+        }
+        setDoneState({ imported, skipped, failed: 0, total })
+        setPhase('done')
+      } catch (err) {
+        setError(`Import failed: ${(err as Error).message}`)
+        setPhase('preview')
+      }
     }
   }
 

--- a/src/dashboardPanel.ts
+++ b/src/dashboardPanel.ts
@@ -219,29 +219,38 @@ export class DashboardPanel {
   }
 
   private async importSessions(rawSessions: Record<string, unknown>[]): Promise<void> {
-    const existing = new Set(this.repo.listSessions().map(s => s.sessionId))
-    const BATCH = 50
-    let imported = 0
-    let skipped = 0
-    const total = rawSessions.length
+    try {
+      const existing = new Set(this.repo.listSessions().map(s => s.sessionId))
+      const BATCH = 50
+      let imported = 0
+      let skipped = 0
+      const total = rawSessions.length
 
-    for (let i = 0; i < rawSessions.length; i += BATCH) {
-      const batch = rawSessions.slice(i, i + BATCH)
-      for (const raw of batch) {
-        const id = raw['sessionId'] as string
-        if (existing.has(id)) { skipped++; continue }
-        existing.add(id)
-        const card = buildImportCard(raw)
-        this.repo.enqueue(card, card.workspace)
-        imported++
+      for (let i = 0; i < rawSessions.length; i += BATCH) {
+        const batch = rawSessions.slice(i, i + BATCH)
+        const cards: SessionSummaryCard[] = []
+        for (const raw of batch) {
+          const id = raw['sessionId'] as string
+          if (existing.has(id)) { skipped++; continue }
+          existing.add(id)
+          cards.push(buildImportCard(raw))
+          imported++
+        }
+        if (cards.length > 0) {
+          this.repo.importCards(cards)
+        }
+        this.panel.webview.postMessage({ type: 'importProgress', imported, total, skipped })
+        // Yield between batches so the webview can render progress and other
+        // tasks (log reader, OTEL) can run without starving the event loop.
+        await new Promise<void>(resolve => setTimeout(resolve, 0))
       }
-      await this.repo.drain()
-      this.panel.webview.postMessage({ type: 'importProgress', imported, total, skipped })
-    }
 
-    this.panel.webview.postMessage({ type: 'importDone', imported, skipped, failed: 0, total })
-    this.update()
-    this.sidebarProvider?.refresh()
+      this.panel.webview.postMessage({ type: 'importDone', imported, skipped, failed: 0, total })
+      this.update()
+      this.sidebarProvider?.refresh()
+    } catch (err) {
+      this.panel.webview.postMessage({ type: 'importError', message: String(err) })
+    }
   }
 
   private async exportSessions(redact: boolean, ids: Set<string> | null = null): Promise<void> {

--- a/src/dashboardPanel.ts
+++ b/src/dashboardPanel.ts
@@ -94,6 +94,8 @@ export class DashboardPanel {
           offset: (msg.query as { offset?: number }).offset ?? 0,
           context: (msg as { context?: string }).context ?? 'search',
         })
+      } else if (msg.type === 'importSessionData' && Array.isArray(msg.sessions)) {
+        void this.importSessions(msg.sessions as Record<string, unknown>[])
       } else if (msg.type === 'exportSessionData' || msg.type === 'exportSessionDataRedacted') {
         const redact = msg.type === 'exportSessionDataRedacted'
         const ids = Array.isArray(msg.sessionIds) ? new Set(msg.sessionIds as string[]) : null
@@ -216,6 +218,32 @@ export class DashboardPanel {
     })
   }
 
+  private async importSessions(rawSessions: Record<string, unknown>[]): Promise<void> {
+    const existing = new Set(this.repo.listSessions().map(s => s.sessionId))
+    const BATCH = 50
+    let imported = 0
+    let skipped = 0
+    const total = rawSessions.length
+
+    for (let i = 0; i < rawSessions.length; i += BATCH) {
+      const batch = rawSessions.slice(i, i + BATCH)
+      for (const raw of batch) {
+        const id = raw['sessionId'] as string
+        if (existing.has(id)) { skipped++; continue }
+        existing.add(id)
+        const card = buildImportCard(raw)
+        this.repo.enqueue(card, card.workspace)
+        imported++
+      }
+      await this.repo.drain()
+      this.panel.webview.postMessage({ type: 'importProgress', imported, total, skipped })
+    }
+
+    this.panel.webview.postMessage({ type: 'importDone', imported, skipped, failed: 0, total })
+    this.update()
+    this.sidebarProvider?.refresh()
+  }
+
   private async exportSessions(redact: boolean, ids: Set<string> | null = null): Promise<void> {
     const all = this.repo.listSessions()
     const sessions = ids ? all.filter(s => ids.has(s.sessionId)) : all
@@ -324,9 +352,46 @@ export class DashboardPanel {
   }
 }
 
-// ── Efficiency stub ───────────────────────────────────────────────────────────
+// ── Import helper ─────────────────────────────────────────────────────────────
 
 import type { SessionSummaryCard } from './summarizers/summarizerTypes'
+
+function buildImportCard(raw: Record<string, unknown>): SessionSummaryCard {
+  const num = (v: unknown, def = 0): number => (typeof v === 'number' ? v : def)
+  const str = (v: unknown, def = ''): string => (typeof v === 'string' ? v : def)
+  const arr = (v: unknown): string[] => (Array.isArray(v) ? v.filter(x => typeof x === 'string') as string[] : [])
+  return {
+    sessionId:       str(raw['sessionId']),
+    traceId:         str(raw['traceId']),
+    source:          (raw['source'] as SessionSummaryCard['source']) ?? 'claude_code',
+    dataSource:      'log',
+    workspace:       str(raw['workspace']),
+    userRequest:     str(raw['userRequest']),
+    model:           str(raw['model']),
+    turns:           num(raw['turns']),
+    totalLlmCalls:   num(raw['turns']),
+    totalToolCalls:  num(raw['totalToolCalls']),
+    inputTokens:     num(raw['inputTokens']),
+    outputTokens:    num(raw['outputTokens']),
+    cacheReadTokens: num(raw['cacheReadTokens']),
+    cacheCreateTokens: num(raw['cacheCreateTokens']),
+    cacheHitRate:    num(raw['cacheHitRate']),
+    durationMs:      num(raw['durationMs']),
+    startTime:       str(raw['startTime'], new Date().toISOString()),
+    filesRead:       arr(raw['filesRead']),
+    filesChanged:    arr(raw['filesChanged']),
+    filesSearched:   [],
+    filesWritten:    [],
+    toolCounts:      (typeof raw['toolCounts'] === 'object' && raw['toolCounts'] !== null ? raw['toolCounts'] : {}) as Record<string, number>,
+    errors:          num(raw['errors']),
+    outcome:         (raw['outcome'] as SessionSummaryCard['outcome']) ?? 'unknown',
+    timeline:        [],
+    backgroundSpans: [],
+    loopSignals:     Array.isArray(raw['loopSignals']) ? raw['loopSignals'] as SessionSummaryCard['loopSignals'] : [],
+  }
+}
+
+// ── Efficiency stub ───────────────────────────────────────────────────────────
 
 function buildEfficiency(sessions: SessionSummaryCard[]) {
   const totalInput = sessions.reduce((a, s) => a + s.inputTokens, 0)

--- a/src/database/writer.ts
+++ b/src/database/writer.ts
@@ -59,6 +59,26 @@ export class DatabaseWriter {
     return this.drainPromise
   }
 
+  /**
+   * Writes import cards directly in one synchronous transaction, bypassing the
+   * async enqueue/drain pipeline. Safe to call while a drain is in progress
+   * because _writeOnce always commits its transaction before suspending at an
+   * await point, so there is never an open transaction when we enter here.
+   */
+  importCards(cards: SessionSummaryCard[]): void {
+    if (cards.length === 0) return
+    this.db.run('BEGIN')
+    try {
+      for (const card of cards) {
+        this._writeSessionRow(card, card.workspace)
+      }
+      this.db.run('COMMIT')
+    } catch (err) {
+      try { this.db.run('ROLLBACK') } catch { /* ignore */ }
+      throw err
+    }
+  }
+
   clearAll(): void {
     // Increment generation so any _drain() currently awaiting _writeOnce() will
     // see the mismatch and abort before writing further sessions to the DB.

--- a/src/sessionRepository.ts
+++ b/src/sessionRepository.ts
@@ -153,6 +153,11 @@ export class SessionRepository {
     return this.writer.drain()
   }
 
+  /** Writes import cards directly in one transaction, bypassing the async drain. */
+  importCards(cards: SessionSummaryCard[]): void {
+    this.writer.importCards(cards)
+  }
+
   /** Clears all three SQLite tables. */
   clearAll(): void {
     this.writer.clearAll()

--- a/standalone/server.ts
+++ b/standalone/server.ts
@@ -71,6 +71,41 @@ function addSpan(span: Span) {
 // when the same session ID appears in both, the OTEL version is used.
 let logSessions: Map<string, SessionSummaryCard> = new Map()
 
+function buildImportCardStandalone(raw: Record<string, unknown>): SessionSummaryCard {
+  const num = (v: unknown, def = 0): number => (typeof v === 'number' ? v : def)
+  const str = (v: unknown, def = ''): string => (typeof v === 'string' ? v : def)
+  const arrStr = (v: unknown): string[] => (Array.isArray(v) ? v.filter(x => typeof x === 'string') as string[] : [])
+  return {
+    sessionId:         str(raw['sessionId']),
+    traceId:           str(raw['traceId']),
+    source:            (raw['source'] as SessionSummaryCard['source']) ?? 'claude_code',
+    dataSource:        'log',
+    workspace:         str(raw['workspace']),
+    userRequest:       str(raw['userRequest']),
+    model:             str(raw['model']),
+    turns:             num(raw['turns']),
+    totalLlmCalls:     num(raw['turns']),
+    totalToolCalls:    num(raw['totalToolCalls']),
+    inputTokens:       num(raw['inputTokens']),
+    outputTokens:      num(raw['outputTokens']),
+    cacheReadTokens:   num(raw['cacheReadTokens']),
+    cacheCreateTokens: num(raw['cacheCreateTokens']),
+    cacheHitRate:      num(raw['cacheHitRate']),
+    durationMs:        num(raw['durationMs']),
+    startTime:         str(raw['startTime'], new Date().toISOString()),
+    filesRead:         arrStr(raw['filesRead']),
+    filesChanged:      arrStr(raw['filesChanged']),
+    filesSearched:     [],
+    filesWritten:      [],
+    toolCounts:        (typeof raw['toolCounts'] === 'object' && raw['toolCounts'] !== null ? raw['toolCounts'] : {}) as Record<string, number>,
+    errors:            num(raw['errors']),
+    outcome:           (raw['outcome'] as SessionSummaryCard['outcome']) ?? 'unknown',
+    timeline:          [],
+    backgroundSpans:   [],
+    loopSignals:       Array.isArray(raw['loopSignals']) ? raw['loopSignals'] as SessionSummaryCard['loopSignals'] : [],
+  }
+}
+
 const logReader = new LogReader()
 
 // ── MCP server ────────────────────────────────────────────────────────────────
@@ -991,6 +1026,41 @@ const uiServer = http.createServer((req, res) => {
     res.write(`data: ${buildUpdatePayload()}\n\n`)
     sseClients.push(res)
     req.on('close', () => { sseClients = sseClients.filter(c => c !== res) })
+    return
+  }
+
+  if (req.method === 'POST' && url === '/api/import') {
+    const chunks: Buffer[] = []
+    req.on('data', (c: Buffer) => chunks.push(c))
+    req.on('end', () => {
+      try {
+        const body = JSON.parse(Buffer.concat(chunks).toString('utf-8')) as { sessions?: unknown[] }
+        if (!Array.isArray(body.sessions)) {
+          res.writeHead(400, { 'Content-Type': 'application/json' })
+          res.end(JSON.stringify({ error: 'sessions array required' }))
+          return
+        }
+        const VALID_SOURCES = new Set(['copilot', 'claude_code', 'codex', 'opencode'])
+        let imported = 0
+        let skipped = 0
+        for (const raw of body.sessions) {
+          if (typeof raw !== 'object' || raw === null) continue
+          const s = raw as Record<string, unknown>
+          const id = typeof s['sessionId'] === 'string' ? s['sessionId'] : ''
+          if (!id || !VALID_SOURCES.has(s['source'] as string)) continue
+          if (logSessions.has(id)) { skipped++; continue }
+          const card = buildImportCardStandalone(s)
+          logSessions.set(id, card)
+          imported++
+        }
+        pushUpdate()
+        res.writeHead(200, { 'Content-Type': 'application/json' })
+        res.end(JSON.stringify({ imported, skipped, failed: 0, total: body.sessions.length }))
+      } catch (e) {
+        res.writeHead(400, { 'Content-Type': 'application/json' })
+        res.end(JSON.stringify({ error: String(e) }))
+      }
+    })
     return
   }
 


### PR DESCRIPTION
Closes #146

## Summary

- New **Import** tab with three-phase UI: drop zone → preview/confirm → progress/done
- Client-side JSON parsing and validation (sessionId + source required); preview shows file name, size, session count, date range, and per-source breakdown before any writes
- VS Code: batched writes via `DatabaseWriter.importCards()` — a new synchronous transaction path that bypasses the async `enqueue`/`drain` pipeline so import never blocks on an in-flight log-reader drain
- Standalone: batched `fetch('/api/import')` calls (50 sessions each) with live progress updates; fixes a silent hang caused by the `acquireVsCodeApi` shim making `vscode` truthy so `importSessionData` was swallowed
- Deduplication against existing sessions before writing; `importError` message surfaced in UI instead of silent hang
- Removes stale pnpm replay note from Export tab

## Test plan

- [ ] Drop an export file — preview shows correct counts and date range
- [ ] Click Import — progress bar advances, done screen shows correct imported/skipped counts
- [ ] Re-import the same file — all sessions skipped
- [ ] Import in standalone mode — batched progress visible, completes correctly
- [ ] Invalid file (non-JSON, missing sessionId) — error shown in drop zone, no crash
- [ ] `pnpm run compile` and `npx tsc --noEmit -p media/tsconfig.json` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)