### PR TITLE
fix: UX review findings — export scope, chart labels, flow zoom, table scroll

### DIFF
--- a/media/dashboard.css
+++ b/media/dashboard.css
@@ -133,6 +133,23 @@ body {
   color: var(--fg);
   background: var(--hover);
 }
+.h-scroll-hint {
+  overflow-x: auto;
+  scrollbar-width: thin;
+}
+.h-scroll-hint::-webkit-scrollbar {
+  height: 7px;
+}
+.h-scroll-hint::-webkit-scrollbar-track {
+  background: transparent;
+}
+.h-scroll-hint::-webkit-scrollbar-thumb {
+  background: var(--border);
+  border-radius: 4px;
+}
+.h-scroll-hint::-webkit-scrollbar-thumb:hover {
+  background: var(--muted);
+}
 
 /* media/src/styles/toolbar.css */
 .toolbar {
@@ -1048,6 +1065,12 @@ body {
   color: var(--accent);
   opacity: 0.85;
   margin-top: auto;
+}
+.export-card-scope {
+  font-size: 11px;
+  color: var(--muted);
+  font-weight: 600;
+  margin-top: 6px;
 }
 .export-btn {
   margin-top: 4px;

--- a/media/src/styles/base.css
+++ b/media/src/styles/base.css
@@ -66,3 +66,15 @@ body { font-family: var(--vscode-font-family); color: var(--fg); background: var
   flex-shrink: 0;
 }
 .sidebar-toggle-btn:hover { color: var(--fg); background: var(--hover); }
+
+/* ── Component: always-visible thin scrollbar for horizontally-scrollable tables.
+   Default overlay scrollbars are invisible until hover, so at narrow widths (e.g. a
+   resized VS Code panel) there's no hint that columns like Duration/Cost exist off-screen. ── */
+.h-scroll-hint {
+  overflow-x: auto;
+  scrollbar-width: thin;
+}
+.h-scroll-hint::-webkit-scrollbar { height: 7px; }
+.h-scroll-hint::-webkit-scrollbar-track { background: transparent; }
+.h-scroll-hint::-webkit-scrollbar-thumb { background: var(--border); border-radius: 4px; }
+.h-scroll-hint::-webkit-scrollbar-thumb:hover { background: var(--muted); }

--- a/media/src/styles/export.css
+++ b/media/src/styles/export.css
@@ -109,6 +109,12 @@
   opacity: 0.85;
   margin-top: auto;
 }
+.export-card-scope {
+  font-size: 11px;
+  color: var(--muted);
+  font-weight: 600;
+  margin-top: 6px;
+}
 
 .export-btn {
   margin-top: 4px;

--- a/media/src/tabs/Analytics.tsx
+++ b/media/src/tabs/Analytics.tsx
@@ -257,7 +257,7 @@ export function Analytics() {
             </div>
           )}
           {dayRows.length > 0 && (
-            <div style="overflow-x:auto;margin-bottom:8px">
+            <div class="h-scroll-hint" style="margin-bottom:8px">
               <table style="border-collapse:collapse;font-size:10px;min-width:100%;white-space:nowrap">
                 <thead>
                   <tr style="border-bottom:1px solid var(--border)">

--- a/media/src/tabs/Cost.tsx
+++ b/media/src/tabs/Cost.tsx
@@ -340,14 +340,16 @@ export function CostBarChart({ sessions, mode }: { sessions: SessionSummaryCard[
         }
         isFirst = false
 
-        // Label only when far enough from the previous one
+        // Label only when far enough from the previous one. Anchor the gap check and the
+        // rendered text at the same point (midX) — anchoring render at x1 while checking
+        // gaps against midX let labels drift into each other for wide (multi-session) days.
         if (midX - lastLabelX >= MIN_LABEL_GAP) {
           const label = dk.length >= 10 ? dk.slice(5, 10) : dk
           ctx.font = labelFont
           ctx.fillStyle = textColor
-          ctx.textAlign = 'left'
+          ctx.textAlign = 'center'
           ctx.textBaseline = 'top'
-          ctx.fillText(label, x1 + 2, pad.top + 1)
+          ctx.fillText(label, midX, pad.top + 1)
           lastLabelX = midX
         }
       }
@@ -530,7 +532,7 @@ export function Cost() {
 
       {/* Session cost table */}
       <h3 style="margin:24px 0 8px;font-size:13px;color:var(--muted)">SESSION COST TABLE</h3>
-      <div style="overflow-x:auto">
+      <div class="h-scroll-hint">
         <table style="width:100%;border-collapse:collapse;font-size:11px">
           <thead>
             <tr style="border-bottom:1px solid var(--vscode-panel-border);color:var(--muted);text-align:left">

--- a/media/src/tabs/Export.tsx
+++ b/media/src/tabs/Export.tsx
@@ -15,6 +15,7 @@ export function Export() {
 
   const sessions = filteredSessions.value
   const empty = sessions.length === 0
+  const scopeLabel = `${sessions.length} session${sessions.length === 1 ? '' : 's'} matching your current filters`
 
   const doExport = () => {
     send('exportSessionData', sessions.map(s => s.sessionId))
@@ -39,7 +40,7 @@ export function Export() {
             <span class="export-card-badge export-badge-raw">Full</span>
           </div>
           <p class="export-card-desc">
-            All recorded sessions exported as JSON — includes prompt text, token counts,
+            Exported as JSON — includes prompt text, token counts,
             tool usage, file changes, cost estimates, and efficiency signals.
           </p>
           <ul class="export-card-includes">
@@ -49,6 +50,7 @@ export function Export() {
             <li>Duration, errors, outcome, loop signals</li>
           </ul>
           <div class="export-card-warning">Keep private — includes prompt text.</div>
+          <div class="export-card-scope">{empty ? 'No sessions match your current filters' : scopeLabel}</div>
           <button
             class={'export-btn' + (rawDone ? ' export-btn-done' : '')}
             onClick={doExport}
@@ -75,6 +77,7 @@ export function Export() {
             <li>✓ Duration, errors, outcome, loop signals</li>
           </ul>
           <div class="export-card-safe">Safer to share — no prompt text or file paths.</div>
+          <div class="export-card-scope">{empty ? 'No sessions match your current filters' : scopeLabel}</div>
           <button
             class={'export-btn export-btn-secondary' + (redactedDone ? ' export-btn-done' : '')}
             onClick={doRedacted}

--- a/media/src/tabs/Flow.tsx
+++ b/media/src/tabs/Flow.tsx
@@ -294,7 +294,9 @@ export function FlowCanvas({ sess, height = 520 }: { sess: SessionSummaryCard; h
       const gW = maxX - minX + 40, gH = maxY - minY + 40
       const rect = canvas.getBoundingClientRect()
       if (!rect.width || !rect.height) return
-      st.zoom = Math.max(0.15, Math.min(rect.width / gW, rect.height / gH, 1.4))
+      // Cap at 2.2x so small/sparse graphs still fill most of the canvas instead of
+      // leaving it mostly empty, while avoiding comically oversized nodes.
+      st.zoom = Math.max(0.15, Math.min(rect.width / gW, rect.height / gH, 2.2))
       st.panX = rect.width  / 2 - (minX + maxX) / 2 * st.zoom
       st.panY = rect.height / 2 - (minY + maxY) / 2 * st.zoom
     }

--- a/media/src/tabs/Patterns.tsx
+++ b/media/src/tabs/Patterns.tsx
@@ -166,7 +166,7 @@ function EfficiencyMap({ sessions }: { sessions: SessionSummaryCard[] }) {
           `padding:4px 8px 4px 0;color:${sort.col === col ? 'var(--fg)' : 'var(--muted)'};font-weight:500;white-space:nowrap;cursor:pointer;user-select:none;font-size:11px`
         const arrow = (col: MatchSort) => sort.col === col ? (sort.dir === 'desc' ? ' ↓' : ' ↑') : ''
         return (
-          <div style="margin-top:12px;overflow-x:auto">
+          <div class="h-scroll-hint" style="margin-top:12px">
             <table style="width:100%;border-collapse:collapse;font-size:11px">
               <thead>
                 <tr style="border-bottom:1px solid var(--border)">
@@ -390,7 +390,7 @@ function HotFiles({ sessions }: { sessions: SessionSummaryCard[] }) {
         <button class={'tab-mini' + (mode === 'written' ? ' active' : '')} onClick={() => setMode('written')}>Written</button>
         <button class={'tab-mini' + (mode === 'both'    ? ' active' : '')} onClick={() => setMode('both')}>Both</button>
       </div>
-      <div style="overflow-x:auto">
+      <div class="h-scroll-hint">
         <table style="width:100%;border-collapse:collapse;font-size:11px">
           <thead>
             <tr style="border-bottom:1px solid var(--border)">

--- a/media/src/tabs/Sessions.tsx
+++ b/media/src/tabs/Sessions.tsx
@@ -414,7 +414,7 @@ export function Sessions() {
 
   return (
     <div id="sessions-content" style="padding-top:8px">
-      <div style="overflow-x:auto">
+      <div class="h-scroll-hint">
       <table style="width:100%;border-collapse:collapse;font-size:11px">
         <thead>
           <tr style="border-bottom:2px solid var(--vscode-panel-border)">


### PR DESCRIPTION
## Summary

Ran a UX review over the dashboard (screenshots + DOM/CSS inspection via Playwright against the standalone build with real session data), and fixed the four issues found:

- **Export tab scope was misleading**: the copy said *"All recorded sessions exported as JSON"* but the export is actually scoped to `filteredSessions` (whatever Time/Agent/Source/text filters are active elsewhere in the app), with no count shown on the card. A user who filtered down earlier could silently export a partial subset while believing they got everything. Both cards now show *"N sessions matching your current filters"*.
- **Analytics daily-cost chart's x-axis date labels could overlap into illegible text** (e.g. `07-20` and `07-23` colliding). Root cause: the minimum-gap check compared day-group midpoints, but the label was rendered left-aligned at the group's start edge — a positional mismatch that let labels drift into each other for days with more sessions (wider bar groups). Render and gap-check now share the same anchor point.
- **Flow graph capped zoom at 1.4x** regardless of available canvas space, leaving small/sparse sessions rendered tiny in a mostly-empty canvas. Raised to 2.2x so small graphs fill more of the space.
- **Session/Analytics/Advisor data tables gave no visual hint they were horizontally scrollable** at narrow widths (e.g. a resized VS Code panel) — overlay scrollbars are invisible until hover. Added a persistent thin styled scrollbar (`.h-scroll-hint`) applied consistently across all four scrollable tables.

Note on the last item: I initially tried making the table header `position: sticky` so it'd stay visible during vertical scroll too, but the horizontal-scroll wrapper (`overflow-x: auto`) itself becomes the CSS "scroll container" that sticky positioning resolves against — so it can only stick relative to a box that doesn't itself scroll vertically. Fixing that properly needs a bigger layout restructuring than this finding warranted, so I kept the smaller, honest fix (styled scrollbar) rather than ship a broken sticky header.

## Test plan
- [ ] Export tab: apply a Time/Agent/Source filter, confirm both export cards show the correct filtered session count instead of implying "all sessions"
- [ ] Analytics tab: view the daily-cost chart over a date range with uneven session distribution across days; confirm all x-axis date labels are legible with no overlap
- [ ] Sessions tab: expand a session with few turns → Flow sub-tab; confirm the graph fills more of the canvas than before
- [ ] Resize to a narrow width (or dock the VS Code panel narrow); confirm a visible scrollbar appears on the Sessions table, Analytics cost-breakdown table, and Advisor's efficiency-map/hot-files tables
- [ ] Spot-check Analytics/Advisor tabs at normal width for visual regressions from the scrollbar-wrapper class swap

🤖 Generated with [Claude Code](https://claude.com/claude-code)