### PR TITLE
fix: collapse standalone sidebar by default, explain empty log-only tabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ Each signal includes a specific recommended action and a **Copy for {Agent}** bu
 
 ## Manual Configuration
 
-The VS Code extension configures agents automatically on first activation. For standalone or Docker mode, run the included setup scripts (see [Configuring Agents for Local / Docker](#configuring-agents-for-local--docker) above). Replace `4318` with your custom port if you changed `agentLens.otlpPort`.
+The VS Code extension and the standalone (`npx`) server both auto-configure Copilot, Claude Code, and Codex on every startup — it's idempotent, so it only rewrites a config file when something is actually missing or different, and does nothing on subsequent starts once already configured. The extension shows a one-time notification (and logs to the Output panel) only when it actually changes something; disable it with the `agentLens.autoConfigureAgents` setting if you'd rather manage agent config yourself. If you change an agent's OTEL settings by hand later and want AgentLens to reapply its own values, use the **Configure OTEL** button in the Settings panel (gear icon) instead of waiting for the next restart. Docker mode runs the same auto-configure code, but it writes to the *container's* filesystem, not your host machine, so it has no effect on your host agents unless you volume-mount their config paths in — use the setup scripts below instead. Replace `4318` with your custom port if you changed `agentLens.otlpPort`.
 
 ### GitHub Copilot
 
@@ -361,6 +361,7 @@ Open the VS Code Command Palette (`Cmd+Shift+P` / `Ctrl+Shift+P`) and search for
 | ------- | ------- | ----------- |
 | `agentLens.otlpPort` | `4318` | Local port for the OTLP trace receiver |
 | `agentLens.enableLogIngestion` | `true` | Read local session log files from Claude Code, Codex, and Copilot CLI. Disable if you only want OTEL data. |
+| `agentLens.autoConfigureAgents` | `true` | Automatically write OTEL telemetry settings into Claude Code's, Codex's, and Copilot's own configuration on every activation. Disabling leaves your agents' configuration untouched — use the **Configure OTEL** button in Settings for a one-off manual apply, or configure OTEL manually (see [Manual Configuration](#manual-configuration)). |
 | `agentLens.sessionRetentionDays` | `90` | How many days to keep session history in the local database |
 
 ## Agent Data Formats

--- a/media/src/App.tsx
+++ b/media/src/App.tsx
@@ -27,7 +27,10 @@ import { instructionFiles, appliedSuggestions, dismissedIds } from './tabs/Instr
 import { IngestionToggles, McpToggle } from './tabs/Settings'
 
 
-const sidebarOpen = signal(true)
+// Standalone opens with the left activity sidebar collapsed by default, since it
+// duplicates content already visible in the main dashboard. VS Code's native
+// sidebar (toggled via workbench commands, not this panel) defaults to open.
+const sidebarOpen = signal(window.__STANDALONE__ !== true)
 const configOpen = signal(false)
 const bellOpen = signal(false)
 

--- a/media/src/App.tsx
+++ b/media/src/App.tsx
@@ -10,7 +10,7 @@ import {
   sessionTextFilter, filteredSessions, evidenceSessionIds,
   sessionSortKey, sessionSortDir,
   workspaceFilter, availableWorkspaces, shortWorkspaceName,
-  enableOtelIngestion, enableLogIngestion, otlpPort,
+  enableOtelIngestion, enableLogIngestion, otlpPort, otelReconfigureResult, type OtelReconfigureResult,
 } from './state'
 import type { TimelineEntry, AgentFilter, InitiatorFilter, DataSourceFilter, WorkspaceFilter, DailyStatRow, LifetimeStats, BurnRate, Projection, SessionSummaryCard } from './types'
 
@@ -24,7 +24,7 @@ import { Help } from './tabs/Help'
 import { Patterns } from './tabs/Patterns'
 import { Automation, checkAutomations } from './tabs/Automation'
 import { instructionFiles, appliedSuggestions, dismissedIds } from './tabs/Instructions'
-import { IngestionToggles, McpToggle } from './tabs/Settings'
+import { IngestionToggles, McpToggle, OtelReconfigureButton } from './tabs/Settings'
 
 
 // Standalone opens with the left activity sidebar collapsed by default, since it
@@ -102,6 +102,7 @@ function ConfigPanel() {
         >×</button>
       </div>
       <IngestionToggles />
+      <OtelReconfigureButton />
       <McpToggle />
       <CollapsibleSection title="Alerts">
         <Alerts />
@@ -304,6 +305,7 @@ export function App() {
         enableOtelIngestion?: boolean
         enableLogIngestion?: boolean
         otlpPort?: number
+        results?: OtelReconfigureResult
       }
       if (msg.type === 'update') {
         if (msg.enableOtelIngestion !== undefined) enableOtelIngestion.value = msg.enableOtelIngestion
@@ -368,6 +370,8 @@ export function App() {
         appliedSuggestions.value = (msg as unknown as {records: typeof appliedSuggestions.value}).records
       } else if (msg.type === 'dismissedSuggestions' && Array.isArray((msg as unknown as {ids?: unknown}).ids)) {
         dismissedIds.value = new Set((msg as unknown as {ids: string[]}).ids)
+      } else if (msg.type === 'reconfigureOtelResult' && msg.results) {
+        otelReconfigureResult.value = msg.results
       } else if (msg.type === 'instructionApplied') {
         // Re-request applied list after successful apply — handled by appliedSuggestions message
       } else if (msg.type === 'searchResults' && msg.sessions != null) {

--- a/media/src/state.ts
+++ b/media/src/state.ts
@@ -117,6 +117,13 @@ export const enableOtelIngestion = signal(true)
 export const enableLogIngestion = signal(true)
 export const otlpPort = signal(4318)
 
+export type OtelReconfigureResult = {
+  claudeCode: { changed: boolean; error?: string }
+  codex: { changed: boolean; error?: string }
+  copilot: { changed: boolean; error?: string }
+} | { error: string }
+export const otelReconfigureResult = signal<OtelReconfigureResult | null>(null)
+
 // ── Session retention signals ─────────────────────────────────────────────────
 
 export const swRetainedSessions = signal<SessionSummaryCard[]>([])

--- a/media/src/styles/base.css
+++ b/media/src/styles/base.css
@@ -50,7 +50,8 @@ body { font-family: var(--vscode-font-family); color: var(--fg); background: var
 .flex-6 { display: flex; align-items: center; gap: 6px }
 .flex-8 { display: flex; align-items: center; gap: 8px }
 
-/* ── Component: sidebar toggle button in tab bar (VS Code extension only) ── */
+/* ── Component: sidebar toggle button in tab bar — toggles the native VS Code
+   sidebar view in the extension, or the #sa-sidebar panel in standalone ── */
 .sidebar-toggle-btn {
   padding: 6px 8px;
   cursor: pointer;

--- a/media/src/tabs/Flow.tsx
+++ b/media/src/tabs/Flow.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'preact/hooks'
 import { rangedSessions, sessionSummary, sessionTimelines, focusedSessionId, vscode } from '../state'
 import { getAgentSourceLabel, getAgentColor, formatMs, formatSessionTime } from '../utils'
 import { calcEntryCost, fmtUsd } from '../sessionMetrics'
+import { LogIngestionNote } from './IngestionNote'
 import type { SessionSummaryCard, TimelineEntry } from '../types'
 
 type FlowCanvasEl = HTMLCanvasElement & { __flowDraw?: () => void; __flowCenter?: () => void }
@@ -139,6 +140,9 @@ export function FlowCanvas({ sess, height = 520 }: { sess: SessionSummaryCard; h
   if (!sessionTimelines.value[sess.sessionId] && vscode) {
     vscode.postMessage({ type: 'loadSessionDetail', sessionId: sess.sessionId })
   }
+
+  const hasTimelineData = ((sessionTimelines.value[sess.sessionId] ?? sess.timeline) ?? [])
+    .some(e => e.type === 'llm' || e.type === 'tool')
 
   useEffect(() => {
     const canvas = canvasRef.current
@@ -628,6 +632,15 @@ export function FlowCanvas({ sess, height = 520 }: { sess: SessionSummaryCard; h
       if (prog) prog.textContent = (st.playbackIdx + 1) + ' / ' + st.playbackTurns.length
       draw()
     }, speedRef.current)
+  }
+
+  if (!hasTimelineData) {
+    return (
+      <div class="empty-state" style={`min-height:${Math.min(height, 160)}px;display:flex;flex-direction:column;align-items:center;justify-content:center`}>
+        No flow data for this session
+        {sess.dataSource === 'log' && <LogIngestionNote feature="flow" />}
+      </div>
+    )
   }
 
   return (

--- a/media/src/tabs/Help.tsx
+++ b/media/src/tabs/Help.tsx
@@ -204,6 +204,7 @@ chmod +x scripts/configure-agents.sh
         </tbody>
       </table>
       <p style="font-size:11px;color:var(--muted);margin:8px 0 0">Start a short <a href="#gl-session">session</a> and check whether a session card appears in the sidebar to confirm data is arriving.</p>
+      <p style="font-size:11px;color:var(--muted);margin:8px 0 0">Prefer not to run the script? The VS Code-family <strong>IDE extension</strong> version of AgentLens auto-configures OTEL for all supported agents automatically on activation — no script needed.</p>
     </div>
   ) : (
     <div style="margin-bottom:20px;background:var(--hover);border:1px solid var(--border);border-left:3px solid var(--warning,#ffb74d);border-radius:4px;padding:10px 14px">

--- a/media/src/tabs/Help.tsx
+++ b/media/src/tabs/Help.tsx
@@ -204,12 +204,12 @@ chmod +x scripts/configure-agents.sh
         </tbody>
       </table>
       <p style="font-size:11px;color:var(--muted);margin:8px 0 0">Start a short <a href="#gl-session">session</a> and check whether a session card appears in the sidebar to confirm data is arriving.</p>
-      <p style="font-size:11px;color:var(--muted);margin:8px 0 0">Prefer not to run the script? The VS Code-family <strong>IDE extension</strong> version of AgentLens auto-configures OTEL for all supported agents automatically on activation — no script needed.</p>
+      <p style="font-size:11px;color:var(--muted);margin:8px 0 0">Prefer not to run the script? The standalone server already tried to auto-configure OTEL for you on startup — check its terminal output for "configured" or "Could not auto-configure" lines. The VS Code-family <strong>IDE extension</strong> version of AgentLens does the same thing automatically on every activation, with an in-editor notification, if you'd rather run it that way — no script needed.</p>
     </div>
   ) : (
     <div style="margin-bottom:20px;background:var(--hover);border:1px solid var(--border);border-left:3px solid var(--warning,#ffb74d);border-radius:4px;padding:10px 14px">
       <p style="font-size:12px;font-weight:600;margin:0 0 8px;color:var(--foreground)">Not seeing any data?</p>
-      <p style="font-size:12px;color:var(--muted);margin:0 0 8px">AgentLens automatically configures all supported agents on first activation. Works in VS Code, Cursor, Windsurf, VSCodium, Trae, Kiro, and other VS Code-family IDEs. Just restart each <a href="#gl-agent">agent</a> once — <a href="#gl-session">sessions</a> will start appearing immediately.</p>
+      <p style="font-size:12px;color:var(--muted);margin:0 0 8px">AgentLens automatically configures all supported agents every time it activates — it only rewrites a config file when something's actually missing, so this is silent after the first successful run. Works in VS Code, Cursor, Windsurf, VSCodium, Trae, Kiro, and other VS Code-family IDEs. Just restart each <a href="#gl-agent">agent</a> once — <a href="#gl-session">sessions</a> will start appearing immediately. Changed an agent's OTEL settings yourself and want AgentLens's values back? Use the <strong>Configure OTEL</strong> button in Settings (gear icon) instead of waiting for the next restart. Disable auto-configuration entirely via the <code style={codeStyle}>agentLens.autoConfigureAgents</code> setting.</p>
       <p style="font-size:11px;color:var(--muted);margin:0 0 6px">Config is read at startup — restart after AgentLens activates:</p>
       <table style="font-size:11px;border-collapse:collapse;width:100%">
         <tbody style="color:var(--muted)">

--- a/media/src/tabs/IngestionNote.tsx
+++ b/media/src/tabs/IngestionNote.tsx
@@ -1,0 +1,14 @@
+import { goToHelp } from '../state'
+
+// Shown alongside an empty-state when a log-ingested session is missing data
+// that OTEL ingestion would have captured (e.g. Trace/Flow/Tools/Files).
+export function LogIngestionNote({ feature }: { feature: string }) {
+  return (
+    <div style="margin-top:8px;font-size:11px;color:var(--muted);line-height:1.5">
+      No {feature} data from local logs for this session.{' '}
+      <a onClick={() => goToHelp('help-config')} style="color:var(--vscode-textLink-foreground,#4fc3f7);cursor:pointer;text-decoration:underline">
+        Configuring OTEL ingestion
+      </a>{' '}would capture this.
+    </div>
+  )
+}

--- a/media/src/tabs/Sessions.tsx
+++ b/media/src/tabs/Sessions.tsx
@@ -3,7 +3,7 @@ import {
   filteredSessions, sessionSummary, sessionTimelines, burnRateData,
   focusedSessionId, vscode, ignoredInsightKeys,
   sessionSortKey, sessionSortDir, type SortKey,
-  workspaceFilter, shortWorkspaceName,
+  workspaceFilter, shortWorkspaceName, goToHelp,
 } from '../state'
 import {
   getAgentColor, getAgentSourceLabel, formatMs, formatCompact, formatSessionTime,
@@ -16,6 +16,7 @@ import { buildDisplaySummary } from '../utils'
 import { Step, StepRow } from './Traces'
 import { FlowCanvas } from './Flow'
 import { ToolsChart } from './Tools'
+import { LogIngestionNote } from './IngestionNote'
 import type { SessionSummaryCard } from '../types'
 
 // ── Session detail panel (shown in expanded row) ──────────────────────────────
@@ -133,7 +134,10 @@ function SessionDetail({ sess }: { sess: SessionSummaryCard }) {
                 <div style="margin-bottom:10px;padding:7px 10px;border-radius:4px;border-left:3px solid var(--vscode-editorWarning-foreground,#cca700);background:var(--hover);font-size:11px;color:var(--muted);line-height:1.5">
                   <span style="color:var(--vscode-editorWarning-foreground,#cca700);font-weight:600">Log-only session</span>
                   {' — '}
-                  {parts.join(', ')} not available from local logs. Enable OTEL ingestion via the Help tab for full telemetry.
+                  {parts.join(', ')} not available from local logs.{' '}
+                  <a onClick={() => goToHelp('help-config')} style="color:var(--vscode-textLink-foreground,#4fc3f7);cursor:pointer;text-decoration:underline">
+                    Enable OTEL ingestion
+                  </a>{' '}for full telemetry.
                 </div>
               )
             })()}
@@ -188,7 +192,12 @@ function SessionDetail({ sess }: { sess: SessionSummaryCard }) {
           <div>
             {steps.length === 0
               ? (timelines[sess.sessionId] !== undefined
-                  ? <div class="empty-state" style="padding:12px 0">No trace data for this session</div>
+                  ? (
+                    <div class="empty-state" style="padding:12px 0">
+                      No trace data for this session
+                      {sess.dataSource === 'log' && <LogIngestionNote feature="trace" />}
+                    </div>
+                  )
                   : <div class="empty-state" style="padding:12px 0">Loading…</div>)
               : (
                 <div class="waterfall">
@@ -222,7 +231,12 @@ function SessionDetail({ sess }: { sess: SessionSummaryCard }) {
         {section === 'files' && (
           <div>
             {sess.filesChanged.length === 0
-              ? <div class="empty-state" style="padding:12px 0">No files modified</div>
+              ? (
+                <div class="empty-state" style="padding:12px 0">
+                  No files modified
+                  {sess.dataSource === 'log' && <LogIngestionNote feature="file change" />}
+                </div>
+              )
               : (
                 <div style="display:flex;flex-direction:column;gap:3px">
                   {sess.filesChanged.map(f => (

--- a/media/src/tabs/Settings.tsx
+++ b/media/src/tabs/Settings.tsx
@@ -1,5 +1,5 @@
-import { useState } from 'preact/hooks'
-import { enableOtelIngestion, enableLogIngestion, otlpPort, vscode } from '../state'
+import { useEffect, useState } from 'preact/hooks'
+import { enableOtelIngestion, enableLogIngestion, otlpPort, vscode, otelReconfigureResult, type OtelReconfigureResult } from '../state'
 
 function sendConfig(key: string, value: boolean) {
   if (vscode) {
@@ -67,6 +67,57 @@ export function IngestionToggles() {
           Clear All Data
         </button>
       </div>
+    </div>
+  )
+}
+
+function summarizeReconfigure(result: OtelReconfigureResult): string {
+  if ('error' in result) return `Failed: ${result.error}`
+  const labels: Record<string, string> = { claudeCode: 'Claude Code', codex: 'Codex', copilot: 'Copilot' }
+  const changed = Object.entries(result).filter(([, r]) => r.changed).map(([k]) => labels[k])
+  const errors = Object.entries(result).filter(([, r]) => r.error).map(([k, r]) => `${labels[k]} (${r.error})`)
+  if (errors.length > 0) return `Failed: ${errors.join(', ')}`
+  if (changed.length === 0) return 'Already up to date — no changes needed.'
+  return `Configured: ${changed.join(', ')}. Restart the agent(s) to start streaming traces.`
+}
+
+export function OtelReconfigureButton() {
+  const [running, setRunning] = useState(false)
+  const result = otelReconfigureResult.value
+
+  function run() {
+    setRunning(true)
+    otelReconfigureResult.value = null
+    if (vscode) {
+      vscode.postMessage({ type: 'reconfigureOtel' })
+    } else {
+      fetch('/action', { method: 'POST', body: JSON.stringify({ type: 'reconfigureOtel' }),
+        headers: { 'Content-Type': 'application/json' } })
+        .then(r => r.json())
+        .then(results => { otelReconfigureResult.value = results })
+        .catch(e => { otelReconfigureResult.value = { error: String(e) } })
+        .finally(() => setRunning(false))
+    }
+  }
+
+  useEffect(() => {
+    if (result) setRunning(false)
+  }, [result])
+
+  return (
+    <div style="padding:12px 16px;border-bottom:1px solid var(--border)">
+      <div style="font-size:12px;font-weight:600;color:var(--fg);margin-bottom:4px">Configure OTEL</div>
+      <div style="font-size:11px;color:var(--muted);margin-bottom:8px">
+        Re-applies AgentLens's OTEL settings to Claude Code, Codex, and Copilot. AgentLens already does this automatically on startup — use this if you changed one of those agent's telemetry settings yourself and want to point it back at AgentLens.
+      </div>
+      <button
+        onClick={run}
+        disabled={running}
+        style="padding:3px 10px;font-size:11px;cursor:pointer;border:1px solid var(--border);border-radius:3px;background:transparent;color:var(--fg)"
+      >
+        {running ? 'Configuring…' : 'Configure OTEL'}
+      </button>
+      {result && <div style="font-size:11px;color:var(--muted);margin-top:6px">{summarizeReconfigure(result)}</div>}
     </div>
   )
 }

--- a/media/src/tabs/Tools.tsx
+++ b/media/src/tabs/Tools.tsx
@@ -1,5 +1,6 @@
 import { rangedSessions, COLORS } from '../state'
 import { getAgentColor, getAgentSourceLabel } from '../utils'
+import { LogIngestionNote } from './IngestionNote'
 import type { SessionSummaryCard } from '../types'
 
 // ── Shared donut chart (used by Tools tab and Sessions detail) ─────────────────
@@ -19,7 +20,13 @@ export function ToolsChart({ sessions }: { sessions: SessionSummaryCard[] }) {
   const entries = Object.entries(counts).sort((a, b) => b[1] - a[1])
 
   if (entries.length === 0) {
-    return <div class="empty-state">No tool calls recorded for this session</div>
+    const allLog = sessions.length > 0 && sessions.every(s => s.dataSource === 'log')
+    return (
+      <div class="empty-state">
+        No tool calls recorded for this session
+        {allLog && <LogIngestionNote feature="tool call" />}
+      </div>
+    )
   }
 
   const total = entries.reduce((sum, e) => sum + e[1], 0)

--- a/package.json
+++ b/package.json
@@ -149,7 +149,7 @@
         "agentLens.autoConfigureAgents": {
           "type": "boolean",
           "default": true,
-          "description": "Automatically write OTEL telemetry settings into Claude Code's (~/.claude/settings.json), Codex's (~/.codex/config.toml), and GitHub Copilot's own configuration so they send session data to AgentLens. Disabling this leaves your agents' configuration untouched — you can still configure OTEL manually (see the Help tab) or rely on agentLens.enableLogIngestion alone. Codex and Copilot CLI sessions have little to show without OTEL: their log files carry only aggregate totals, no per-turn tool calls or responses."
+          "description": "Automatically write OTEL telemetry settings into Claude Code's (~/.claude/settings.json), Codex's (~/.codex/config.toml), and GitHub Copilot's own configuration so they send session data to AgentLens. Runs on every activation but only rewrites a file when something's actually missing, so it's silent after the first successful run (shows a notification only when it changes something). Disabling this leaves your agents' configuration untouched — you can still trigger it manually with the Configure OTEL button in Settings, configure OTEL by hand (see the Help tab), or rely on agentLens.enableLogIngestion alone. Codex and Copilot CLI sessions have little to show without OTEL: their log files carry only aggregate totals, no per-turn tool calls or responses."
         },
         "agentLens.enableOtelIngestion": {
           "type": "boolean",

--- a/src/dashboardPanel.ts
+++ b/src/dashboardPanel.ts
@@ -4,6 +4,7 @@ import { SessionRepository } from './sessionRepository'
 import { InstructionRepository } from './database/instructionRepository'
 import { detectInstructionFiles, appendSuggestion, removeSuggestion } from './instructionFiles'
 import { computeBaseline } from './instructionEffectiveness'
+import { autoConfigureCopilot, autoConfigureClaudeCode, autoConfigureCodex } from './autoConfig'
 
 export class DashboardPanel {
   public static currentPanel: DashboardPanel | undefined
@@ -115,6 +116,14 @@ export class DashboardPanel {
         }
       } else if (msg.type === 'setVsCodeConfig' && typeof msg.key === 'string') {
         void vscode.workspace.getConfiguration('agentLens').update(msg.key as string, msg.value, vscode.ConfigurationTarget.Global)
+      } else if (msg.type === 'reconfigureOtel') {
+        const port = vscode.workspace.getConfiguration('agentLens').get<number>('otlpPort', 4318)
+        const [copilot, claudeCode, codex] = await Promise.all([
+          autoConfigureCopilot(port),
+          autoConfigureClaudeCode(port),
+          autoConfigureCodex(port),
+        ])
+        this.panel.webview.postMessage({ type: 'reconfigureOtelResult', results: { copilot, claudeCode, codex } })
       } else if (msg.type === 'getInstructionFiles' && msg.workspace) {
         const wsFolders = vscode.workspace.workspaceFolders
         const wsRoot = (wsFolders?.[0]?.uri.fsPath) ?? (msg.workspace as string)

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -208,6 +208,17 @@ export async function activate(context: vscode.ExtensionContext) {
     )
   }
 
+  const configuredAgents: string[] = []
+  if (copilotResult.changed) configuredAgents.push('Copilot')
+  if (claudeResult.changed) configuredAgents.push('Claude Code')
+  if (codexResult.changed) configuredAgents.push('Codex')
+  if (configuredAgents.length > 0) {
+    outputChannel.appendLine(`Auto-configured OTEL telemetry for: ${configuredAgents.join(', ')}`)
+    vscode.window.showInformationMessage(
+      `AgentLens configured OTEL telemetry for ${configuredAgents.join(', ')} — restart the agent(s) to start streaming traces. Disable via the agentLens.autoConfigureAgents setting.`
+    )
+  }
+
   // ── Panels ───────────────────────────────────────────────────────────────────
   const repo = repository ?? fallbackRepository(store)
   const provider = new SidebarPanel(repo, context.extensionUri)

--- a/src/sidebarPanel.ts
+++ b/src/sidebarPanel.ts
@@ -326,6 +326,11 @@ export class SidebarPanel implements vscode.WebviewViewProvider {
     padding: 8px 10px; margin-bottom: 8px; border-radius: 4px;
     font-size: 11px; line-height: 1.4;
   }
+  .sb-live-header {
+    font-size: 9px; text-transform: uppercase; letter-spacing: 0.5px;
+    color: var(--vscode-descriptionForeground); font-weight: 600;
+    padding-bottom: 6px; margin-bottom: 2px;
+  }
 </style>
 </head>
 <body>
@@ -338,6 +343,8 @@ export class SidebarPanel implements vscode.WebviewViewProvider {
   </div>` : ''}
 
   <div class="sb-body">
+
+    <div class="sb-live-header" title="Updates live as the current agent session progresses">Live &middot; Current Session Activity</div>
 
     <!-- Status row -->
     <div class="sb-card" style="margin-bottom:6px">

--- a/standalone/server.ts
+++ b/standalone/server.ts
@@ -953,7 +953,10 @@ function getHtml(): string {
 
   <div id="sa-wrap">
     <!-- ── Sidebar (live session monitor) ────────────────────────────────── -->
-    <div id="sa-sidebar">
+    <div id="sa-sidebar" class="sa-collapsed">
+      <div style="flex-shrink:0;padding:7px 10px;border-bottom:1px solid var(--vscode-panel-border)" title="Updates live as the current agent session progresses">
+        <span style="font-size:9px;text-transform:uppercase;letter-spacing:.5px;color:var(--vscode-descriptionForeground);font-weight:600">Live &middot; Current Session Activity</span>
+      </div>
       <div style="flex:1;overflow-y:auto;padding:8px 8px 8px;font-family:var(--vscode-font-family);color:var(--vscode-foreground)">
         <!-- Status row -->
         <div class="sb-card" style="margin-bottom:6px">

--- a/standalone/server.ts
+++ b/standalone/server.ts
@@ -1235,13 +1235,26 @@ const uiServer = http.createServer((req, res) => {
   if (req.method === 'POST' && url === '/action') {
     const chunks: Buffer[] = []
     req.on('data', (c: Buffer) => chunks.push(c))
-    req.on('end', () => {
+    req.on('end', async () => {
       try {
         const body = JSON.parse(Buffer.concat(chunks).toString('utf-8')) as { type?: string }
         if (body.type === 'clearAll') {
           spans = []
           try { fs.writeFileSync(DATA_FILE, '[]') } catch (e) { console.warn('[AgentLens] Could not clear data file:', e) }
           pushUpdate()
+        } else if (body.type === 'reconfigureOtel') {
+          const [claudeCode, codex, copilotResults] = await Promise.all([
+            autoConfigureClaudeCode(OTLP_PORT),
+            autoConfigureCodex(OTLP_PORT),
+            autoConfigureCopilotStandalone(OTLP_PORT),
+          ])
+          const copilot = {
+            changed: copilotResults.some(r => r.changed),
+            error: copilotResults.find(r => r.error)?.error,
+          }
+          res.writeHead(200, { 'Content-Type': 'application/json' })
+          res.end(JSON.stringify({ claudeCode, codex, copilot }))
+          return
         }
       } catch (e) { console.warn('[AgentLens] Malformed /action body:', e) }
       res.writeHead(200); res.end()

--- a/standalone/server.ts
+++ b/standalone/server.ts
@@ -910,6 +910,15 @@ function getHtml(): string {
                 }));
               })
               .catch(function(e) { console.warn('[AgentLens] timeline fetch failed', e); });
+          } else if (msg.type === 'reconfigureOtel') {
+            fetch('/action', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ type: 'reconfigureOtel' }) })
+              .then(function(r) { return r.json(); })
+              .then(function(results) {
+                window.dispatchEvent(new MessageEvent('message', { data: { type: 'reconfigureOtelResult', results: results } }));
+              })
+              .catch(function(e) {
+                window.dispatchEvent(new MessageEvent('message', { data: { type: 'reconfigureOtelResult', results: { error: String(e) } } }));
+              });
           }
         }
       };


### PR DESCRIPTION
## Summary
- Standalone's left "live session monitor" sidebar now defaults to collapsed (duplicated the main dashboard) and gained a "Live · Current Session Activity" header so its purpose is explicit once expanded; VS Code's own sidebar toggle is unaffected.
- The VS Code extension's own native sidebar view got the same "Live · Current Session Activity" header for consistency.
- Trace, Flow, Tools, and Files tabs now explain *why* they're blank for a log-only session instead of rendering silently empty, linking to the Help tab's OTEL setup section.
- Fixes Flow specifically: its tab label counts LLM calls from a field every ingestion path populates, but the canvas renders from the session timeline, which log ingestion leaves empty for Codex/Copilot — so a nonzero count next to an empty canvas is now a labeled empty state instead of a near-invisible canvas-drawn message.
- Help's standalone "not seeing any data?" callout now also mentions that the VS Code extension auto-configures OTEL automatically, as a no-script alternative.
- OTEL auto-configuration (writes into Claude Code's, Codex's, and Copilot's own config files) previously ran silently with no way to know it had touched files outside the extension's sandbox. Now: the VS Code extension shows an info toast and logs to the Output panel whenever it actually changes something (idempotent — stays silent once already configured). Added a "Configure OTEL" button in Settings (both VS Code and standalone) to manually re-apply AgentLens's OTEL values on demand, e.g. after changing an agent's telemetry config by hand. Docs (README, package.json setting description, in-app Help) updated to describe the actual behavior — runs on every activation, not just "first activation" as previously stated.

## Test plan
- [ ] Run standalone server, confirm left sidebar starts collapsed and expands with the new "Live · Current Session Activity" header
- [ ] Confirm VS Code extension's native sidebar toggle behavior is unchanged, and its sidebar view shows the new header
- [ ] Load a log-only (Codex/Copilot) session and check Trace, Flow, Tools, and Files tabs show the new empty-state explanation with working link to Help
- [ ] Load an OTEL-ingested session and confirm empty states are unaffected (no ingestion note shown) when data is genuinely absent
- [ ] Check Help tab standalone callout mentions the VS Code extension auto-config alternative
- [ ] Reload the VS Code extension with a stale/missing agent OTEL config and confirm the info toast + Output panel log appear, then confirm no toast on a second reload (idempotent)
- [ ] Click "Configure OTEL" in Settings (VS Code and standalone) after manually editing an agent's OTEL config; confirm it's reapplied and the button reports what changed
- [ ] Click "Configure OTEL" with everything already correctly configured; confirm it reports "Already up to date"

🤖 Generated with [Claude Code](https://claude.com/claude-code)