### PR TITLE
chore: refresh pricing data across all sources (2026-07-19)

### DIFF
--- a/PRICING_SOURCES.md
+++ b/PRICING_SOURCES.md
@@ -1,7 +1,18 @@
 # Pricing Sources
 
-This file records exactly where each agent's billing data is retrieved from.
-Update `media/src/pricing.ts` whenever rates change and bump `PRICING_LAST_UPDATED`.
+This file records exactly where each agent's billing data is retrieved from, and the current
+best-known rates for each model. It's a reference + refresh runbook, not a changelog — pricing
+corrections that change displayed cost belong in `CHANGELOG.md` at release time, not here.
+
+## How to refresh this file
+
+1. Fetch each source URL below and compare against the rate tables here.
+2. Update `RATES` in both `src/pricing.ts` and `media/src/pricing.ts` to match. See
+   "Notes for maintainers" at the bottom for lookup/normalization details.
+3. Bump `PRICING_LAST_UPDATED` in `media/src/pricing.ts` and the "verified" dates below.
+4. Run `tsc --noEmit` (both configs), `eslint src media/src`, and `mocha` to confirm nothing broke.
+5. If a rate or model can't be confirmed from a source, add it to that section's "Known gaps"
+   instead of guessing.
 
 ---
 
@@ -13,7 +24,7 @@ Copilot has three billing models depending on plan type and date.
 
 **Who it applies to:** All Copilot plans on the new billing model, default from June 1, 2026.
 
-**Source:** <https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing>
+**Source:** <https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing> (verified 2026-07-19)
 
 **What this page provides:**
 
@@ -35,12 +46,14 @@ aiCredits = cost / 0.01
 **Who it applies to:** Copilot annual-plan holders who opt to stay on request-based billing
 after June 1, 2026. These users face significantly higher multipliers than the pre-June rates.
 
-**Source:** <https://docs.github.com/en/copilot/reference/copilot-billing/model-multipliers-for-annual-plans>
+**Source:** <https://docs.github.com/en/copilot/reference/copilot-billing/model-multipliers-for-annual-plans> (verified 2026-07-19)
 
 **What this page provides:**
 
 - Post-June multipliers for annual plan holders (`multiplierAnnualPostJun1` field in `ModelRates`)
 - Formula is the same as Model 3 — only the multiplier values differ
+- A separate note: Copilot code review has a model multiplier of 13 (each code review request
+  deducts 13 from the premium request quota) — see Known gaps below
 
 **Formula:**
 
@@ -67,15 +80,18 @@ cost = userPromptCount × multiplierAnnualPostJun1 × $0.04
 cost = userPromptCount × multiplier × $0.04
 ```
 
-### Changes found on 2026-07-19 review
+This model is now fully historical (we're past the June 1, 2026 cutover), so its source page no
+longer lists per-model multipliers directly — it points to the annual-plan legacy page instead,
+which 404s. `multiplier` values in `RATES` are frozen at their last-known state for historical
+sessions; don't expect to re-verify them.
 
-- **`gpt-5-mini` / `gpt-5 mini`** and **`raptor-mini`** are no longer included/$0 models — both now bill at $0.25/$0.025/–/$2.00 (input/cache read/cache write/output per MTok) under the AI Credits model. Both keep their existing `multiplierAnnualPostJun1` of 0.33.
-- **`gpt-5.5` annual-plan multiplier corrected**: `multiplierAnnualPostJun1` was 7.5, docs now show 57. The pre-Jun1 `multiplier` field (7.5) could not be re-verified — that page 404's as pre-June billing is now fully historical.
-- **New GPT-5.6 family** (Luna/Terra/Sol) added — Luna is the small/fast tier (~gpt-4o-mini-ish pricing), Terra matches gpt-5.4 pricing, Sol matches gpt-5.5 pricing (including a long-context surcharge tier at 2x rates, threshold unconfirmed). None of the three appear yet on the annual-plan multiplier page, so `multiplierAnnualPostJun1` is set to 0 pending publication.
-- **New third-party marketplace models**: `mai-code-1-flash` (Microsoft, $0.75/$0.075/–/$4.50) and `kimi-k2.7-code` (Moonshot AI, $0.95/$0.19/–/$4.00) added to `media/src/pricing.ts` only — these are Copilot-marketplace-only models, not expected to appear via direct-API telemetry from Claude Code/Codex, so they were not added to `src/pricing.ts`.
-- **Claude Opus 4.6 fast mode removed** (2026-06-29): requests to `claude-opus-4-6` with `speed: "fast"` now run at standard speed and bill at standard rates. The `claude-opus-4-6-fast` entry was changed from the old 6x multiplied rate to the standard Opus 4.6 rate in both rate tables.
-- **Copilot code review multiplier**: the annual-plan multipliers page notes "Copilot code review has a model multiplier of 13" (each code review request deducts 13 from the premium request quota). Not currently modeled anywhere in `pricing.ts` — AgentLens doesn't distinguish code-review-triggered requests from regular premium requests. Flagged here as a known gap rather than guessed at.
-- `gpt-4.1`, `gpt-4o`, `gpt-4o-mini` are no longer listed on the current AI Credits pricing page at all (paid or included) — left unchanged in `RATES` since they may still be reachable for historical/legacy sessions; treat as deprecated.
+**Known gaps:**
+
+- **Copilot code review multiplier**: not currently modeled in `pricing.ts` — AgentLens doesn't
+  distinguish code-review-triggered requests from regular premium requests.
+- `gpt-4.1`, `gpt-4o`, `gpt-4o-mini` are no longer listed on the current AI Credits pricing page
+  at all (paid or included). Kept in `RATES` at their legacy rate for historical/legacy sessions;
+  treat as deprecated.
 
 ---
 
@@ -118,23 +134,29 @@ On `claude_code.llm_request` spans (per-API-call):
 
 **Rates (USD per 1M tokens, verified 2026-07-19):**
 
-| Model                                                                          | Input  | Cache Write (5m) | Cache Write (1h) | Cache Read | Output  |
-| ------------------------------------------------------------------------------ | ------ | ---------------- | ----------------- | ---------- | ------- |
-| `claude-opus-4-8`                                                              | $5.00  | $6.25             | $10.00            | $0.50      | $25.00  |
-| `claude-opus-4-7`                                                              | $5.00  | $6.25             | $10.00            | $0.50      | $25.00  |
-| `claude-opus-4-6`                                                              | $5.00  | $6.25             | $10.00            | $0.50      | $25.00  |
-| `claude-opus-4-5`                                                              | $5.00  | $6.25             | $10.00            | $0.50      | $25.00  |
-| `claude-sonnet-5` (introductory, through 2026-08-31)                           | $2.00  | $2.50             | $4.00             | $0.20      | $10.00  |
-| `claude-sonnet-5` (standard, from 2026-09-01)                                  | $3.00  | $3.75             | $6.00             | $0.30      | $15.00  |
-| `claude-sonnet-4-6`                                                            | $3.00  | $3.75             | $6.00             | $0.30      | $15.00  |
-| `claude-sonnet-4-5`                                                            | $3.00  | $3.75             | $6.00             | $0.30      | $15.00  |
-| `claude-sonnet-4`                                                              | $3.00  | $3.75             | $6.00             | $0.30      | $15.00  |
-| `claude-haiku-4-5`                                                             | $1.00  | $1.25             | $2.00             | $0.10      | $5.00   |
-| `claude-fable-5`                                                               | $10.00 | $12.50            | $20.00            | $1.00      | $50.00  |
-| `claude-mythos-5` (limited availability, see anthropic.com/glasswing)          | $10.00 | $12.50            | $20.00            | $1.00      | $50.00  |
-| `claude-opus-4-8` (fast, 2x)                                                   | $10.00 | $12.50            | $20.00            | $1.00      | $50.00  |
-| `claude-opus-4-7` (fast, 6x — deprecated, removal scheduled 2026-07-24)        | $30.00 | $37.50            | $60.00            | $3.00      | $150.00 |
-| `claude-opus-4-6` (fast — **removed 2026-06-29**; now bills at standard rate)  | $5.00  | $6.25             | $10.00            | $0.50      | $25.00  |
+| Model                                                                  | Input  | Cache Write (5m) | Cache Write (1h) | Cache Read | Output  |
+| ----------------------------------------------------------------------- | ------ | ----------------- | ----------------- | ---------- | ------- |
+| `claude-opus-4-8`                                                        | $5.00  | $6.25              | $10.00             | $0.50      | $25.00  |
+| `claude-opus-4-7`                                                        | $5.00  | $6.25              | $10.00             | $0.50      | $25.00  |
+| `claude-opus-4-6`                                                        | $5.00  | $6.25              | $10.00             | $0.50      | $25.00  |
+| `claude-opus-4-5`                                                        | $5.00  | $6.25              | $10.00             | $0.50      | $25.00  |
+| `claude-sonnet-5` (introductory, through 2026-08-31)                     | $2.00  | $2.50              | $4.00              | $0.20      | $10.00  |
+| `claude-sonnet-5` (standard, from 2026-09-01)                            | $3.00  | $3.75              | $6.00              | $0.30      | $15.00  |
+| `claude-sonnet-4-6`                                                      | $3.00  | $3.75              | $6.00              | $0.30      | $15.00  |
+| `claude-sonnet-4-5`                                                      | $3.00  | $3.75              | $6.00              | $0.30      | $15.00  |
+| `claude-sonnet-4`                                                        | $3.00  | $3.75              | $6.00              | $0.30      | $15.00  |
+| `claude-haiku-4-5`                                                       | $1.00  | $1.25              | $2.00              | $0.10      | $5.00   |
+| `claude-fable-5`                                                         | $10.00 | $12.50             | $20.00             | $1.00      | $50.00  |
+| `claude-mythos-5` (limited availability, see anthropic.com/glasswing)   | $10.00 | $12.50             | $20.00             | $1.00      | $50.00  |
+| `claude-opus-4-8` (fast mode, 2x)                                        | $10.00 | $12.50             | $20.00             | $1.00      | $50.00  |
+| `claude-opus-4-7` (fast mode, 6x)                                        | $30.00 | $37.50             | $60.00             | $3.00      | $150.00 |
+| `claude-opus-4-6` (fast mode — bills at standard rate, see note below)  | $5.00  | $6.25              | $10.00             | $0.50      | $25.00  |
+
+Fast mode is currently only available for Opus 4.7 and 4.8. `claude-opus-4-6` no longer supports
+fast mode — requests with `speed: "fast"` run at standard speed and bill at the standard rate, so
+its `-fast` entry in `RATES` is set equal to the standard rate rather than a multiplied one.
+Opus 4.7 fast mode is deprecated and scheduled for removal on 2026-07-24 — after that date, check
+whether the source page still lists it and update or drop the entry accordingly.
 
 **Tiered pricing — `claude-sonnet-4` only:**
 
@@ -156,16 +178,16 @@ The threshold applies per API call, not cumulatively across a session. `calcToke
 | `claude-opus-4-1` / `claude-opus-4`  | $15.00  | $1.50      | $75.00   |
 | `claude-haiku-3-5`                   | $0.80   | $0.08      | $4.00    |
 
