### PR TITLE
fix: cap span store to prevent RangeError: Invalid string length on save

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,7 @@ Environment variables:
 | `UI_PORT` | `3000` | Dashboard port |
 | `DATA_DIR` | `~/.agentlens` | Directory for persistent span data |
 | `BIND_HOST` | `127.0.0.1` | Set to `0.0.0.0` for LAN access |
+| `AGENTLENS_MAX_SPANS` | `50000` | Cap on in-memory/persisted spans; oldest spans are dropped once exceeded |
 
 The local server uses the same port as the VS Code extension — only one can run at a time. To run both simultaneously, use different ports:
 

--- a/src/spanStore.ts
+++ b/src/spanStore.ts
@@ -1,0 +1,23 @@
+import type { Span } from './types'
+
+/**
+ * Default cap on in-memory/persisted spans for the standalone server.
+ * Keeps spans.json well under V8's ~512MB max string length so
+ * JSON.stringify(spans) never throws RangeError: Invalid string length.
+ */
+export const DEFAULT_MAX_SPANS = 50_000
+
+// Only prune once the array drifts this far past the cap, so a steady stream
+// of ingestion doesn't trigger an O(n) splice on every single span.
+const PRUNE_BUFFER = 1_000
+
+/**
+ * Drops the oldest spans in place once `spans` exceeds `maxSpans` by more
+ * than the prune buffer. Returns the number of spans dropped (0 if none).
+ */
+export function pruneSpans(spans: Span[], maxSpans: number = DEFAULT_MAX_SPANS): number {
+  if (spans.length <= maxSpans + PRUNE_BUFFER) return 0
+  const dropped = spans.length - maxSpans
+  spans.splice(0, dropped)
+  return dropped
+}

--- a/src/test/spanStore.test.ts
+++ b/src/test/spanStore.test.ts
@@ -1,0 +1,44 @@
+import * as assert from 'assert'
+import { pruneSpans } from '../spanStore'
+import type { Span } from '../types'
+
+function makeSpans(n: number): Span[] {
+  return Array.from({ length: n }, (_, i) => ({
+    traceId: `trace-${i}`,
+    spanId: `span-${i}`,
+    name: 'test-span',
+    startTime: String(i),
+    endTime: String(i),
+    attributes: [],
+  }))
+}
+
+suite('spanStore', () => {
+  test('pruneSpans does nothing when under the cap', () => {
+    const spans = makeSpans(10)
+    const dropped = pruneSpans(spans, 100)
+    assert.strictEqual(dropped, 0)
+    assert.strictEqual(spans.length, 10)
+  })
+
+  test('pruneSpans does nothing until the buffer past the cap is exceeded', () => {
+    const spans = makeSpans(150)
+    const dropped = pruneSpans(spans, 100) // 150 <= 100 + 1000 buffer
+    assert.strictEqual(dropped, 0)
+    assert.strictEqual(spans.length, 150)
+  })
+
+  test('pruneSpans trims down to the cap once the buffer is exceeded', () => {
+    const spans = makeSpans(1200)
+    const dropped = pruneSpans(spans, 100) // 1200 > 100 + 1000 buffer
+    assert.strictEqual(dropped, 1100)
+    assert.strictEqual(spans.length, 100)
+  })
+
+  test('pruneSpans drops the oldest spans, keeping the most recent', () => {
+    const spans = makeSpans(1200)
+    pruneSpans(spans, 100)
+    assert.strictEqual(spans[0].spanId, 'span-1100')
+    assert.strictEqual(spans[spans.length - 1].spanId, 'span-1199')
+  })
+})

--- a/standalone/server.ts
+++ b/standalone/server.ts
@@ -22,17 +22,24 @@ import { generateSuggestions } from '../src/instructionAdvisor'
 import { detectInstructionFiles, appendSuggestion } from '../src/instructionFiles'
 import type { Span } from '../src/types'
 import type { SessionSummaryCard } from '../src/summarizers/summarizerTypes'
+import { pruneSpans, DEFAULT_MAX_SPANS } from '../src/spanStore'
 
 const OTLP_PORT  = parseInt(process.env.OTLP_PORT  ?? '4318')
 const UI_PORT    = parseInt(process.env.UI_PORT    ?? '3000')
 const MCP_PORT   = parseInt(process.env.MCP_PORT   ?? '4316')
 const BIND_HOST  = process.env.BIND_HOST ?? '127.0.0.1'
+const MAX_SPANS  = parseInt(process.env.AGENTLENS_MAX_SPANS ?? '') || DEFAULT_MAX_SPANS
 
 const mediaDir  = path.join(__dirname, '..', 'media')
 const DATA_DIR  = process.env.DATA_DIR ?? path.join(os.homedir(), '.agentlens')
 const DATA_FILE = path.join(DATA_DIR, 'spans.json')
 
 // ── Span store with file persistence ─────────────────────────────────────────
+//
+// The in-memory/persisted span list is capped at MAX_SPANS (see spanStore.ts)
+// to keep spans.json well under V8's max string length — without a cap,
+// JSON.stringify(spans) eventually throws RangeError: Invalid string length
+// and every save silently fails forever.
 
 let spans: Span[] = []
 let sseClients: http.ServerResponse[] = []
