### PR TITLE
fix: standalone UI hangs empty after startup

### DIFF
--- a/standalone/server.ts
+++ b/standalone/server.ts
@@ -220,6 +220,8 @@ async function startLogIngestion() {
     .map(v => `  ${v.label.padEnd(20)} ${String(v.count).padStart(4)}  (${v.dir})`)
     .join('\n')
   console.log(`[AgentLens] Loaded ${total} sessions from local logs:\n${lines}`)
+  // Push loaded sessions to any SSE clients that connected before the scan finished.
+  pushUpdate()
 }
 
 // ── OTLP parsing ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #151

## Summary

- `startLogIngestion()` awaits sql.js before scanning, so the browser connects to `/events` during that gap and receives an empty payload
- After the scan finishes, `fileState` is fully current so the 5-second `runLogScan` poll finds no changed files and never calls `pushUpdate()` — sessions are in memory but never sent to the client
- Fix: call `pushUpdate()` at the end of `startLogIngestion()` once `logSessions` is populated

## Test plan

- [ ] `npx agentlens-dashboard` — sessions appear immediately after startup without requiring a page refresh
- [ ] Sessions still update normally when new log files are written (5s poll / fs.watch path unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)