-**Notable event — newer-tokenizer models (updated 2026-07-19):**
+**Tokenizer note:**
 
-Claude Opus 4.7 and later Opus models, Claude Fable 5, Claude Mythos 5, Claude Mythos Preview, and Claude Sonnet 5 use a newer tokenizer that produces approximately 30% more tokens for the same input text than the previous tokenizer (used by Sonnet 4.6 and earlier). Per-token prices did not change — this is not a billing model change, just affects token counts, so effective cost per request can be meaningfully higher for these models even at the same rate card. (Previously documented as an Opus-4.7-only, "up to 35%" change based on the April 16, 2026 rollout; the official docs now describe it as ~30% and applying to the broader newer-tokenizer model family above.)
+Claude Opus 4.7 and later Opus models, Claude Fable 5, Claude Mythos 5, Claude Mythos Preview, and Claude Sonnet 5 use a newer tokenizer that produces approximately 30% more tokens for the same input text than the previous tokenizer (used by Sonnet 4.6 and earlier). Per-token prices are unaffected — this only changes token counts, so effective cost per request can be meaningfully higher for these models even at the same rate card.
 
 **Known gaps:**
 
-- **Cache write TTL**: Anthropic supports 5-minute and 1-hour cache TTLs at different rates (1.25x and 2x base input price respectively; cache reads are 0.1x base input). The `cache_creation_tokens` field in telemetry does not distinguish between them. Claude Code CLI uses 5-minute caches by default, so the 5-minute rate is used. If 1-hour caches are in use, cost will be underestimated (5-minute write is 1.25x input, 1-hour write is 2x input — roughly 37% higher).
-- **Fast mode (`/fast`)**: When fast mode is active, `usage.speed` is `"fast"` in the log. AgentLens reads this and appends `-fast` to the stored model ID (e.g. `claude-opus-4-7-fast`) so the correct multiplied rates are applied. As of 2026-07-19: Opus 4.8 fast mode is 2x standard rates; Opus 4.7 fast mode is 6x standard rates but is **deprecated and scheduled for removal on 2026-07-24**; Opus 4.6 fast mode was **removed on 2026-06-29** — `claude-opus-4-6` requests with `speed: "fast"` now run at standard speed and bill at standard rates, so the `claude-opus-4-6-fast` entry in `RATES` has been set equal to the standard `claude-opus-4-6` rate rather than a multiplied one. Revisit the Opus 4.7 fast-mode entry after 2026-07-24.
+- **Cache write TTL**: Anthropic supports 5-minute and 1-hour cache TTLs at different rates (1.25x and 2x base input price respectively; cache reads are 0.1x base input). The `cache_creation_tokens` field in telemetry does not distinguish between them. Claude Code CLI uses 5-minute caches by default, so the 5-minute rate is used. If 1-hour caches are in use, cost will be underestimated by roughly 37%.
+- **Fast mode (`/fast`)**: When fast mode is active, `usage.speed` is `"fast"` in the log. AgentLens reads this and appends `-fast` to the stored model ID (e.g. `claude-opus-4-7-fast`) so the correct rate is applied. See the fast-mode note under the rate table above for current per-model status.
 - **Data residency multiplier**: `inference_geo: "us"` (Opus 4.6, Sonnet 4.6, and later models) applies a 1.1x multiplier to all token pricing categories. Not currently modeled — cost is underestimated by ~10% for sessions pinned to US-only inference.
-- **Sonnet 5 introductory pricing cutover**: `claude-sonnet-5` is priced at $2/$0.20/$2.50/$10 (input/cache read/cache write/output) through 2026-08-31, then $3/$0.30/$3.75/$15 from 2026-09-01. The rate table currently holds the introductory rate; it must be updated by hand on the cutover date since there's no date-driven rate selection in `pricing.ts`.
+- **Sonnet 5 introductory pricing cutover**: the rate table currently holds the introductory rate ($2/$0.20/$2.50/$10). It must be updated by hand to the standard rate ($3/$0.30/$3.75/$15) on 2026-09-01, since there's no date-driven rate selection in `pricing.ts`.
 - **Deprecated models**: Models older than claude-opus-4 (e.g. claude-3-5-sonnet, claude-3-opus) may appear in historical sessions. Add them to `RATES` in `pricing.ts` if encountered; missing models show as `~$?`.
 
 ---
@@ -180,7 +202,7 @@ Codex CLI uses OpenAI token-based pricing only — no request-multiplier system.
 
 **Sources:**
 
-- Rate card (official, may require login): <https://help.openai.com/en/articles/20001106-codex-rate-card>
+- Rate card (official, may require login): <https://help.openai.com/en/articles/20001106-codex-rate-card> — returned 403 on 2026-07-19; requires an authenticated session to fetch.
 - Codex CLI pricing page (credits; divide by 25 for USD): <https://developers.openai.com/codex/pricing>
 - API pricing (USD, includes codex models): <https://developers.openai.com/api/docs/pricing>
 - `codex-mini-latest` model spec: <https://developers.openai.com/api/docs/models/codex-mini-latest>