@@ -41,28 +48,53 @@ let sseClients: http.ServerResponse[] = []
 try {
   if (!fs.existsSync(DATA_DIR)) fs.mkdirSync(DATA_DIR, { recursive: true })
   if (fs.existsSync(DATA_FILE)) {
-    const raw = fs.readFileSync(DATA_FILE, 'utf-8')
-    spans = JSON.parse(raw) as Span[]
-    console.log(`[AgentLens] Loaded ${spans.length} spans from ${DATA_FILE}`)
+    const { size } = fs.statSync(DATA_FILE)
+    const MAX_LOADABLE_BYTES = 450 * 1024 * 1024 // stay clear of Node's ~512MB string ceiling
+    if (size > MAX_LOADABLE_BYTES) {
+      const backupFile = `${DATA_FILE}.bak`
+      fs.renameSync(DATA_FILE, backupFile)
+      console.warn(`[AgentLens] ${DATA_FILE} was ${(size / 1024 / 1024).toFixed(0)}MB — too large to load safely. Moved it to ${backupFile} and starting fresh.`)
+    } else {
+      const raw = fs.readFileSync(DATA_FILE, 'utf-8')
+      spans = JSON.parse(raw) as Span[]
+      const dropped = pruneSpans(spans, MAX_SPANS)
+      console.log(`[AgentLens] Loaded ${spans.length} spans from ${DATA_FILE}${dropped ? ` (dropped ${dropped} oldest to respect the ${MAX_SPANS}-span cap)` : ''}`)
+    }
   }
 } catch (e) {
   console.warn('[AgentLens] Could not load persisted data:', e)
+}
+
+function saveSpansNow() {
+  try {
+    fs.writeFileSync(DATA_FILE, JSON.stringify(spans))
+  } catch (e) {
+    if (e instanceof RangeError && spans.length > 1) {
+      const keep = Math.floor(spans.length / 2)
+      const dropped = spans.length - keep
+      spans.splice(0, dropped)
+      console.warn(`[AgentLens] Save failed (spans array too large to serialize) — dropped oldest ${dropped} spans and retrying`)
+      try { fs.writeFileSync(DATA_FILE, JSON.stringify(spans)) } catch (e2) {
+        console.warn('[AgentLens] Could not save data after emergency prune:', e2)
+      }
+    } else {
+      console.warn('[AgentLens] Could not save data:', e)
+    }
+  }
 }
 
 // Debounced save — writes at most once per second under continuous ingestion
 let saveTimer: ReturnType<typeof setTimeout> | null = null
 function scheduleSave() {
   if (saveTimer) clearTimeout(saveTimer)
-  saveTimer = setTimeout(() => {
-    try { fs.writeFileSync(DATA_FILE, JSON.stringify(spans)) } catch (e) {
-      console.warn('[AgentLens] Could not save data:', e)
-    }
-  }, 1000)
+  saveTimer = setTimeout(saveSpansNow, 1000)
 }
 
 function addSpan(span: Span) {
   if (span.receivedAt === undefined) span.receivedAt = Date.now()
   spans.push(span)
+  const dropped = pruneSpans(spans, MAX_SPANS)
+  if (dropped > 0) console.warn(`[AgentLens] Pruned ${dropped} oldest spans to stay under the ${MAX_SPANS}-span cap`)
 }
 
 // ── Log file sessions ─────────────────────────────────────────────────────────
@@ -1407,10 +1439,8 @@ uiServer.listen(UI_PORT, BIND_HOST, () => {
 
 function shutdown() {
   if (saveTimer) clearTimeout(saveTimer)
-  try {
-    fs.writeFileSync(DATA_FILE, JSON.stringify(spans))
-    console.log(`\n[AgentLens] Saved ${spans.length} spans to ${DATA_FILE}`)
-  } catch { /* ignore */ }
+  saveSpansNow()
+  console.log(`\n[AgentLens] Saved ${spans.length} spans to ${DATA_FILE}`)
   process.exit(0)
 }
 process.on('SIGINT', shutdown)


### PR DESCRIPTION
## Summary
- The standalone dashboard server kept every ingested span forever in memory and did a full `JSON.stringify(spans)` rewrite of `spans.json` every ~1s. Under heavy/long-term usage this array eventually exceeds V8's ~512MB max string length, so `JSON.stringify` throws `RangeError: Invalid string length` — saves fail silently forever, and once the file itself crosses that size it can no longer even be read back on startup.
- Adds `pruneSpans()` in `src/spanStore.ts`, a small pure/testable helper that caps the span array (default 50k spans, configurable via `AGENTLENS_MAX_SPANS`), enforced on ingest and applied after loading a persisted file.
- Guards the startup load path: if `spans.json` is already too large to load safely (>450MB), it's moved to `spans.json.bak` instead of crashing, and the server starts fresh.
- Adds a self-healing fallback in the save path: if a save ever throws `RangeError` anyway, halve the in-memory array and retry once, with a clear warning, instead of failing forever.

## Test plan
- [x] `pnpm run check-types` passes
- [x] `pnpm run lint` — 0 errors (pre-existing unrelated warnings only)
- [x] New unit tests (`src/test/spanStore.test.ts`) pass, run via mocha's programmatic API (the `mocha` CLI itself is currently broken under Node v26 in this environment due to a `yargs` ESM/CJS interop issue — pre-existing, unrelated to this change, confirmed identical failure on `main`)
- [x] Manually reproduced the reported crash: built a ~460MB `spans.json`, started the server against it, confirmed it logs a clear warning, backs up the oversized file to `.bak`, and starts cleanly instead of crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)