### PR TITLE
fix: first session in standalone Traces tab never loads timeline

### DIFF
--- a/media/src/tabs/Traces.tsx
+++ b/media/src/tabs/Traces.tsx
@@ -316,6 +316,12 @@ function SessionBlock({ sess, sessIdx, sessNum, totalCount, isFirst }: {
   const loadedTimeline = timelines[sess.sessionId]
   const isLoading = !collapsed && loadedTimeline === undefined
 
+  useEffect(() => {
+    if (!collapsed && loadedTimeline === undefined) {
+      if (vscode) vscode.postMessage({ type: 'loadSessionDetail', sessionId: sess.sessionId })
+    }
+  }, [sess.sessionId, collapsed])
+
   const toggle = () => {
     const opening = collapsed
     setCollapsed(v => !v)


### PR DESCRIPTION
Fixes #161

## Summary

- First session in Traces tab starts expanded by default (`isFirst=true`) but `loadSessionDetail` was only dispatched inside the click handler `toggle()`
- Added a `useEffect` to fire the fetch on mount when `collapsed=false` and `loadedTimeline` is undefined
- The `toggle()` fast path is kept for subsequent user clicks

## Test plan

- [ ] Open standalone dashboard with OTEL sessions — first Traces session should load its timeline automatically without any click
- [ ] Collapse and re-expand — timeline should still load correctly
- [ ] Non-first sessions still require a click to expand and load

🤖 Generated with [Claude Code](https://claude.com/claude-code)