@@ -219,27 +241,27 @@ Model name available on `codex.user_prompt`, `codex.turn_ttft`, and `codex.tool_
 
 | Model                   | Input   | Cached Input | Output  | Cache discount | Notes                                          |
 | ----------------------- | ------- | ------------ | ------- | -------------- | ---------------------------------------------- |
-| `gpt-5.6-sol`           | $5.00   | $0.50        | $30.00  | 90%            | New 2026-07-19; flagship, same rate as gpt-5.5 |
-| `gpt-5.6-terra`         | $2.50   | $0.25        | $15.00  | 90%            | New 2026-07-19; same rate as gpt-5.4           |
-| `gpt-5.6-luna`          | $1.00   | $0.10        | $6.00   | 90%            | New 2026-07-19; small/fast                     |
+| `gpt-5.6-sol`           | $5.00   | $0.50        | $30.00  | 90%            | Flagship; same rate as gpt-5.5; has a long-context surcharge tier, threshold unconfirmed |
+| `gpt-5.6-terra`         | $2.50   | $0.25        | $15.00  | 90%            | Mid tier; same rate as gpt-5.4                 |
+| `gpt-5.6-luna`          | $1.00   | $0.10        | $6.00   | 90%            | Small/fast tier                                |
 | `gpt-5.5`               | $5.00   | $0.50        | $30.00  | 90%            |                                                 |
 | `gpt-5.4`               | $2.50   | $0.25        | $15.00  | 90%            |                                                 |
 | `gpt-5.4-mini`          | $0.75   | $0.075       | $4.50   | 90%            |                                                 |
-| `gpt-5.3-codex`         | $1.75   | $0.175       | $14.00  | 90%            | No longer listed on the Codex CLI pricing page — likely superseded by the GPT-5.6 family (exact current default not confirmed by docs) |
-| `gpt-5.3-codex-spark`   | TBD     | TBD          | TBD     | —              | Research preview; runs on specialized low-latency hardware; not available in the API at launch, no rates published |
+| `gpt-5.3-codex`         | $1.75   | $0.175       | $14.00  | 90%            | Deprecated — superseded by the GPT-5.6 family  |
+| `gpt-5.3-codex-spark`   | TBD     | TBD          | TBD     | —              | Research preview; specialized low-latency hardware; not available in the API, no rates published |
 | `gpt-5.2`               | $1.75   | $0.175       | $14.00  | 90%            | Deprecated                                     |
 | `gpt-5.1-codex`         | $1.75   | $0.175       | $14.00  | 90%            | Deprecated                                     |
 | `gpt-5.1-codex-mini`    | $0.75   | $0.075       | $4.50   | 90%            | Deprecated                                     |
 | `codex-mini-latest`     | $1.50   | $0.375       | $6.00   | 75%            | Fine-tuned o4-mini; 200K ctx; deprecated       |
 
-**Credits to USD conversion:** Rates on the Codex CLI pricing page are expressed in credits. 1 USD = 25 credits (re-verified 2026-07-19: gpt-5.6-sol at 125 credits/MTok input = $5.00, gpt-5.6-terra at 62.5 credits = $2.50, gpt-5.6-luna at 25 credits = $1.00, gpt-5.4-mini at 18.75 credits = $0.75 — all consistent with the API pricing page).
+**Credits to USD conversion:** Rates on the Codex CLI pricing page are expressed in credits. 1 USD = 25 credits — verify by checking `inputPerMTok × 25` against the listed credits figure for any current model (e.g. gpt-5.6-sol: $5.00 × 25 = 125 credits, matching the page).
 
 **Known gaps:**
 
 - Long-context surcharges: `gpt-5.5` and `gpt-5.6-sol` have a long-context tier ($10/$1.00/$45 above a certain token threshold — verify the cutoff from the API pricing page). Not yet implemented.
 - `gpt-5.3-codex-spark`: research preview with no published rates.
-- Reasoning tokens (`codex.usage.reasoning_output_tokens`): included in `gen_ai.usage.output_tokens` and billed at the standard output rate per available data; verify against the official rate card (`help.openai.com/en/articles/20001106-codex-rate-card` returned 403 on 2026-07-19 — requires an authenticated session to fetch).
-- Which GPT-5.6 variant (Sol/Terra/Luna) is the actual current default model invoked by plain `codex` CLI runs (as opposed to an explicit model flag) is not confirmed by public docs.
+- Reasoning tokens (`codex.usage.reasoning_output_tokens`): included in `gen_ai.usage.output_tokens` and billed at the standard output rate per available data; verify against the official rate card once it's fetchable (see Sources above).
+- Which GPT-5.6 variant (Sol/Terra/Luna) is the actual default model invoked by plain `codex` CLI runs (as opposed to an explicit model flag) is not confirmed by public docs.
 
 ---
 
@@ -251,16 +273,16 @@ OpenCode uses token-based pricing for third-party models (routed through its pro
 
 **Who it applies to:** Users of OpenCode's built-in Zen model tier during the limited evaluation period.
 
-**Source:** <https://opencode.ai/docs/zen/>
+**Source:** <https://opencode.ai/docs/zen/> (verified 2026-07-19)
 
-**Rates:** $0 — still completely free during evaluation as of 2026-07-19 (re-verified: no change). All token fields (`inputPerMTok`, `cacheReadPerMTok`, `cacheWritePerMTok`, `outputPerMTok`) are set to 0 in the rate table.
+**Rates:** $0 — free during evaluation. All token fields (`inputPerMTok`, `cacheReadPerMTok`, `cacheWritePerMTok`, `outputPerMTok`) are set to 0 in the rate table.
 
 **Model ID in OpenCode SQLite:** Stored as JSON `{"id":"big-pickle","providerID":"opencode"}` in the `model` column of the `session` table. AgentLens extracts the `id` field and normalizes it for rate lookup.
 
 **Known gaps:**
 
 - big-pickle pricing is stated as free "during limited evaluation" — it may become paid in the future. Check the source URL and update the rate table when rates are published.
-- **New free Zen-exclusive models (as of 2026-07-19, not yet added to `RATES`):** OpenCode Zen now also lists DeepSeek V4 Flash Free, MiMo-V2.5 Free, North Mini Code Free, and Nemotron 3 Ultra Free as $0 models, alongside 40+ paid third-party models (GPT, Claude, Gemini, Grok, DeepSeek, Qwen, MiniMax, GLM, Kimi families). These free models were not added here because their exact `id` string as it appears in the OpenCode SQLite `model` JSON column isn't confirmed — guessing the wrong slug would silently fail to match rather than cause harm (missing models fall back to `~$?`), but it should be confirmed from real telemetry (or the OpenCode Zen model list API) before adding.
+- **Other free Zen-exclusive models not yet in `RATES`:** OpenCode Zen also lists DeepSeek V4 Flash Free, MiMo-V2.5 Free, North Mini Code Free, and Nemotron 3 Ultra Free as $0 models, alongside 40+ paid third-party models (GPT, Claude, Gemini, Grok, DeepSeek, Qwen, MiniMax, GLM, Kimi families). Not added here because their exact `id` string as it appears in the OpenCode SQLite `model` JSON column isn't confirmed — guessing the wrong slug would silently fail to match rather than cause harm (missing models fall back to `~$?`), but confirm from real telemetry (or the OpenCode Zen model list API) before adding.
 - Other models used through OpenCode (e.g. Anthropic, OpenAI, or Google models routed via OpenCode's provider abstraction) are billed by the underlying provider at their standard rates. AgentLens applies the provider's published rates for those models automatically.
 
 ---
@@ -272,3 +294,6 @@ OpenCode uses token-based pricing for third-party models (routed through its pro
   `normalizeModelId()` in `pricing.ts` strips these before table lookup.
 - If a model appears in telemetry but is missing from the rate table, the UI shows `~$?` rather than $0
   to avoid silently under-reporting cost. Add the model to `RATES` in `pricing.ts` to resolve.
+- Pricing corrections that change displayed cost for real sessions (not just new-model additions)
+  are user-facing bug fixes — log them in `CHANGELOG.md` under `### Fixed` at the next release,
+  same as any other bug.

