### PR TITLE
chore: upgrade CI, release, and Docker to Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18, 20]
+        node-version: [24]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: pnpm
 
       - name: Install dependencies
@@ -72,7 +72,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
 
       - name: Install vsce
         run: npm install -g @vscode/vsce
@@ -115,7 +115,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: pnpm
           # registry-url is required so setup-node writes the registry endpoint to
           # .npmrc. Without it, npm throws ENEEDAUTH before attempting OIDC.
@@ -124,7 +124,8 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Upgrade npm for OIDC Trusted Publishing
-        # Node 20 ships with npm 10.x. OIDC Trusted Publishing requires npm 11.x+.
+        # OIDC Trusted Publishing requires npm 11.x+; keep this in sync with
+        # whatever version ships bundled with the node-version above.
         run: npm install -g npm@latest
 
       - name: Install dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # ── Build stage ────────────────────────────────────────────────────────────────
-FROM --platform=$BUILDPLATFORM node:20-alpine AS builder
+FROM --platform=$BUILDPLATFORM node:24-alpine AS builder
 WORKDIR /app
 
 RUN npm install -g pnpm@10
@@ -17,7 +17,7 @@ COPY media/dashboard.css media/help-mascot.png media/mascot.png ./media/
 RUN node esbuild.js --production
 
 # ── Runtime stage ─────────────────────────────────────────────────────────────
-FROM node:20-alpine
+FROM node:24-alpine
 WORKDIR /app
 
 RUN addgroup -S agentlens && adduser -S agentlens -G agentlens

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "url": "https://github.com/RogerReed/agentlens"
   },
   "engines": {
-    "vscode": "^1.118.0"
+    "vscode": "^1.118.0",
+    "node": ">=24"
   },
   "icon": "media/mascot.png",
   "galleryBanner": {


### PR DESCRIPTION
## Summary

Standardizes the project on Node 24 across CI, the release workflow, and Docker — fixes the `publish-npm` job in `release.yml`, which is currently broken on Node 20: `npm install -g npm@latest` now installs an npm version that requires Node `^22.22.2 || ^24.15.0 || >=26`, so the step fails outright on Node 20 before it ever attempts to publish (this is what's been blocking npm publishing on the last couple of tag releases, most recently v0.8.6).

- `.github/workflows/ci.yml`: matrix reduced to a single Node 24 job (was `[18, 20]`)
- `.github/workflows/release.yml`: all three jobs (`package`, `publish-vsce`, `publish-npm`) now set up Node 24; updated a stale comment referencing Node 20's bundled npm version
- `Dockerfile`: both build and runtime stages now use `node:24-alpine` (was `node:20-alpine`)
- `package.json`: added `engines.node: ">=24"` to document the requirement (`engines.vscode` was already there for the VS Code compatibility range, which is unrelated and untouched)

Dropped Node 18/20 from the CI test matrix rather than adding 24 alongside them — worth flagging in case you wanted broader version coverage kept. Easy to re-add if so.

## Test plan

- [x] `tsc --noEmit` (both root and `media/tsconfig.json`) — passes
- [x] `eslint src media/src` — 0 errors (pre-existing warnings only)
- [x] `mocha` unit tests — 177 passing
- [x] Confirmed `media/dashboard.css` (a committed build artifact) was untouched by this change — an earlier local `--production` build run accidentally minified it, reverted before committing
- [ ] Actual CI run on this PR will validate the workflow YAML end-to-end
- [ ] Docker build not run locally (no Docker daemon in this session) — `docker.yml` only triggers on `v*` tags, so it won't run against this PR; worth a manual `docker build .` sanity check before the next release tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)