### PR TITLE
fix: clear genAiResponseBuffer after successful span injection to prevent OOM

### DIFF
--- a/src/otlpCollector.ts
+++ b/src/otlpCollector.ts
@@ -21,7 +21,9 @@ export class OtlpCollector {
   private codexActivePromptSessionId = ''
   // Buffers gen_ai.choice / gen_ai.assistant.message log event content keyed by traceId:spanId.
   // Spans and their log events arrive on separate HTTP requests; this handles either ordering.
+  // Capped at 500 entries to evict orphaned entries when a span is dropped by the agent exporter.
   private genAiResponseBuffer = new Map<string, string>()
+  private readonly GEN_AI_BUFFER_MAX = 500
 
   constructor(
     private port: number,
@@ -399,8 +401,17 @@ export class OtlpCollector {
               if (formatted) {
                 const bufKey = `${logTraceId}:${logSpanId}`
                 this.genAiResponseBuffer.set(bufKey, formatted)
-                // If the span already exists in the store, inject immediately.
-                this.store.injectSpanAttribute(logTraceId, logSpanId, 'gen_ai.output.messages', formatted)
+                // Evict oldest entry when cap is exceeded (guards against orphaned entries
+                // if the matching span is never received).
+                if (this.genAiResponseBuffer.size > this.GEN_AI_BUFFER_MAX) {
+                  const firstKey = this.genAiResponseBuffer.keys().next().value
+                  if (firstKey !== undefined) { this.genAiResponseBuffer.delete(firstKey) }
+                }
+                // If the span already exists in the store, inject immediately and remove
+                // from buffer — the span-before-log ordering means processTraces already
+                // ran and will not call genAiResponseBuffer.delete() for this key.
+                const injected = this.store.injectSpanAttribute(logTraceId, logSpanId, 'gen_ai.output.messages', formatted)
+                if (injected) { this.genAiResponseBuffer.delete(bufKey) }
               }
             }
             continue


### PR DESCRIPTION
Fixes #155

## Summary

- Delete `genAiResponseBuffer` entry immediately when `injectSpanAttribute` returns `true` (span-before-log ordering), so the buffer doesn't accumulate one large JSON blob per LLM call
- Add a 500-entry LRU-style cap to evict orphaned entries if a span is ever dropped by the agent's OTLP exporter

## Root cause

When a `gen_ai.choice` log event arrives after its matching `claude_code.llm_request` span (the common case with `gen_ai_latest_experimental`), `processLogs` injected the content via `injectSpanAttribute` but never deleted the buffer entry. Only `processTraces` deleted entries — and it had already run. One leaked entry per LLM call, each potentially containing the full accumulated conversation context, grew the heap to 4 GB and crashed VS Code.

## Test plan

- Run a long Claude Code session with `CLAUDE_CODE_ENABLE_TELEMETRY=1` and `gen_ai_latest_experimental` instrumentation; verify heap usage stays flat across many turns
- Confirm `genAiResponseBuffer.size` stays near 0 throughout (buffer entries are created transiently then deleted on injection)

🤖 Generated with [Claude Code](https://claude.com/claude-code)