--- a/PRICING_SOURCES.md
+++ b/PRICING_SOURCES.md
@@ -67,6 +67,16 @@ cost = userPromptCount × multiplierAnnualPostJun1 × $0.04
 cost = userPromptCount × multiplier × $0.04
 ```
 
+### Changes found on 2026-07-19 review
+
+- **`gpt-5-mini` / `gpt-5 mini`** and **`raptor-mini`** are no longer included/$0 models — both now bill at $0.25/$0.025/–/$2.00 (input/cache read/cache write/output per MTok) under the AI Credits model. Both keep their existing `multiplierAnnualPostJun1` of 0.33.
+- **`gpt-5.5` annual-plan multiplier corrected**: `multiplierAnnualPostJun1` was 7.5, docs now show 57. The pre-Jun1 `multiplier` field (7.5) could not be re-verified — that page 404's as pre-June billing is now fully historical.
+- **New GPT-5.6 family** (Luna/Terra/Sol) added — Luna is the small/fast tier (~gpt-4o-mini-ish pricing), Terra matches gpt-5.4 pricing, Sol matches gpt-5.5 pricing (including a long-context surcharge tier at 2x rates, threshold unconfirmed). None of the three appear yet on the annual-plan multiplier page, so `multiplierAnnualPostJun1` is set to 0 pending publication.
+- **New third-party marketplace models**: `mai-code-1-flash` (Microsoft, $0.75/$0.075/–/$4.50) and `kimi-k2.7-code` (Moonshot AI, $0.95/$0.19/–/$4.00) added to `media/src/pricing.ts` only — these are Copilot-marketplace-only models, not expected to appear via direct-API telemetry from Claude Code/Codex, so they were not added to `src/pricing.ts`.
+- **Claude Opus 4.6 fast mode removed** (2026-06-29): requests to `claude-opus-4-6` with `speed: "fast"` now run at standard speed and bill at standard rates. The `claude-opus-4-6-fast` entry was changed from the old 6x multiplied rate to the standard Opus 4.6 rate in both rate tables.
+- **Copilot code review multiplier**: the annual-plan multipliers page notes "Copilot code review has a model multiplier of 13" (each code review request deducts 13 from the premium request quota). Not currently modeled anywhere in `pricing.ts` — AgentLens doesn't distinguish code-review-triggered requests from regular premium requests. Flagged here as a known gap rather than guessed at.
+- `gpt-4.1`, `gpt-4o`, `gpt-4o-mini` are no longer listed on the current AI Credits pricing page at all (paid or included) — left unchanged in `RATES` since they may still be reachable for historical/legacy sessions; treat as deprecated.
+
 ---
 
 ## Claude
@@ -77,7 +87,7 @@ Claude Code CLI uses Anthropic API token-based pricing only — no request-multi
 
 **Who it applies to:** All Claude Code CLI users billed through the Anthropic API.
 
-**Source:** <https://platform.claude.com/docs/en/about-claude/pricing> (verified 2026-06-08)
+**Source:** <https://platform.claude.com/docs/en/about-claude/pricing> (verified 2026-07-19)
 
 **Formula:**
 
@@ -106,21 +116,25 @@ On `claude_code.llm_request` spans (per-API-call):
 - `ttft_ms` — time to first token in ms
 - `stop_reason` — e.g. `tool_use`, `end_turn`
 
-**Rates (USD per 1M tokens, verified 2026-06-08):**
+**Rates (USD per 1M tokens, verified 2026-07-19):**
 
-| Model                          | Input   | Cache Write (5m) | Cache Write (1h) | Cache Read | Output   |
-| ------------------------------ | ------- | ---------------- | ---------------- | ---------- | -------- |
-| `claude-opus-4-8`              | $5.00   | $6.25            | $10.00           | $0.50      | $25.00   |
-| `claude-opus-4-7`              | $5.00   | $6.25            | $10.00           | $0.50      | $25.00   |
-| `claude-opus-4-6`              | $5.00   | $6.25            | $10.00           | $0.50      | $25.00   |
-| `claude-opus-4-5`              | $5.00   | $6.25            | $10.00           | $0.50      | $25.00   |
-| `claude-sonnet-4-6`            | $3.00   | $3.75            | $6.00            | $0.30      | $15.00   |
-| `claude-sonnet-4-5`            | $3.00   | $3.75            | $6.00            | $0.30      | $15.00   |
-| `claude-sonnet-4`              | $3.00   | $3.75            | $6.00            | $0.30      | $15.00   |
-| `claude-haiku-4-5`             | $1.00   | $1.25            | $2.00            | $0.10      | $5.00    |
-| `claude-opus-4-8` (fast, 2x)   | $10.00  | $12.50           | $20.00           | $1.00      | $50.00   |
-| `claude-opus-4-7` (fast, 6x)   | $30.00  | $37.50           | $60.00           | $3.00      | $150.00  |
-| `claude-opus-4-6` (fast, 6x)   | $30.00  | $37.50           | $60.00           | $3.00      | $150.00  |
+| Model                                                                          | Input  | Cache Write (5m) | Cache Write (1h) | Cache Read | Output  |
+| ------------------------------------------------------------------------------ | ------ | ---------------- | ----------------- | ---------- | ------- |
+| `claude-opus-4-8`                                                              | $5.00  | $6.25             | $10.00            | $0.50      | $25.00  |
+| `claude-opus-4-7`                                                              | $5.00  | $6.25             | $10.00            | $0.50      | $25.00  |
+| `claude-opus-4-6`                                                              | $5.00  | $6.25             | $10.00            | $0.50      | $25.00  |
+| `claude-opus-4-5`                                                              | $5.00  | $6.25             | $10.00            | $0.50      | $25.00  |
+| `claude-sonnet-5` (introductory, through 2026-08-31)                           | $2.00  | $2.50             | $4.00             | $0.20      | $10.00  |
+| `claude-sonnet-5` (standard, from 2026-09-01)                                  | $3.00  | $3.75             | $6.00             | $0.30      | $15.00  |
+| `claude-sonnet-4-6`                                                            | $3.00  | $3.75             | $6.00             | $0.30      | $15.00  |
+| `claude-sonnet-4-5`                                                            | $3.00  | $3.75             | $6.00             | $0.30      | $15.00  |
+| `claude-sonnet-4`                                                              | $3.00  | $3.75             | $6.00             | $0.30      | $15.00  |
+| `claude-haiku-4-5`                                                             | $1.00  | $1.25             | $2.00             | $0.10      | $5.00   |
+| `claude-fable-5`                                                               | $10.00 | $12.50            | $20.00            | $1.00      | $50.00  |
+| `claude-mythos-5` (limited availability, see anthropic.com/glasswing)          | $10.00 | $12.50            | $20.00            | $1.00      | $50.00  |
+| `claude-opus-4-8` (fast, 2x)                                                   | $10.00 | $12.50            | $20.00            | $1.00      | $50.00  |
+| `claude-opus-4-7` (fast, 6x — deprecated, removal scheduled 2026-07-24)        | $30.00 | $37.50            | $60.00            | $3.00      | $150.00 |
+| `claude-opus-4-6` (fast — **removed 2026-06-29**; now bills at standard rate)  | $5.00  | $6.25             | $10.00            | $0.50      | $25.00  |
 
 **Tiered pricing — `claude-sonnet-4` only:**
 
@@ -142,14 +156,16 @@ The threshold applies per API call, not cumulatively across a session. `calcToke
 | `claude-opus-4-1` / `claude-opus-4`  | $15.00  | $1.50      | $75.00   |
 | `claude-haiku-3-5`                   | $0.80   | $0.08      | $4.00    |
 
-**Notable event — Opus 4.7 tokenizer change (April 16, 2026):**
+**Notable event — newer-tokenizer models (updated 2026-07-19):**
 
-A new tokenizer was deployed for claude-opus-4-7 on April 16, 2026 that generates up to 35% more tokens for the same input text. Per-token prices did not change, but effective cost per request can be up to 35% higher for sessions after this date compared to sessions before. This is not a billing model change — just affects token counts.
+Claude Opus 4.7 and later Opus models, Claude Fable 5, Claude Mythos 5, Claude Mythos Preview, and Claude Sonnet 5 use a newer tokenizer that produces approximately 30% more tokens for the same input text than the previous tokenizer (used by Sonnet 4.6 and earlier). Per-token prices did not change — this is not a billing model change, just affects token counts, so effective cost per request can be meaningfully higher for these models even at the same rate card. (Previously documented as an Opus-4.7-only, "up to 35%" change based on the April 16, 2026 rollout; the official docs now describe it as ~30% and applying to the broader newer-tokenizer model family above.)
 
 **Known gaps:**
 
-- **Cache write TTL**: Anthropic supports 5-minute and 1-hour cache TTLs at different rates. The `cache_creation_tokens` field in telemetry does not distinguish between them. Claude Code CLI uses 5-minute caches by default, so the 5-minute rate is used. If 1-hour caches are in use, cost will be underestimated by ~37%.
-- **Fast mode (`/fast`)**: When fast mode is active, `usage.speed` is `"fast"` in the log. AgentLens reads this and appends `-fast` to the stored model ID (e.g. `claude-opus-4-7-fast`) so the correct multiplied rates are applied: 6x for Opus 4.6/4.7, 2x for Opus 4.8.
+- **Cache write TTL**: Anthropic supports 5-minute and 1-hour cache TTLs at different rates (1.25x and 2x base input price respectively; cache reads are 0.1x base input). The `cache_creation_tokens` field in telemetry does not distinguish between them. Claude Code CLI uses 5-minute caches by default, so the 5-minute rate is used. If 1-hour caches are in use, cost will be underestimated (5-minute write is 1.25x input, 1-hour write is 2x input — roughly 37% higher).
+- **Fast mode (`/fast`)**: When fast mode is active, `usage.speed` is `"fast"` in the log. AgentLens reads this and appends `-fast` to the stored model ID (e.g. `claude-opus-4-7-fast`) so the correct multiplied rates are applied. As of 2026-07-19: Opus 4.8 fast mode is 2x standard rates; Opus 4.7 fast mode is 6x standard rates but is **deprecated and scheduled for removal on 2026-07-24**; Opus 4.6 fast mode was **removed on 2026-06-29** — `claude-opus-4-6` requests with `speed: "fast"` now run at standard speed and bill at standard rates, so the `claude-opus-4-6-fast` entry in `RATES` has been set equal to the standard `claude-opus-4-6` rate rather than a multiplied one. Revisit the Opus 4.7 fast-mode entry after 2026-07-24.
+- **Data residency multiplier**: `inference_geo: "us"` (Opus 4.6, Sonnet 4.6, and later models) applies a 1.1x multiplier to all token pricing categories. Not currently modeled — cost is underestimated by ~10% for sessions pinned to US-only inference.
+- **Sonnet 5 introductory pricing cutover**: `claude-sonnet-5` is priced at $2/$0.20/$2.50/$10 (input/cache read/cache write/output) through 2026-08-31, then $3/$0.30/$3.75/$15 from 2026-09-01. The rate table currently holds the introductory rate; it must be updated by hand on the cutover date since there's no date-driven rate selection in `pricing.ts`.
 - **Deprecated models**: Models older than claude-opus-4 (e.g. claude-3-5-sonnet, claude-3-opus) may appear in historical sessions. Add them to `RATES` in `pricing.ts` if encountered; missing models show as `~$?`.
 
 ---
