### PR TITLE
fix: Windows log paths for Codex and Copilot CLI session discovery

### DIFF
--- a/src/logReader.ts
+++ b/src/logReader.ts
@@ -9,9 +9,11 @@
  *                Override: CLAUDE_CONFIG_DIR (comma-separated list of config dirs)
  *
  *   Codex        ~/.codex/sessions/<project>/<uuid>.jsonl
+ *                %LOCALAPPDATA%\Codex\sessions\<project>\<uuid>.jsonl  (Windows)
  *                Override: CODEX_HOME (comma-separated list of home dirs)
  *
  *   Copilot CLI  ~/.copilot/session-state/<uuid>/events.jsonl
+ *                %APPDATA%\copilot\session-state\<uuid>\events.jsonl  (Windows)
  *
  *   Copilot Chat ~/Library/Application Support/<IDE>/User/workspaceStorage/<hash>/chatSessions/<uuid>.jsonl
  *   (VS Code-   %APPDATA%\<IDE>\User\workspaceStorage\<hash>\chatSessions\<uuid>.jsonl
@@ -69,8 +71,15 @@ function codexSessionsDirs(): string[] {
     return envVal.split(',').map(p => p.trim()).filter(Boolean)
       .map(p => path.join(p, 'sessions'))
   }
-  const base = path.join(homeDir(), '.codex', 'sessions')
-  return fs.existsSync(base) ? [base] : []
+  const candidates: string[] = []
+  if (process.platform === 'win32') {
+    const local = process.env['LOCALAPPDATA']
+    const appData = process.env['APPDATA']
+    if (local) candidates.push(path.join(local, 'Codex', 'sessions'))
+    if (appData) candidates.push(path.join(appData, 'Codex', 'sessions'))
+  }
+  candidates.push(path.join(homeDir(), '.codex', 'sessions'))
+  return candidates.filter(d => { try { return fs.statSync(d).isDirectory() } catch { return false } })
 }
 
 function openCodeDataDirs(): string[] {
@@ -94,8 +103,13 @@ function openCodeDataDirs(): string[] {
 function copilotSessionStateDir(): string | null {
   // Copilot CLI writes session logs to ~/.copilot/session-state/<uuid>/events.jsonl
   // automatically, with no env setup required.
-  const dir = path.join(homeDir(), '.copilot', 'session-state')
-  return fs.existsSync(dir) ? dir : null
+  const candidates: string[] = []
+  if (process.platform === 'win32') {
+    const appData = process.env['APPDATA']
+    if (appData) candidates.push(path.join(appData, 'copilot', 'session-state'))
+  }
+  candidates.push(path.join(homeDir(), '.copilot', 'session-state'))
+  return candidates.find(d => { try { return fs.statSync(d).isDirectory() } catch { return false } }) ?? null
 }
 
 function vscodeFamilyWorkspaceStorageRoots(): string[] {


### PR DESCRIPTION
Closes #153

## Summary

- `codexSessionsDirs()` now checks `%LOCALAPPDATA%\Codex\sessions` and `%APPDATA%\Codex\sessions` on Windows before falling back to `~/.codex/sessions`
- `copilotSessionStateDir()` now checks `%APPDATA%\copilot\session-state` on Windows before falling back to `~/.copilot/session-state`
- File header comment updated to document both new Windows paths
- Pattern matches the existing Windows handling in `claudeProjectsDirs()`; all candidates are filtered to only directories that actually exist, so no regression on macOS/Linux

## Test plan

- [ ] On Windows: run `npx agentlens-dashboard` with Codex sessions present — confirm they appear
- [ ] On Windows: run with Copilot CLI sessions present — confirm they appear
- [ ] On macOS/Linux: confirm existing sessions still load normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)