@@ -199,27 +215,31 @@ On `session_task.turn` spans (per-turn aggregate):
 
 Model name available on `codex.user_prompt`, `codex.turn_ttft`, and `codex.tool_decision` spans via `model` attribute.
 
-**Rates (USD per 1M tokens, verified 2026-05-28):**
+**Rates (USD per 1M tokens, verified 2026-07-19):**
 
 | Model                   | Input   | Cached Input | Output  | Cache discount | Notes                                          |
 | ----------------------- | ------- | ------------ | ------- | -------------- | ---------------------------------------------- |
-| `gpt-5.5`               | $5.00   | $0.50        | $30.00  | 90%            | Flagship; used directly by Codex CLI           |
-| `gpt-5.4`               | $2.50   | $0.25        | $15.00  | 90%            |                                                |
-| `gpt-5.4-mini`          | $0.75   | $0.075       | $4.50   | 90%            |                                                |
-| `gpt-5.3-codex`         | $1.75   | $0.175       | $14.00  | 90%            | Current primary Codex model                    |
-| `gpt-5.3-codex-spark`   | TBD     | TBD          | TBD     | —              | Research preview, no rates published           |
+| `gpt-5.6-sol`           | $5.00   | $0.50        | $30.00  | 90%            | New 2026-07-19; flagship, same rate as gpt-5.5 |
+| `gpt-5.6-terra`         | $2.50   | $0.25        | $15.00  | 90%            | New 2026-07-19; same rate as gpt-5.4           |
+| `gpt-5.6-luna`          | $1.00   | $0.10        | $6.00   | 90%            | New 2026-07-19; small/fast                     |
+| `gpt-5.5`               | $5.00   | $0.50        | $30.00  | 90%            |                                                 |
+| `gpt-5.4`               | $2.50   | $0.25        | $15.00  | 90%            |                                                 |
+| `gpt-5.4-mini`          | $0.75   | $0.075       | $4.50   | 90%            |                                                 |
+| `gpt-5.3-codex`         | $1.75   | $0.175       | $14.00  | 90%            | No longer listed on the Codex CLI pricing page — likely superseded by the GPT-5.6 family (exact current default not confirmed by docs) |
+| `gpt-5.3-codex-spark`   | TBD     | TBD          | TBD     | —              | Research preview; runs on specialized low-latency hardware; not available in the API at launch, no rates published |
 | `gpt-5.2`               | $1.75   | $0.175       | $14.00  | 90%            | Deprecated                                     |
 | `gpt-5.1-codex`         | $1.75   | $0.175       | $14.00  | 90%            | Deprecated                                     |
 | `gpt-5.1-codex-mini`    | $0.75   | $0.075       | $4.50   | 90%            | Deprecated                                     |
 | `codex-mini-latest`     | $1.50   | $0.375       | $6.00   | 75%            | Fine-tuned o4-mini; 200K ctx; deprecated       |
 
-**Credits to USD conversion:** Rates on the Codex CLI pricing page are expressed in credits. 1 USD = 25 credits (verified: gpt-5.5 listed as 125 credits/MTok input = $5.00).
+**Credits to USD conversion:** Rates on the Codex CLI pricing page are expressed in credits. 1 USD = 25 credits (re-verified 2026-07-19: gpt-5.6-sol at 125 credits/MTok input = $5.00, gpt-5.6-terra at 62.5 credits = $2.50, gpt-5.6-luna at 25 credits = $1.00, gpt-5.4-mini at 18.75 credits = $0.75 — all consistent with the API pricing page).
 
 **Known gaps:**
 
-- Long-context surcharges: `gpt-5.5` has a long-context tier ($10/$1.00/$45 above a certain token threshold — verify the cutoff from the API pricing page). Not yet implemented.
+- Long-context surcharges: `gpt-5.5` and `gpt-5.6-sol` have a long-context tier ($10/$1.00/$45 above a certain token threshold — verify the cutoff from the API pricing page). Not yet implemented.
 - `gpt-5.3-codex-spark`: research preview with no published rates.
-- Reasoning tokens (`codex.usage.reasoning_output_tokens`): included in `gen_ai.usage.output_tokens` and billed at the standard output rate per available data; verify against the official rate card.
+- Reasoning tokens (`codex.usage.reasoning_output_tokens`): included in `gen_ai.usage.output_tokens` and billed at the standard output rate per available data; verify against the official rate card (`help.openai.com/en/articles/20001106-codex-rate-card` returned 403 on 2026-07-19 — requires an authenticated session to fetch).
+- Which GPT-5.6 variant (Sol/Terra/Luna) is the actual current default model invoked by plain `codex` CLI runs (as opposed to an explicit model flag) is not confirmed by public docs.
 
 ---
 
@@ -233,13 +253,14 @@ OpenCode uses token-based pricing for third-party models (routed through its pro
 
 **Source:** <https://opencode.ai/docs/zen/>
 
-**Rates:** $0 — completely free during evaluation. All token fields (`inputPerMTok`, `cacheReadPerMTok`, `cacheWritePerMTok`, `outputPerMTok`) are set to 0 in the rate table.
+**Rates:** $0 — still completely free during evaluation as of 2026-07-19 (re-verified: no change). All token fields (`inputPerMTok`, `cacheReadPerMTok`, `cacheWritePerMTok`, `outputPerMTok`) are set to 0 in the rate table.
 
 **Model ID in OpenCode SQLite:** Stored as JSON `{"id":"big-pickle","providerID":"opencode"}` in the `model` column of the `session` table. AgentLens extracts the `id` field and normalizes it for rate lookup.
 
 **Known gaps:**
 
 - big-pickle pricing is stated as free "during limited evaluation" — it may become paid in the future. Check the source URL and update the rate table when rates are published.
+- **New free Zen-exclusive models (as of 2026-07-19, not yet added to `RATES`):** OpenCode Zen now also lists DeepSeek V4 Flash Free, MiMo-V2.5 Free, North Mini Code Free, and Nemotron 3 Ultra Free as $0 models, alongside 40+ paid third-party models (GPT, Claude, Gemini, Grok, DeepSeek, Qwen, MiniMax, GLM, Kimi families). These free models were not added here because their exact `id` string as it appears in the OpenCode SQLite `model` JSON column isn't confirmed — guessing the wrong slug would silently fail to match rather than cause harm (missing models fall back to `~$?`), but it should be confirmed from real telemetry (or the OpenCode Zen model list API) before adding.
 - Other models used through OpenCode (e.g. Anthropic, OpenAI, or Google models routed via OpenCode's provider abstraction) are billed by the underlying provider at their standard rates. AgentLens applies the provider's published rates for those models automatically.
 
 ---

--- a/media/src/pricing.ts
+++ b/media/src/pricing.ts
@@ -2,7 +2,7 @@
 // Token rates (post Jun 1, 2026):        https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing
 // Request multipliers (pre Jun 1, 2026): https://docs.github.com/en/copilot/concepts/billing/copilot-requests
 // Annual-plan multipliers (post Jun 1):  https://docs.github.com/en/copilot/reference/copilot-billing/model-multipliers-for-annual-plans
-export const PRICING_LAST_UPDATED = '2026-06-10'
+export const PRICING_LAST_UPDATED = '2026-07-19'
 
 // Three billing modes:
 //   'token'          — new token-based AI Credits billing, effective Jun 1, 2026
@@ -30,10 +30,11 @@ export interface ModelRates {
 const RATES: Record<string, ModelRates> = {
   // ── OpenAI ─────────────────────────────────────────────────────────────────────────────────────
   //                                                                     token rates ──────────────────────────────────── │ pre-Jun1  │ annual post-Jun1
-  // included models: 0× pre-Jun1 AND $0 in token mode (included in Copilot subscription per footnote 1)
+  // gpt-4.1: no longer listed on the current pricing page — kept at legacy $0 rate for historical sessions.
   'gpt-4.1':             { inputPerMTok: 0,     cacheReadPerMTok: 0,      cacheWritePerMTok: 0, outputPerMTok: 0,     multiplier: 0,    multiplierAnnualPostJun1: 1 },
-  'gpt-5-mini':          { inputPerMTok: 0,     cacheReadPerMTok: 0,      cacheWritePerMTok: 0, outputPerMTok: 0,     multiplier: 0,    multiplierAnnualPostJun1: 0.33 },
-  'gpt-5 mini':          { inputPerMTok: 0,     cacheReadPerMTok: 0,      cacheWritePerMTok: 0, outputPerMTok: 0,     multiplier: 0,    multiplierAnnualPostJun1: 0.33 },
+  // gpt-5-mini: no longer included/$0 as of 2026-07-19 — now billed at standard token rates.
+  'gpt-5-mini':          { inputPerMTok: 0.25,  cacheReadPerMTok: 0.025,  cacheWritePerMTok: 0, outputPerMTok: 2.00,  multiplier: 0,    multiplierAnnualPostJun1: 0.33 },
+  'gpt-5 mini':          { inputPerMTok: 0.25,  cacheReadPerMTok: 0.025,  cacheWritePerMTok: 0, outputPerMTok: 2.00,  multiplier: 0,    multiplierAnnualPostJun1: 0.33 },
   // older included models kept for historical sessions
   'gpt-4o':              { inputPerMTok: 2.50,  cacheReadPerMTok: 1.25,   cacheWritePerMTok: 0, outputPerMTok: 10.00, multiplier: 0,    multiplierAnnualPostJun1: 0.33 },
   'gpt-4o-mini':         { inputPerMTok: 0.15,  cacheReadPerMTok: 0.075,  cacheWritePerMTok: 0, outputPerMTok: 0.60,  multiplier: 0,    multiplierAnnualPostJun1: 0.33 },
@@ -49,7 +50,12 @@ const RATES: Record<string, ModelRates> = {
   'gpt-5.4':             { inputPerMTok: 2.50,  cacheReadPerMTok: 0.25,   cacheWritePerMTok: 0, outputPerMTok: 15.00, multiplier: 1,    multiplierAnnualPostJun1: 6 },  // long-context surcharge (>272K tokens) not implemented
   'gpt-5.4-mini':        { inputPerMTok: 0.75,  cacheReadPerMTok: 0.075,  cacheWritePerMTok: 0, outputPerMTok: 4.50,  multiplier: 0.33, multiplierAnnualPostJun1: 6 },
   'gpt-5.4-nano':        { inputPerMTok: 0.20,  cacheReadPerMTok: 0.02,   cacheWritePerMTok: 0, outputPerMTok: 1.25,  multiplier: 0.25, multiplierAnnualPostJun1: 0.25 },
-  'gpt-5.5':             { inputPerMTok: 5.00,  cacheReadPerMTok: 0.50,   cacheWritePerMTok: 0, outputPerMTok: 30.00, multiplier: 7.5,  multiplierAnnualPostJun1: 7.5 },  // TBD per docs; long-context surcharge (>unknown threshold) not implemented
+  'gpt-5.5':             { inputPerMTok: 5.00,  cacheReadPerMTok: 0.50,   cacheWritePerMTok: 0, outputPerMTok: 30.00, multiplier: 7.5,  multiplierAnnualPostJun1: 57 },  // annual multiplier corrected 2026-07-19 (was 7.5); long-context surcharge (>unknown threshold) not implemented
+  // gpt-5.6 family (new as of 2026-07-19): Luna (small/fast), Terra (mid, ~gpt-5.4 pricing), Sol (flagship, ~gpt-5.5 pricing).
+  // Not yet listed on the annual-plan multiplier page — multiplierAnnualPostJun1 set to 0 until published.
+  'gpt-5.6-luna':        { inputPerMTok: 1.00,  cacheReadPerMTok: 0.10,   cacheWritePerMTok: 0, outputPerMTok: 6.00,  multiplier: 0,    multiplierAnnualPostJun1: 0 },
+  'gpt-5.6-terra':       { inputPerMTok: 2.50,  cacheReadPerMTok: 0.25,   cacheWritePerMTok: 0, outputPerMTok: 15.00, multiplier: 0,    multiplierAnnualPostJun1: 0 },
+  'gpt-5.6-sol':         { inputPerMTok: 5.00,  cacheReadPerMTok: 0.50,   cacheWritePerMTok: 0, outputPerMTok: 30.00, multiplier: 0,    multiplierAnnualPostJun1: 0 },  // long-context surcharge (>unknown threshold) not implemented
   // ── Codex-only models ──────────────────────────────────────────────────────────────────────────
   // codex-mini-latest: fine-tuned o4-mini; 75% cache discount (not the usual 90%); deprecated
   'codex-mini-latest':   { inputPerMTok: 1.50,  cacheReadPerMTok: 0.375,  cacheWritePerMTok: 0, outputPerMTok: 6.00,  multiplier: 0,    multiplierAnnualPostJun1: 0 },
@@ -64,15 +70,22 @@ const RATES: Record<string, ModelRates> = {
                              inputAbove200kPerMTok: 6.00, outputAbove200kPerMTok: 22.50, cacheReadAbove200kPerMTok: 0.60, cacheWriteAbove200kPerMTok: 7.50 },
   'claude-sonnet-4-5':     { inputPerMTok:  3.00, cacheReadPerMTok: 0.30, cacheWritePerMTok:  3.75, outputPerMTok: 15.00, multiplier: 1,    multiplierAnnualPostJun1: 6 },
   'claude-sonnet-4-6':     { inputPerMTok:  3.00, cacheReadPerMTok: 0.30, cacheWritePerMTok:  3.75, outputPerMTok: 15.00, multiplier: 1,    multiplierAnnualPostJun1: 9 },
+  // claude-sonnet-5: introductory token pricing through 2026-08-31 ($2/$0.20/$2.50/$10); standard ($3/$0.30/$3.75/$15)
+  // takes effect 2026-09-01 — update this row on that date. Not listed on the annual-plan multiplier page.
+  'claude-sonnet-5':       { inputPerMTok:  2.00, cacheReadPerMTok: 0.20, cacheWritePerMTok:  2.50, outputPerMTok: 10.00, multiplier: 0,  multiplierAnnualPostJun1: 0 },
   'claude-opus-4-5':       { inputPerMTok:  5.00, cacheReadPerMTok: 0.50, cacheWritePerMTok:  6.25, outputPerMTok: 25.00, multiplier: 3,    multiplierAnnualPostJun1: 15 },
   'claude-opus-4-6':       { inputPerMTok:  5.00, cacheReadPerMTok: 0.50, cacheWritePerMTok:  6.25, outputPerMTok: 25.00, multiplier: 3,    multiplierAnnualPostJun1: 27 },
   'claude-opus-4-7':       { inputPerMTok:  5.00, cacheReadPerMTok: 0.50, cacheWritePerMTok:  6.25, outputPerMTok: 25.00, multiplier: 15,   multiplierAnnualPostJun1: 27 },
   'claude-opus-4-8':       { inputPerMTok:  5.00, cacheReadPerMTok: 0.50, cacheWritePerMTok:  6.25, outputPerMTok: 25.00, multiplier: 15,   multiplierAnnualPostJun1: 27 },
-  // fast mode (/fast toggle in Claude Code) — model ID appended with -fast by logReader when usage.speed === 'fast'
-  'claude-opus-4-6-fast':  { inputPerMTok: 30.00, cacheReadPerMTok: 3.00, cacheWritePerMTok: 37.50, outputPerMTok: 150.00, multiplier: 30, multiplierAnnualPostJun1: 30 },
+  // fast mode (/fast toggle in Claude Code) — model ID appended with -fast by logReader when usage.speed === 'fast'.
+  // Opus 4.6 fast mode was removed 2026-06-29: requests run at standard speed/rates despite the -fast suffix.
+  'claude-opus-4-6-fast':  { inputPerMTok:  5.00, cacheReadPerMTok: 0.50, cacheWritePerMTok:  6.25, outputPerMTok:  25.00, multiplier: 3,  multiplierAnnualPostJun1: 27 },
+  // Opus 4.7 fast mode is deprecated, scheduled for removal 2026-07-24 — Copilot's own pricing docs don't list a fast-mode
+  // row for it at all, so this rate is carried over from direct Anthropic API pricing as a best estimate.
   'claude-opus-4-7-fast':  { inputPerMTok: 30.00, cacheReadPerMTok: 3.00, cacheWritePerMTok: 37.50, outputPerMTok: 150.00, multiplier: 30, multiplierAnnualPostJun1: 30 },
   'claude-opus-4-8-fast':  { inputPerMTok: 10.00, cacheReadPerMTok: 1.00, cacheWritePerMTok: 12.50, outputPerMTok:  50.00, multiplier: 30, multiplierAnnualPostJun1: 30 },
   'claude-fable-5':        { inputPerMTok: 10.00, cacheReadPerMTok: 1.00, cacheWritePerMTok: 12.50, outputPerMTok:  50.00, multiplier: 0,  multiplierAnnualPostJun1: 0 },  // not yet listed in Copilot billing docs
+  'claude-mythos-5':       { inputPerMTok: 10.00, cacheReadPerMTok: 1.00, cacheWritePerMTok: 12.50, outputPerMTok:  50.00, multiplier: 0,  multiplierAnnualPostJun1: 0 },  // limited availability preview; not yet listed in Copilot billing docs
   // ── Google ─────────────────────────────────────────────────────────────────────────────────────
   'gemini-2.5-pro':   { inputPerMTok: 1.25, cacheReadPerMTok: 0.125, cacheWritePerMTok: 0, outputPerMTok: 10.00, multiplier: 1,    multiplierAnnualPostJun1: 1 },  // long-context surcharge (>200K tokens) not implemented
   'gemini-3-flash':   { inputPerMTok: 0.50, cacheReadPerMTok: 0.05,  cacheWritePerMTok: 0, outputPerMTok: 3.00,  multiplier: 0.33, multiplierAnnualPostJun1: 0.33 },
@@ -80,9 +93,13 @@ const RATES: Record<string, ModelRates> = {
   'gemini-3.1-pro':   { inputPerMTok: 2.00, cacheReadPerMTok: 0.20,  cacheWritePerMTok: 0, outputPerMTok: 12.00, multiplier: 1,    multiplierAnnualPostJun1: 6 },  // long-context surcharge (>200K tokens) not implemented
   'gemini-3.5-flash': { inputPerMTok: 1.50, cacheReadPerMTok: 0.15,  cacheWritePerMTok: 0, outputPerMTok: 9.00,  multiplier: 14,   multiplierAnnualPostJun1: 14 },
   // ── Fine-tuned ─────────────────────────────────────────────────────────────────────────────────
-  // raptor-mini uses GPT-5 mini pricing per footnote 5 — included ($0) in token mode, same annual multiplier
-  'raptor-mini': { inputPerMTok: 0,    cacheReadPerMTok: 0,     cacheWritePerMTok: 0, outputPerMTok: 0,     multiplier: 0, multiplierAnnualPostJun1: 0.33 },
+  // raptor-mini: no longer included/$0 as of 2026-07-19 — now billed at the same standard rate as gpt-5-mini.
+  'raptor-mini': { inputPerMTok: 0.25, cacheReadPerMTok: 0.025, cacheWritePerMTok: 0, outputPerMTok: 2.00,  multiplier: 0, multiplierAnnualPostJun1: 0.33 },
   'goldeneye':   { inputPerMTok: 1.25, cacheReadPerMTok: 0.125, cacheWritePerMTok: 0, outputPerMTok: 10.00, multiplier: 0, multiplierAnnualPostJun1: 0 },
+  // ── Other third-party (new to Copilot marketplace as of 2026-07-19) ───────────────────────────────
+  // Not yet listed on the annual-plan multiplier page — multiplierAnnualPostJun1 set to 0 until published.
+  'mai-code-1-flash': { inputPerMTok: 0.75, cacheReadPerMTok: 0.075, cacheWritePerMTok: 0, outputPerMTok: 4.50, multiplier: 0, multiplierAnnualPostJun1: 0.33 },
+  'kimi-k2.7-code':   { inputPerMTok: 0.95, cacheReadPerMTok: 0.19,  cacheWritePerMTok: 0, outputPerMTok: 4.00, multiplier: 0, multiplierAnnualPostJun1: 0 },
   // ── OpenCode Zen  https://opencode.ai/docs/zen/ ────────────────────────────
   // big-pickle: OpenCode's stealth model, free during limited evaluation period.
   'big-pickle':  { inputPerMTok: 0,    cacheReadPerMTok: 0,     cacheWritePerMTok: 0, outputPerMTok: 0,     multiplier: 0, multiplierAnnualPostJun1: 0 },

--- a/src/pricing.ts
+++ b/src/pricing.ts
@@ -1,6 +1,6 @@
 // Pricing data for extension-host cost computation (cost_usd stored in sessions table).
 // Rate table is kept in sync with media/src/pricing.ts — update both when rates change.
-// PRICING_LAST_UPDATED: 2026-06-10
+// PRICING_LAST_UPDATED: 2026-07-19
 
 export interface ModelRates {
   inputPerMTok: number
@@ -17,9 +17,11 @@ export interface ModelRates {
 
 const RATES: Record<string, ModelRates> = {
   // ── OpenAI ─────────────────────────────────────────────────────────────────
+  // gpt-4.1: no longer listed on the current API pricing page — kept at legacy $0 rate for historical sessions.
   'gpt-4.1':            { inputPerMTok: 0,     cacheReadPerMTok: 0,      cacheWritePerMTok: 0, outputPerMTok: 0,     contextWindowTokens: 1_000_000 },
-  'gpt-5-mini':         { inputPerMTok: 0,     cacheReadPerMTok: 0,      cacheWritePerMTok: 0, outputPerMTok: 0,     contextWindowTokens: 200_000 },
-  'gpt-5 mini':         { inputPerMTok: 0,     cacheReadPerMTok: 0,      cacheWritePerMTok: 0, outputPerMTok: 0,     contextWindowTokens: 200_000 },
+  // gpt-5-mini: no longer an included/$0 model as of the 2026-07-19 pricing page — now billed at standard rates.
+  'gpt-5-mini':         { inputPerMTok: 0.25,  cacheReadPerMTok: 0.025,  cacheWritePerMTok: 0, outputPerMTok: 2.00,  contextWindowTokens: 200_000 },
+  'gpt-5 mini':         { inputPerMTok: 0.25,  cacheReadPerMTok: 0.025,  cacheWritePerMTok: 0, outputPerMTok: 2.00,  contextWindowTokens: 200_000 },
   'gpt-4o':             { inputPerMTok: 2.50,  cacheReadPerMTok: 1.25,   cacheWritePerMTok: 0, outputPerMTok: 10.00, contextWindowTokens: 128_000 },
   'gpt-4o-mini':        { inputPerMTok: 0.15,  cacheReadPerMTok: 0.075,  cacheWritePerMTok: 0, outputPerMTok: 0.60,  contextWindowTokens: 128_000 },
   'gpt-5.1':            { inputPerMTok: 1.75,  cacheReadPerMTok: 0.175,  cacheWritePerMTok: 0, outputPerMTok: 14.00, contextWindowTokens: 256_000 },
@@ -33,7 +35,12 @@ const RATES: Record<string, ModelRates> = {
   'gpt-5.4-mini':       { inputPerMTok: 0.75,  cacheReadPerMTok: 0.075,  cacheWritePerMTok: 0, outputPerMTok: 4.50,  contextWindowTokens: 200_000 },
   'gpt-5.4-nano':       { inputPerMTok: 0.20,  cacheReadPerMTok: 0.02,   cacheWritePerMTok: 0, outputPerMTok: 1.25,  contextWindowTokens: 128_000 },
   'gpt-5.5':            { inputPerMTok: 5.00,  cacheReadPerMTok: 0.50,   cacheWritePerMTok: 0, outputPerMTok: 30.00, contextWindowTokens: 256_000 },
+  // gpt-5.6 family (new as of 2026-07-19): Luna (small/fast), Terra (mid, ~gpt-5.4 pricing), Sol (flagship, ~gpt-5.5 pricing).
+  'gpt-5.6-luna':       { inputPerMTok: 1.00,  cacheReadPerMTok: 0.10,   cacheWritePerMTok: 0, outputPerMTok: 6.00,  contextWindowTokens: 256_000 },
+  'gpt-5.6-terra':      { inputPerMTok: 2.50,  cacheReadPerMTok: 0.25,   cacheWritePerMTok: 0, outputPerMTok: 15.00, contextWindowTokens: 256_000 },
+  'gpt-5.6-sol':        { inputPerMTok: 5.00,  cacheReadPerMTok: 0.50,   cacheWritePerMTok: 0, outputPerMTok: 30.00, contextWindowTokens: 256_000 },
   // ── Codex-only ─────────────────────────────────────────────────────────────
+  // codex-mini-latest: deprecated per OpenAI docs; kept for historical sessions.
   'codex-mini-latest':  { inputPerMTok: 1.50,  cacheReadPerMTok: 0.375,  cacheWritePerMTok: 0, outputPerMTok: 6.00,  contextWindowTokens: 200_000 },
   // ── Anthropic ──────────────────────────────────────────────────────────────
   'claude-opus-4':      { inputPerMTok: 15.00, cacheReadPerMTok: 1.50,  cacheWritePerMTok: 18.75, outputPerMTok: 75.00, contextWindowTokens: 200_000 },
@@ -44,14 +51,21 @@ const RATES: Record<string, ModelRates> = {
                           inputAbove200kPerMTok: 6.00, outputAbove200kPerMTok: 22.50, cacheReadAbove200kPerMTok: 0.60, cacheWriteAbove200kPerMTok: 7.50 },
   'claude-sonnet-4-5':  { inputPerMTok:  3.00, cacheReadPerMTok: 0.30,  cacheWritePerMTok:  3.75, outputPerMTok: 15.00, contextWindowTokens: 1_000_000 },
   'claude-sonnet-4-6':  { inputPerMTok:  3.00, cacheReadPerMTok: 0.30,  cacheWritePerMTok:  3.75, outputPerMTok: 15.00, contextWindowTokens: 1_000_000 },
+  // claude-sonnet-5: introductory pricing through 2026-08-31 ($2/$0.20/$2.50/$10); standard pricing ($3/$0.30/$3.75/$15,
+  // matching sonnet-4-6) takes effect 2026-09-01. Update this row on that date.
+  'claude-sonnet-5':    { inputPerMTok:  2.00, cacheReadPerMTok: 0.20,  cacheWritePerMTok:  2.50, outputPerMTok: 10.00, contextWindowTokens: 1_000_000 },
   'claude-opus-4-5':    { inputPerMTok:  5.00, cacheReadPerMTok: 0.50,  cacheWritePerMTok:  6.25, outputPerMTok: 25.00, contextWindowTokens: 1_000_000 },
   'claude-opus-4-6':    { inputPerMTok:  5.00, cacheReadPerMTok: 0.50,  cacheWritePerMTok:  6.25, outputPerMTok: 25.00, contextWindowTokens: 1_000_000 },
   'claude-opus-4-7':    { inputPerMTok:  5.00, cacheReadPerMTok: 0.50,  cacheWritePerMTok:  6.25, outputPerMTok: 25.00, contextWindowTokens: 1_000_000 },
   'claude-opus-4-8':    { inputPerMTok:  5.00, cacheReadPerMTok: 0.50,  cacheWritePerMTok:  6.25, outputPerMTok: 25.00, contextWindowTokens: 1_000_000 },
-  'claude-opus-4-6-fast':{ inputPerMTok: 30.00, cacheReadPerMTok: 3.00, cacheWritePerMTok: 37.50, outputPerMTok: 150.00, contextWindowTokens: 1_000_000 },
+  // fast mode for Opus 4.6 was removed 2026-06-29 — requests now run at standard speed/rates despite the -fast suffix.
+  'claude-opus-4-6-fast':{ inputPerMTok:  5.00, cacheReadPerMTok: 0.50, cacheWritePerMTok:  6.25, outputPerMTok:  25.00, contextWindowTokens: 1_000_000 },
+  // fast mode for Opus 4.7 is deprecated and scheduled for removal 2026-07-24 — remove/fold into standard rate after that date.
   'claude-opus-4-7-fast':{ inputPerMTok: 30.00, cacheReadPerMTok: 3.00, cacheWritePerMTok: 37.50, outputPerMTok: 150.00, contextWindowTokens: 1_000_000 },
   'claude-opus-4-8-fast':{ inputPerMTok: 10.00, cacheReadPerMTok: 1.00, cacheWritePerMTok: 12.50, outputPerMTok:  50.00, contextWindowTokens: 1_000_000 },
   'claude-fable-5':      { inputPerMTok: 10.00, cacheReadPerMTok: 1.00, cacheWritePerMTok: 12.50, outputPerMTok:  50.00, contextWindowTokens: 1_000_000 },
+  // claude-mythos-5: limited-availability preview (anthropic.com/glasswing), same rates as Fable 5.
+  'claude-mythos-5':     { inputPerMTok: 10.00, cacheReadPerMTok: 1.00, cacheWritePerMTok: 12.50, outputPerMTok:  50.00, contextWindowTokens: 1_000_000 },
   // ── Google ─────────────────────────────────────────────────────────────────
   'gemini-2.5-pro':  { inputPerMTok: 1.25, cacheReadPerMTok: 0.125, cacheWritePerMTok: 0, outputPerMTok: 10.00, contextWindowTokens: 1_000_000 },
   'gemini-3-flash':  { inputPerMTok: 0.50, cacheReadPerMTok: 0.05,  cacheWritePerMTok: 0, outputPerMTok:  3.00, contextWindowTokens: 1_000_000 },
@@ -59,7 +73,8 @@ const RATES: Record<string, ModelRates> = {
   'gemini-3.1-pro':  { inputPerMTok: 2.00, cacheReadPerMTok: 0.20,  cacheWritePerMTok: 0, outputPerMTok: 12.00, contextWindowTokens: 1_000_000 },
   'gemini-3.5-flash':{ inputPerMTok: 1.50, cacheReadPerMTok: 0.15,  cacheWritePerMTok: 0, outputPerMTok:  9.00, contextWindowTokens: 1_000_000 },
   // ── Fine-tuned ─────────────────────────────────────────────────────────────
-  'raptor-mini': { inputPerMTok: 0,    cacheReadPerMTok: 0,     cacheWritePerMTok: 0, outputPerMTok:  0,     contextWindowTokens: 0 },
+  // raptor-mini: no longer an included/$0 model as of the 2026-07-19 Copilot pricing page — now billed at standard rates.
+  'raptor-mini': { inputPerMTok: 0.25, cacheReadPerMTok: 0.025, cacheWritePerMTok: 0, outputPerMTok:  2.00,  contextWindowTokens: 0 },
   'goldeneye':   { inputPerMTok: 1.25, cacheReadPerMTok: 0.125, cacheWritePerMTok: 0, outputPerMTok: 10.00, contextWindowTokens: 0 },
   // ── OpenCode Zen  https://opencode.ai/docs/zen/ ────────────────────────────
   // big-pickle: OpenCode's stealth model, free during limited evaluation period.


### PR DESCRIPTION
## Summary

Reviewed every source listed in `PRICING_SOURCES.md` (Copilot AI Credits + multiplier docs, direct Anthropic API pricing, Codex CLI/OpenAI API pricing, OpenCode Zen) and refreshed `src/pricing.ts` and `media/src/pricing.ts` accordingly.

**New models added:**
- `claude-sonnet-5` (introductory pricing through 2026-08-31, standard pricing from 2026-09-01) and `claude-mythos-5` (limited-availability preview)
- `gpt-5.6-luna` / `gpt-5.6-terra` / `gpt-5.6-sol` (new OpenAI flagship family, used by both Codex CLI and Copilot)
- `mai-code-1-flash` and `kimi-k2.7-code` — new third-party models in the Copilot marketplace (Copilot table only)

**Rate corrections (real drift from what was in the tables):**
- `claude-opus-4-6-fast`: fast mode for Opus 4.6 was removed 2026-06-29 — requests now bill at standard Opus 4.6 rates instead of the old 6x multiplier
- `gpt-5-mini` / `raptor-mini`: no longer included/$0 models — now billed at standard AI Credits rates ($0.25/$0.025/–/$2.00)
- `gpt-5.5` post-June-1 annual-plan multiplier: was `7.5`, docs now show `57`

**Docs:** `PRICING_SOURCES.md` updated with re-verified source dates, the tokenizer-change note broadened to match current Anthropic docs (~30% more tokens, applies to the whole newer-tokenizer model family, not just Opus 4.7), and new "Known gaps" entries (data residency 1.1x multiplier, Copilot code review multiplier of 13, new free OpenCode Zen models pending ID confirmation).

Full list of what changed and why is in the "Changes found on 2026-07-19 review" section of `PRICING_SOURCES.md`.

## Test plan

- [x] `tsc --noEmit` (both root and `media/tsconfig.json`) — passes
- [x] `eslint src media/src` — 0 errors (pre-existing warnings only, none in touched files)
- [x] `mocha` unit tests — 177 passing, including the `pricing` suite
- [ ] Manual spot-check in the extension UI (not run — no VS Code host available in this session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)