### PR TITLE
chore: refresh model pricing per PRICING_SOURCES.md runbook (2026-08-07)

### DIFF
--- a/PRICING_SOURCES.md
+++ b/PRICING_SOURCES.md
@@ -24,7 +24,7 @@ Copilot has three billing models depending on plan type and date.
 
 **Who it applies to:** All Copilot plans on the new billing model, default from June 1, 2026.
 
-**Source:** <https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing> (verified 2026-07-19)
+**Source:** <https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing> (verified 2026-08-07)
 
 **What this page provides:**
 
@@ -46,7 +46,7 @@ aiCredits = cost / 0.01
 **Who it applies to:** Copilot annual-plan holders who opt to stay on request-based billing
 after June 1, 2026. These users face significantly higher multipliers than the pre-June rates.
 
-**Source:** <https://docs.github.com/en/copilot/reference/copilot-billing/model-multipliers-for-annual-plans> (verified 2026-07-19)
+**Source:** <https://docs.github.com/en/copilot/reference/copilot-billing/model-multipliers-for-annual-plans> (verified 2026-08-07)
 
 **What this page provides:**
 
@@ -89,9 +89,27 @@ sessions; don't expect to re-verify them.
 
 - **Copilot code review multiplier**: not currently modeled in `pricing.ts` — AgentLens doesn't
   distinguish code-review-triggered requests from regular premium requests.
-- `gpt-4.1`, `gpt-4o`, `gpt-4o-mini` are no longer listed on the current AI Credits pricing page
-  at all (paid or included). Kept in `RATES` at their legacy rate for historical/legacy sessions;
-  treat as deprecated.
+- `gpt-4o`, `gpt-4o-mini` are no longer listed on the current AI Credits pricing page at all (paid
+  or included). Kept in `RATES` at their legacy rate for historical/legacy sessions; treat as
+  deprecated. `gpt-4.1` **is** listed again as of 2026-08-07 (real rates: $2.00/$0.50/$8.00) — it
+  was previously assumed delisted/$0; that assumption was wrong or stale and has been corrected.
+- **Long-context surcharge tier** (GPT-5.4, GPT-5.5, and the whole GPT-5.6 family): confirmed to
+  exist — Copilot's pricing page lists a distinct "Long context" row for each, consistently at 2x
+  the default input/cache-read/cache-write rate and 1.5x the default output rate. The token
+  threshold that triggers it is still not stated anywhere we've found (for GPT-5.4 it's rumored to
+  be 272K based on its context window, but that's unconfirmed). Not implemented — `RATES` holds
+  only the default-tier rate. Don't wire this up with a guessed threshold; a wrong threshold would
+  silently mis-price every session that crosses it, which is worse than the current known
+  under-count for long-context calls.
+- `gpt-5.1-codex`, `gpt-5.1-codex-mini`, `gpt-5.1-codex-max`: not independently re-confirmed in the
+  2026-08-07 refresh — absent from the general API pricing page (only base `gpt-5.1` was listed,
+  and it turned out to have been repriced down to $1.25/$10.00 from $1.75/$14.00). Left unchanged
+  at their prior values on the assumption they didn't move, but that's unverified — re-check next
+  refresh.
+- **New third-party marketplace models** (`grok-4.5`, `kimi-k3`, `gemini-3.6-flash`): added
+  2026-08-07 from the Copilot pricing page. Exact telemetry model-ID slugs are unconfirmed (guessed
+  from the docs display name, following the existing naming convention) — verify against real
+  telemetry when encountered.
 
 ---
 
@@ -103,7 +121,7 @@ Claude Code CLI uses Anthropic API token-based pricing only — no request-multi
 
 **Who it applies to:** All Claude Code CLI users billed through the Anthropic API.
 
-**Source:** <https://platform.claude.com/docs/en/about-claude/pricing> (verified 2026-07-19)
+**Source:** <https://platform.claude.com/docs/en/about-claude/pricing> (verified 2026-08-07)
 
 **Formula:**
 
@@ -132,10 +150,11 @@ On `claude_code.llm_request` spans (per-API-call):
 - `ttft_ms` — time to first token in ms
 - `stop_reason` — e.g. `tool_use`, `end_turn`
 
-**Rates (USD per 1M tokens, verified 2026-07-19):**
+**Rates (USD per 1M tokens, verified 2026-08-07):**
 
 | Model                                                                  | Input  | Cache Write (5m) | Cache Write (1h) | Cache Read | Output  |
 | ----------------------------------------------------------------------- | ------ | ----------------- | ----------------- | ---------- | ------- |
+| `claude-opus-5`                                                          | $5.00  | $6.25              | $10.00             | $0.50      | $25.00  |
 | `claude-opus-4-8`                                                        | $5.00  | $6.25              | $10.00             | $0.50      | $25.00  |
 | `claude-opus-4-7`                                                        | $5.00  | $6.25              | $10.00             | $0.50      | $25.00  |
 | `claude-opus-4-6`                                                        | $5.00  | $6.25              | $10.00             | $0.50      | $25.00  |
@@ -148,15 +167,18 @@ On `claude_code.llm_request` spans (per-API-call):
 | `claude-haiku-4-5`                                                       | $1.00  | $1.25              | $2.00              | $0.10      | $5.00   |
 | `claude-fable-5`                                                         | $10.00 | $12.50             | $20.00             | $1.00      | $50.00  |
 | `claude-mythos-5` (limited availability, see anthropic.com/glasswing)   | $10.00 | $12.50             | $20.00             | $1.00      | $50.00  |
+| `claude-opus-5` (fast mode, 2x)                                          | $10.00 | $12.50             | $20.00             | $1.00      | $50.00  |
 | `claude-opus-4-8` (fast mode, 2x)                                        | $10.00 | $12.50             | $20.00             | $1.00      | $50.00  |
-| `claude-opus-4-7` (fast mode, 6x)                                        | $30.00 | $37.50             | $60.00             | $3.00      | $150.00 |
+| `claude-opus-4-7` (fast mode, 6x — **historical only, removed**)        | $30.00 | $37.50             | $60.00             | $3.00      | $150.00 |
 | `claude-opus-4-6` (fast mode — bills at standard rate, see note below)  | $5.00  | $6.25              | $10.00             | $0.50      | $25.00  |
 
-Fast mode is currently only available for Opus 4.7 and 4.8. `claude-opus-4-6` no longer supports
-fast mode — requests with `speed: "fast"` run at standard speed and bill at the standard rate, so
-its `-fast` entry in `RATES` is set equal to the standard rate rather than a multiplied one.
-Opus 4.7 fast mode is deprecated and scheduled for removal on 2026-07-24 — after that date, check
-whether the source page still lists it and update or drop the entry accordingly.
+Fast mode is currently available only for Opus 5 and Opus 4.8 (both listed together, same rate, on
+Anthropic's fast-mode pricing table). As of this refresh (2026-08-07), Anthropic's docs explicitly
+confirm Opus 4.7 fast mode has been removed — requests with `speed: "fast"` now return an error
+rather than being billed. Its `-fast` entry in `RATES` is frozen for historical sessions only.
+`claude-opus-4-6` still doesn't support fast mode — requests with `speed: "fast"` run at standard
+speed and bill at the standard rate, so its `-fast` entry is set equal to the standard rate rather
+than a multiplied one.
 
 **Tiered pricing — `claude-sonnet-4` only:**
 
@@ -202,8 +224,8 @@ Codex CLI uses OpenAI token-based pricing only — no request-multiplier system.
 
 **Sources:**
 
-- Rate card (official, may require login): <https://help.openai.com/en/articles/20001106-codex-rate-card> — returned 403 on 2026-07-19; requires an authenticated session to fetch.
-- Codex CLI pricing page (credits; divide by 25 for USD): <https://developers.openai.com/codex/pricing>
+- Rate card (official, may require login): <https://help.openai.com/en/articles/20001106-codex-rate-card> — returned 403 on 2026-07-19; requires an authenticated session to fetch. Not re-attempted 2026-08-07.
+- Codex CLI pricing page (credits; divide by 25 for USD): <https://developers.openai.com/codex/pricing> — as of 2026-08-07 this 308-redirects to <https://learn.chatgpt.com/docs/pricing>; use that URL directly.
 - API pricing (USD, includes codex models): <https://developers.openai.com/api/docs/pricing>
 - `codex-mini-latest` model spec: <https://developers.openai.com/api/docs/models/codex-mini-latest>
 - Prompt caching mechanics: <https://developers.openai.com/api/docs/guides/prompt-caching>
@@ -237,31 +259,40 @@ On `session_task.turn` spans (per-turn aggregate):
 
 Model name available on `codex.user_prompt`, `codex.turn_ttft`, and `codex.tool_decision` spans via `model` attribute.
 
-**Rates (USD per 1M tokens, verified 2026-07-19):**
+**Rates (USD per 1M tokens, verified 2026-08-07):**
 
-| Model                   | Input   | Cached Input | Output  | Cache discount | Notes                                          |
-| ----------------------- | ------- | ------------ | ------- | -------------- | ---------------------------------------------- |
-| `gpt-5.6-sol`           | $5.00   | $0.50        | $30.00  | 90%            | Flagship; same rate as gpt-5.5; has a long-context surcharge tier, threshold unconfirmed |
-| `gpt-5.6-terra`         | $2.50   | $0.25        | $15.00  | 90%            | Mid tier; same rate as gpt-5.4                 |
-| `gpt-5.6-luna`          | $1.00   | $0.10        | $6.00   | 90%            | Small/fast tier                                |
-| `gpt-5.5`               | $5.00   | $0.50        | $30.00  | 90%            |                                                 |
-| `gpt-5.4`               | $2.50   | $0.25        | $15.00  | 90%            |                                                 |
-| `gpt-5.4-mini`          | $0.75   | $0.075       | $4.50   | 90%            |                                                 |
-| `gpt-5.3-codex`         | $1.75   | $0.175       | $14.00  | 90%            | Deprecated — superseded by the GPT-5.6 family  |
-| `gpt-5.3-codex-spark`   | TBD     | TBD          | TBD     | —              | Research preview; specialized low-latency hardware; not available in the API, no rates published |
-| `gpt-5.2`               | $1.75   | $0.175       | $14.00  | 90%            | Deprecated                                     |
-| `gpt-5.1-codex`         | $1.75   | $0.175       | $14.00  | 90%            | Deprecated                                     |
-| `gpt-5.1-codex-mini`    | $0.75   | $0.075       | $4.50   | 90%            | Deprecated                                     |
-| `codex-mini-latest`     | $1.50   | $0.375       | $6.00   | 75%            | Fine-tuned o4-mini; 200K ctx; deprecated       |
+| Model                   | Input   | Cached Input | Cache Write | Output  | Cache discount | Notes                                          |
+| ----------------------- | ------- | ------------ | ----------- | ------- | -------------- | ---------------------------------------------- |
+| `gpt-5.6-sol`           | $5.00   | $0.50        | $6.25       | $30.00  | 90%            | Flagship; same rate as gpt-5.5; has a long-context surcharge tier (2x input/cache, 1.5x output — threshold unconfirmed) |
+| `gpt-5.6-terra`         | $2.00   | $0.20        | $2.50       | $12.00  | 90%            | Mid tier. Corrected 2026-08-07 (was $2.50/$15.00) |
+| `gpt-5.6-luna`          | $0.20   | $0.02        | $0.25       | $1.20   | 90%            | Small/fast tier. Corrected 2026-08-07 (was $1.00/$6.00) |
+| `gpt-5.5`               | $5.00   | $0.50        | —           | $30.00  | 90%            | Long-context surcharge tier (2x input/cache, 1.5x output — threshold unconfirmed) |
+| `gpt-5.4`               | $2.50   | $0.25        | —           | $15.00  | 90%            | Long-context surcharge tier (2x input/cache, 1.5x output — threshold unconfirmed, possibly 272K) |
+| `gpt-5.4-mini`          | $0.75   | $0.075       | —           | $4.50   | 90%            |                                                 |
+| `gpt-5.3-codex`         | $1.75   | $0.175       | —           | $14.00  | 90%            | Deprecated — superseded by the GPT-5.6 family  |
+| `gpt-5.3-codex-spark`   | TBD     | TBD          | —           | TBD     | —              | Research preview; specialized low-latency hardware; not available in the API, no rates published |
+| `gpt-5.2`               | $1.75   | $0.175       | —           | $14.00  | 90%            | Deprecated                                     |
+| `gpt-5.1`               | $1.25   | $0.125       | —           | $10.00  | 90%            | Corrected 2026-08-07 (was $1.75/$14.00 — repriced down below gpt-5.2) |
+| `gpt-5.1-codex`         | $1.75   | $0.175       | —           | $14.00  | 90%            | Deprecated; not independently re-confirmed 2026-08-07 (see Known gaps) |
+| `gpt-5.1-codex-mini`    | $0.75   | $0.075       | —           | $4.50   | 90%            | Deprecated; not independently re-confirmed 2026-08-07 (see Known gaps) |
+| `gpt-4.1`               | $2.00   | $0.50        | —           | $8.00   | 75%            | Re-listed 2026-08-07 — previously assumed delisted/$0; that was wrong or stale |
+| `codex-mini-latest`     | $1.50   | $0.375       | —           | $6.00   | 75%            | Fine-tuned o4-mini; 200K ctx; deprecated       |
 
 **Credits to USD conversion:** Rates on the Codex CLI pricing page are expressed in credits. 1 USD = 25 credits — verify by checking `inputPerMTok × 25` against the listed credits figure for any current model (e.g. gpt-5.6-sol: $5.00 × 25 = 125 credits, matching the page).
 
 **Known gaps:**
 
-- Long-context surcharges: `gpt-5.5` and `gpt-5.6-sol` have a long-context tier ($10/$1.00/$45 above a certain token threshold — verify the cutoff from the API pricing page). Not yet implemented.
+- Long-context surcharges: `gpt-5.4`, `gpt-5.5`, and the whole `gpt-5.6` family have a long-context
+  tier. As of 2026-08-07 the multiplier pattern is confirmed (2x input/cache-read/cache-write, 1.5x
+  output) via Copilot's pricing page, but the token threshold that triggers it is still not stated
+  anywhere found. Not implemented — don't wire this up with a guessed threshold.
 - `gpt-5.3-codex-spark`: research preview with no published rates.
 - Reasoning tokens (`codex.usage.reasoning_output_tokens`): included in `gen_ai.usage.output_tokens` and billed at the standard output rate per available data; verify against the official rate card once it's fetchable (see Sources above).
 - Which GPT-5.6 variant (Sol/Terra/Luna) is the actual default model invoked by plain `codex` CLI runs (as opposed to an explicit model flag) is not confirmed by public docs.
+- `gpt-5.1-codex`, `gpt-5.1-codex-mini`, `gpt-5.1-codex-max`: absent from the general API pricing
+  page during the 2026-08-07 refresh (only base `gpt-5.1` was listed, and it had in fact been
+  repriced). Left unchanged on the assumption they didn't move — re-verify next refresh, ideally
+  against the auth-gated rate card directly.
 
 ---
 
@@ -273,7 +304,7 @@ OpenCode uses token-based pricing for third-party models (routed through its pro
 
 **Who it applies to:** Users of OpenCode's built-in Zen model tier during the limited evaluation period.
 
-**Source:** <https://opencode.ai/docs/zen/> (verified 2026-07-19)
+**Source:** <https://opencode.ai/docs/zen/> (verified 2026-08-07)
 
 **Rates:** $0 — free during evaluation. All token fields (`inputPerMTok`, `cacheReadPerMTok`, `cacheWritePerMTok`, `outputPerMTok`) are set to 0 in the rate table.
 
@@ -282,7 +313,7 @@ OpenCode uses token-based pricing for third-party models (routed through its pro
 **Known gaps:**
 
 - big-pickle pricing is stated as free "during limited evaluation" — it may become paid in the future. Check the source URL and update the rate table when rates are published.
-- **Other free Zen-exclusive models not yet in `RATES`:** OpenCode Zen also lists DeepSeek V4 Flash Free, MiMo-V2.5 Free, North Mini Code Free, and Nemotron 3 Ultra Free as $0 models, alongside 40+ paid third-party models (GPT, Claude, Gemini, Grok, DeepSeek, Qwen, MiniMax, GLM, Kimi families). Not added here because their exact `id` string as it appears in the OpenCode SQLite `model` JSON column isn't confirmed — guessing the wrong slug would silently fail to match rather than cause harm (missing models fall back to `~$?`), but confirm from real telemetry (or the OpenCode Zen model list API) before adding.
+- **Other free Zen-exclusive models not yet in `RATES`:** OpenCode Zen also lists DeepSeek V4 Flash Free, MiMo-V2.5 Free, North Mini Code Free, Nemotron 3 Ultra Free, and — new as of the 2026-08-07 refresh — Laguna S 2.1 Free, Ling-3.0-tiny Free, and LongCat-2.0 Free as $0 models, alongside 40+ paid third-party models (GPT, Claude, Gemini, Grok, DeepSeek, Qwen, MiniMax, GLM, Kimi families). Not added here because their exact `id` string as it appears in the OpenCode SQLite `model` JSON column isn't confirmed — guessing the wrong slug would silently fail to match rather than cause harm (missing models fall back to `~$?`), but confirm from real telemetry (or the OpenCode Zen model list API) before adding.
 - Other models used through OpenCode (e.g. Anthropic, OpenAI, or Google models routed via OpenCode's provider abstraction) are billed by the underlying provider at their standard rates. AgentLens applies the provider's published rates for those models automatically.
 
 ---

--- a/media/src/pricing.ts
+++ b/media/src/pricing.ts
@@ -2,7 +2,7 @@
 // Token rates (post Jun 1, 2026):        https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing
 // Request multipliers (pre Jun 1, 2026): https://docs.github.com/en/copilot/concepts/billing/copilot-requests
 // Annual-plan multipliers (post Jun 1):  https://docs.github.com/en/copilot/reference/copilot-billing/model-multipliers-for-annual-plans
-export const PRICING_LAST_UPDATED = '2026-07-19'
+export const PRICING_LAST_UPDATED = '2026-08-07'
 
 // Three billing modes:
 //   'token'          — new token-based AI Credits billing, effective Jun 1, 2026
@@ -30,8 +30,9 @@ export interface ModelRates {
 const RATES: Record<string, ModelRates> = {
   // ── OpenAI ─────────────────────────────────────────────────────────────────────────────────────
   //                                                                     token rates ──────────────────────────────────── │ pre-Jun1  │ annual post-Jun1
-  // gpt-4.1: no longer listed on the current pricing page — kept at legacy $0 rate for historical sessions.
-  'gpt-4.1':             { inputPerMTok: 0,     cacheReadPerMTok: 0,      cacheWritePerMTok: 0, outputPerMTok: 0,     multiplier: 0,    multiplierAnnualPostJun1: 1 },
+  // gpt-4.1: re-listed on the pricing page as of 2026-08-07 at real rates (previously assumed delisted/$0 —
+  // that turned out to be wrong or stale; correcting to the live page value).
+  'gpt-4.1':             { inputPerMTok: 2.00,  cacheReadPerMTok: 0.50,   cacheWritePerMTok: 0, outputPerMTok: 8.00,  multiplier: 0,    multiplierAnnualPostJun1: 1 },
   // gpt-5-mini: no longer included/$0 as of 2026-07-19 — now billed at standard token rates.
   'gpt-5-mini':          { inputPerMTok: 0.25,  cacheReadPerMTok: 0.025,  cacheWritePerMTok: 0, outputPerMTok: 2.00,  multiplier: 0,    multiplierAnnualPostJun1: 0.33 },
   'gpt-5 mini':          { inputPerMTok: 0.25,  cacheReadPerMTok: 0.025,  cacheWritePerMTok: 0, outputPerMTok: 2.00,  multiplier: 0,    multiplierAnnualPostJun1: 0.33 },
@@ -39,7 +40,10 @@ const RATES: Record<string, ModelRates> = {
   'gpt-4o':              { inputPerMTok: 2.50,  cacheReadPerMTok: 1.25,   cacheWritePerMTok: 0, outputPerMTok: 10.00, multiplier: 0,    multiplierAnnualPostJun1: 0.33 },
   'gpt-4o-mini':         { inputPerMTok: 0.15,  cacheReadPerMTok: 0.075,  cacheWritePerMTok: 0, outputPerMTok: 0.60,  multiplier: 0,    multiplierAnnualPostJun1: 0.33 },
   // GPT-5.1 family — in annual-plan table but not in new token pricing (request-only models)
-  'gpt-5.1':             { inputPerMTok: 1.75,  cacheReadPerMTok: 0.175,  cacheWritePerMTok: 0, outputPerMTok: 14.00, multiplier: 1,    multiplierAnnualPostJun1: 3 },
+  // gpt-5.1 corrected 2026-08-07 — was $1.75/$14.00, live pricing page now shows $1.25/$10.00 (older-gen model
+  // repriced down below gpt-5.2). gpt-5.1-codex/-mini/-max not independently re-confirmed this round — left
+  // unchanged, see PRICING_SOURCES.md Known gaps.
+  'gpt-5.1':             { inputPerMTok: 1.25,  cacheReadPerMTok: 0.125,  cacheWritePerMTok: 0, outputPerMTok: 10.00, multiplier: 1,    multiplierAnnualPostJun1: 3 },
   'gpt-5.1-codex':       { inputPerMTok: 1.75,  cacheReadPerMTok: 0.175,  cacheWritePerMTok: 0, outputPerMTok: 14.00, multiplier: 1,    multiplierAnnualPostJun1: 3 },
   'gpt-5.1-codex-mini':  { inputPerMTok: 0.75,  cacheReadPerMTok: 0.075,  cacheWritePerMTok: 0, outputPerMTok: 4.50,  multiplier: 0.33, multiplierAnnualPostJun1: 0.33 },
   'gpt-5.1-codex-max':   { inputPerMTok: 1.75,  cacheReadPerMTok: 0.175,  cacheWritePerMTok: 0, outputPerMTok: 14.00, multiplier: 1,    multiplierAnnualPostJun1: 3 },
@@ -51,11 +55,15 @@ const RATES: Record<string, ModelRates> = {
   'gpt-5.4-mini':        { inputPerMTok: 0.75,  cacheReadPerMTok: 0.075,  cacheWritePerMTok: 0, outputPerMTok: 4.50,  multiplier: 0.33, multiplierAnnualPostJun1: 6 },
   'gpt-5.4-nano':        { inputPerMTok: 0.20,  cacheReadPerMTok: 0.02,   cacheWritePerMTok: 0, outputPerMTok: 1.25,  multiplier: 0.25, multiplierAnnualPostJun1: 0.25 },
   'gpt-5.5':             { inputPerMTok: 5.00,  cacheReadPerMTok: 0.50,   cacheWritePerMTok: 0, outputPerMTok: 30.00, multiplier: 7.5,  multiplierAnnualPostJun1: 57 },  // annual multiplier corrected 2026-07-19 (was 7.5); long-context surcharge (>unknown threshold) not implemented
-  // gpt-5.6 family (new as of 2026-07-19): Luna (small/fast), Terra (mid, ~gpt-5.4 pricing), Sol (flagship, ~gpt-5.5 pricing).
-  // Not yet listed on the annual-plan multiplier page — multiplierAnnualPostJun1 set to 0 until published.
-  'gpt-5.6-luna':        { inputPerMTok: 1.00,  cacheReadPerMTok: 0.10,   cacheWritePerMTok: 0, outputPerMTok: 6.00,  multiplier: 0,    multiplierAnnualPostJun1: 0 },
-  'gpt-5.6-terra':       { inputPerMTok: 2.50,  cacheReadPerMTok: 0.25,   cacheWritePerMTok: 0, outputPerMTok: 15.00, multiplier: 0,    multiplierAnnualPostJun1: 0 },
-  'gpt-5.6-sol':         { inputPerMTok: 5.00,  cacheReadPerMTok: 0.50,   cacheWritePerMTok: 0, outputPerMTok: 30.00, multiplier: 0,    multiplierAnnualPostJun1: 0 },  // long-context surcharge (>unknown threshold) not implemented
+  // gpt-5.6 family: Luna (small/fast), Terra (mid), Sol (flagship). Corrected 2026-08-07 — Luna and Terra were
+  // repriced down (Luna $1.00→$0.20 input, Terra $2.50→$2.00 input), and the whole family gained real cache-write
+  // pricing (1.25x input, confirmed across the Copilot docs, OpenAI's pricing page, and the Codex credits page).
+  // Still not yet listed on the annual-plan multiplier page — multiplierAnnualPostJun1 stays 0 until published.
+  // A "long context" surcharge tier also exists above an unconfirmed token threshold (~2x input/cache, ~1.5x
+  // output per Copilot's docs) — not implemented; see PRICING_SOURCES.md Known gaps.
+  'gpt-5.6-luna':        { inputPerMTok: 0.20,  cacheReadPerMTok: 0.02,   cacheWritePerMTok: 0.25, outputPerMTok: 1.20,  multiplier: 0,    multiplierAnnualPostJun1: 0 },
+  'gpt-5.6-terra':       { inputPerMTok: 2.00,  cacheReadPerMTok: 0.20,   cacheWritePerMTok: 2.50, outputPerMTok: 12.00, multiplier: 0,    multiplierAnnualPostJun1: 0 },
+  'gpt-5.6-sol':         { inputPerMTok: 5.00,  cacheReadPerMTok: 0.50,   cacheWritePerMTok: 6.25, outputPerMTok: 30.00, multiplier: 0,    multiplierAnnualPostJun1: 0 },
   // ── Codex-only models ──────────────────────────────────────────────────────────────────────────
   // codex-mini-latest: fine-tuned o4-mini; 75% cache discount (not the usual 90%); deprecated
   'codex-mini-latest':   { inputPerMTok: 1.50,  cacheReadPerMTok: 0.375,  cacheWritePerMTok: 0, outputPerMTok: 6.00,  multiplier: 0,    multiplierAnnualPostJun1: 0 },
@@ -77,13 +85,21 @@ const RATES: Record<string, ModelRates> = {
   'claude-opus-4-6':       { inputPerMTok:  5.00, cacheReadPerMTok: 0.50, cacheWritePerMTok:  6.25, outputPerMTok: 25.00, multiplier: 3,    multiplierAnnualPostJun1: 27 },
   'claude-opus-4-7':       { inputPerMTok:  5.00, cacheReadPerMTok: 0.50, cacheWritePerMTok:  6.25, outputPerMTok: 25.00, multiplier: 15,   multiplierAnnualPostJun1: 27 },
   'claude-opus-4-8':       { inputPerMTok:  5.00, cacheReadPerMTok: 0.50, cacheWritePerMTok:  6.25, outputPerMTok: 25.00, multiplier: 15,   multiplierAnnualPostJun1: 27 },
+  // claude-opus-5: added 2026-08-07, now GA per both Anthropic's and Copilot's pricing pages — same rate as Opus 4.8.
+  // Not yet listed on the annual-plan multiplier page — multiplierAnnualPostJun1 set to 0 until published.
+  'claude-opus-5':         { inputPerMTok:  5.00, cacheReadPerMTok: 0.50, cacheWritePerMTok:  6.25, outputPerMTok: 25.00, multiplier: 0,  multiplierAnnualPostJun1: 0 },
   // fast mode (/fast toggle in Claude Code) — model ID appended with -fast by logReader when usage.speed === 'fast'.
   // Opus 4.6 fast mode was removed 2026-06-29: requests run at standard speed/rates despite the -fast suffix.
   'claude-opus-4-6-fast':  { inputPerMTok:  5.00, cacheReadPerMTok: 0.50, cacheWritePerMTok:  6.25, outputPerMTok:  25.00, multiplier: 3,  multiplierAnnualPostJun1: 27 },
-  // Opus 4.7 fast mode is deprecated, scheduled for removal 2026-07-24 — Copilot's own pricing docs don't list a fast-mode
-  // row for it at all, so this rate is carried over from direct Anthropic API pricing as a best estimate.
+  // Opus 4.7 fast mode is confirmed removed as of this refresh (2026-08-07) — Anthropic's docs now state requests
+  // with speed:"fast" return an error. Copilot's own pricing docs never listed a fast-mode row for it either.
+  // Entry frozen for historical sessions only.
   'claude-opus-4-7-fast':  { inputPerMTok: 30.00, cacheReadPerMTok: 3.00, cacheWritePerMTok: 37.50, outputPerMTok: 150.00, multiplier: 30, multiplierAnnualPostJun1: 30 },
   'claude-opus-4-8-fast':  { inputPerMTok: 10.00, cacheReadPerMTok: 1.00, cacheWritePerMTok: 12.50, outputPerMTok:  50.00, multiplier: 30, multiplierAnnualPostJun1: 30 },
+  // claude-opus-5-fast: added 2026-08-07 — Anthropic's fast-mode table lists Opus 5 and Opus 4.8 together at the
+  // same rate; Copilot's own docs don't yet list a distinct fast-mode row for it, so multiplier is carried over
+  // from Opus 4.8's fast-mode entry as a best estimate.
+  'claude-opus-5-fast':    { inputPerMTok: 10.00, cacheReadPerMTok: 1.00, cacheWritePerMTok: 12.50, outputPerMTok:  50.00, multiplier: 30, multiplierAnnualPostJun1: 30 },
   'claude-fable-5':        { inputPerMTok: 10.00, cacheReadPerMTok: 1.00, cacheWritePerMTok: 12.50, outputPerMTok:  50.00, multiplier: 0,  multiplierAnnualPostJun1: 0 },  // not yet listed in Copilot billing docs
   'claude-mythos-5':       { inputPerMTok: 10.00, cacheReadPerMTok: 1.00, cacheWritePerMTok: 12.50, outputPerMTok:  50.00, multiplier: 0,  multiplierAnnualPostJun1: 0 },  // limited availability preview; not yet listed in Copilot billing docs
   // ── Google ─────────────────────────────────────────────────────────────────────────────────────
@@ -92,6 +108,8 @@ const RATES: Record<string, ModelRates> = {
   'gemini-3-pro':     { inputPerMTok: 2.00, cacheReadPerMTok: 0.20,  cacheWritePerMTok: 0, outputPerMTok: 12.00, multiplier: 1,    multiplierAnnualPostJun1: 6 },
   'gemini-3.1-pro':   { inputPerMTok: 2.00, cacheReadPerMTok: 0.20,  cacheWritePerMTok: 0, outputPerMTok: 12.00, multiplier: 1,    multiplierAnnualPostJun1: 6 },  // long-context surcharge (>200K tokens) not implemented
   'gemini-3.5-flash': { inputPerMTok: 1.50, cacheReadPerMTok: 0.15,  cacheWritePerMTok: 0, outputPerMTok: 9.00,  multiplier: 14,   multiplierAnnualPostJun1: 14 },
+  // gemini-3.6-flash: added 2026-08-07, new on the Copilot pricing page. Not yet on the annual multiplier page.
+  'gemini-3.6-flash': { inputPerMTok: 1.50, cacheReadPerMTok: 0.15,  cacheWritePerMTok: 0, outputPerMTok: 7.50,  multiplier: 0,    multiplierAnnualPostJun1: 0 },
   // ── Fine-tuned ─────────────────────────────────────────────────────────────────────────────────
   // raptor-mini: no longer included/$0 as of 2026-07-19 — now billed at the same standard rate as gpt-5-mini.
   'raptor-mini': { inputPerMTok: 0.25, cacheReadPerMTok: 0.025, cacheWritePerMTok: 0, outputPerMTok: 2.00,  multiplier: 0, multiplierAnnualPostJun1: 0.33 },
@@ -100,6 +118,12 @@ const RATES: Record<string, ModelRates> = {
   // Not yet listed on the annual-plan multiplier page — multiplierAnnualPostJun1 set to 0 until published.
   'mai-code-1-flash': { inputPerMTok: 0.75, cacheReadPerMTok: 0.075, cacheWritePerMTok: 0, outputPerMTok: 4.50, multiplier: 0, multiplierAnnualPostJun1: 0.33 },
   'kimi-k2.7-code':   { inputPerMTok: 0.95, cacheReadPerMTok: 0.19,  cacheWritePerMTok: 0, outputPerMTok: 4.00, multiplier: 0, multiplierAnnualPostJun1: 0 },
+  // ── Other third-party (new to Copilot marketplace as of 2026-08-07) ───────────────────────────────
+  // Not yet listed on the annual-plan multiplier page. Exact telemetry model-ID slug unconfirmed (guessed from
+  // the Copilot docs display name, matching the existing naming convention) — a wrong guess fails safe (falls
+  // back to ~$? rather than mis-pricing), same risk tolerance as the OpenCode Zen free-model gaps below.
+  'grok-4.5':         { inputPerMTok: 2.00, cacheReadPerMTok: 0.50,  cacheWritePerMTok: 0, outputPerMTok: 6.00, multiplier: 0, multiplierAnnualPostJun1: 0 },
+  'kimi-k3':          { inputPerMTok: 3.00, cacheReadPerMTok: 0.30,  cacheWritePerMTok: 0, outputPerMTok: 15.00, multiplier: 0, multiplierAnnualPostJun1: 0 },
   // ── OpenCode Zen  https://opencode.ai/docs/zen/ ────────────────────────────
   // big-pickle: OpenCode's stealth model, free during limited evaluation period.
   'big-pickle':  { inputPerMTok: 0,    cacheReadPerMTok: 0,     cacheWritePerMTok: 0, outputPerMTok: 0,     multiplier: 0, multiplierAnnualPostJun1: 0 },

--- a/src/pricing.ts
+++ b/src/pricing.ts
@@ -1,6 +1,6 @@
 // Pricing data for extension-host cost computation (cost_usd stored in sessions table).
 // Rate table is kept in sync with media/src/pricing.ts — update both when rates change.
-// PRICING_LAST_UPDATED: 2026-07-19
+// PRICING_LAST_UPDATED: 2026-08-07
 
 export interface ModelRates {
   inputPerMTok: number
@@ -17,14 +17,18 @@ export interface ModelRates {
 
 const RATES: Record<string, ModelRates> = {
   // ── OpenAI ─────────────────────────────────────────────────────────────────
-  // gpt-4.1: no longer listed on the current API pricing page — kept at legacy $0 rate for historical sessions.
-  'gpt-4.1':            { inputPerMTok: 0,     cacheReadPerMTok: 0,      cacheWritePerMTok: 0, outputPerMTok: 0,     contextWindowTokens: 1_000_000 },
+  // gpt-4.1: re-listed on the API pricing page as of 2026-08-07 at real rates (previously assumed delisted/$0 —
+  // that turned out to be wrong or stale; correcting to the live page value).
+  'gpt-4.1':            { inputPerMTok: 2.00,  cacheReadPerMTok: 0.50,   cacheWritePerMTok: 0, outputPerMTok: 8.00,  contextWindowTokens: 1_000_000 },
   // gpt-5-mini: no longer an included/$0 model as of the 2026-07-19 pricing page — now billed at standard rates.
   'gpt-5-mini':         { inputPerMTok: 0.25,  cacheReadPerMTok: 0.025,  cacheWritePerMTok: 0, outputPerMTok: 2.00,  contextWindowTokens: 200_000 },
   'gpt-5 mini':         { inputPerMTok: 0.25,  cacheReadPerMTok: 0.025,  cacheWritePerMTok: 0, outputPerMTok: 2.00,  contextWindowTokens: 200_000 },
   'gpt-4o':             { inputPerMTok: 2.50,  cacheReadPerMTok: 1.25,   cacheWritePerMTok: 0, outputPerMTok: 10.00, contextWindowTokens: 128_000 },
   'gpt-4o-mini':        { inputPerMTok: 0.15,  cacheReadPerMTok: 0.075,  cacheWritePerMTok: 0, outputPerMTok: 0.60,  contextWindowTokens: 128_000 },
-  'gpt-5.1':            { inputPerMTok: 1.75,  cacheReadPerMTok: 0.175,  cacheWritePerMTok: 0, outputPerMTok: 14.00, contextWindowTokens: 256_000 },
+  // gpt-5.1: corrected 2026-08-07 — was $1.75/$14.00, live API pricing page now shows $1.25/$10.00 (older-gen
+  // model repriced down below gpt-5.2). gpt-5.1-codex/-mini/-max not independently re-confirmed this round
+  // (absent from the general pricing page); left unchanged — see PRICING_SOURCES.md Known gaps.
+  'gpt-5.1':            { inputPerMTok: 1.25,  cacheReadPerMTok: 0.125,  cacheWritePerMTok: 0, outputPerMTok: 10.00, contextWindowTokens: 256_000 },
   'gpt-5.1-codex':      { inputPerMTok: 1.75,  cacheReadPerMTok: 0.175,  cacheWritePerMTok: 0, outputPerMTok: 14.00, contextWindowTokens: 256_000 },
   'gpt-5.1-codex-mini': { inputPerMTok: 0.75,  cacheReadPerMTok: 0.075,  cacheWritePerMTok: 0, outputPerMTok: 4.50,  contextWindowTokens: 256_000 },
   'gpt-5.1-codex-max':  { inputPerMTok: 1.75,  cacheReadPerMTok: 0.175,  cacheWritePerMTok: 0, outputPerMTok: 14.00, contextWindowTokens: 256_000 },
@@ -35,10 +39,14 @@ const RATES: Record<string, ModelRates> = {
   'gpt-5.4-mini':       { inputPerMTok: 0.75,  cacheReadPerMTok: 0.075,  cacheWritePerMTok: 0, outputPerMTok: 4.50,  contextWindowTokens: 200_000 },
   'gpt-5.4-nano':       { inputPerMTok: 0.20,  cacheReadPerMTok: 0.02,   cacheWritePerMTok: 0, outputPerMTok: 1.25,  contextWindowTokens: 128_000 },
   'gpt-5.5':            { inputPerMTok: 5.00,  cacheReadPerMTok: 0.50,   cacheWritePerMTok: 0, outputPerMTok: 30.00, contextWindowTokens: 256_000 },
-  // gpt-5.6 family (new as of 2026-07-19): Luna (small/fast), Terra (mid, ~gpt-5.4 pricing), Sol (flagship, ~gpt-5.5 pricing).
-  'gpt-5.6-luna':       { inputPerMTok: 1.00,  cacheReadPerMTok: 0.10,   cacheWritePerMTok: 0, outputPerMTok: 6.00,  contextWindowTokens: 256_000 },
-  'gpt-5.6-terra':      { inputPerMTok: 2.50,  cacheReadPerMTok: 0.25,   cacheWritePerMTok: 0, outputPerMTok: 15.00, contextWindowTokens: 256_000 },
-  'gpt-5.6-sol':        { inputPerMTok: 5.00,  cacheReadPerMTok: 0.50,   cacheWritePerMTok: 0, outputPerMTok: 30.00, contextWindowTokens: 256_000 },
+  // gpt-5.6 family: Luna (small/fast), Terra (mid), Sol (flagship). Corrected 2026-08-07 — Luna and Terra were
+  // repriced down (Luna $1.00→$0.20 input, Terra $2.50→$2.00 input), and the whole family gained real cache-write
+  // pricing (1.25x input, confirmed across the Copilot docs, OpenAI's pricing page, and the Codex credits page).
+  // A "long context" surcharge tier also exists above an unconfirmed token threshold (~2x input/cache, ~1.5x
+  // output per Copilot's docs) — not implemented; see PRICING_SOURCES.md Known gaps.
+  'gpt-5.6-luna':       { inputPerMTok: 0.20,  cacheReadPerMTok: 0.02,   cacheWritePerMTok: 0.25, outputPerMTok: 1.20,  contextWindowTokens: 256_000 },
+  'gpt-5.6-terra':      { inputPerMTok: 2.00,  cacheReadPerMTok: 0.20,   cacheWritePerMTok: 2.50, outputPerMTok: 12.00, contextWindowTokens: 256_000 },
+  'gpt-5.6-sol':        { inputPerMTok: 5.00,  cacheReadPerMTok: 0.50,   cacheWritePerMTok: 6.25, outputPerMTok: 30.00, contextWindowTokens: 256_000 },
   // ── Codex-only ─────────────────────────────────────────────────────────────
   // codex-mini-latest: deprecated per OpenAI docs; kept for historical sessions.
   'codex-mini-latest':  { inputPerMTok: 1.50,  cacheReadPerMTok: 0.375,  cacheWritePerMTok: 0, outputPerMTok: 6.00,  contextWindowTokens: 200_000 },
@@ -58,11 +66,16 @@ const RATES: Record<string, ModelRates> = {
   'claude-opus-4-6':    { inputPerMTok:  5.00, cacheReadPerMTok: 0.50,  cacheWritePerMTok:  6.25, outputPerMTok: 25.00, contextWindowTokens: 1_000_000 },
   'claude-opus-4-7':    { inputPerMTok:  5.00, cacheReadPerMTok: 0.50,  cacheWritePerMTok:  6.25, outputPerMTok: 25.00, contextWindowTokens: 1_000_000 },
   'claude-opus-4-8':    { inputPerMTok:  5.00, cacheReadPerMTok: 0.50,  cacheWritePerMTok:  6.25, outputPerMTok: 25.00, contextWindowTokens: 1_000_000 },
+  // claude-opus-5: added 2026-08-07, now GA per Anthropic's pricing page — same rate as Opus 4.8.
+  'claude-opus-5':      { inputPerMTok:  5.00, cacheReadPerMTok: 0.50,  cacheWritePerMTok:  6.25, outputPerMTok: 25.00, contextWindowTokens: 1_000_000 },
   // fast mode for Opus 4.6 was removed 2026-06-29 — requests now run at standard speed/rates despite the -fast suffix.
   'claude-opus-4-6-fast':{ inputPerMTok:  5.00, cacheReadPerMTok: 0.50, cacheWritePerMTok:  6.25, outputPerMTok:  25.00, contextWindowTokens: 1_000_000 },
-  // fast mode for Opus 4.7 is deprecated and scheduled for removal 2026-07-24 — remove/fold into standard rate after that date.
+  // fast mode for Opus 4.7 is confirmed removed as of this refresh (2026-08-07) — Anthropic's docs now state
+  // requests with speed:"fast" return an error. Entry frozen for historical sessions only.
   'claude-opus-4-7-fast':{ inputPerMTok: 30.00, cacheReadPerMTok: 3.00, cacheWritePerMTok: 37.50, outputPerMTok: 150.00, contextWindowTokens: 1_000_000 },
   'claude-opus-4-8-fast':{ inputPerMTok: 10.00, cacheReadPerMTok: 1.00, cacheWritePerMTok: 12.50, outputPerMTok:  50.00, contextWindowTokens: 1_000_000 },
+  // claude-opus-5-fast: added 2026-08-07 — Anthropic's fast-mode table lists Opus 5 and Opus 4.8 together at the same rate.
+  'claude-opus-5-fast':  { inputPerMTok: 10.00, cacheReadPerMTok: 1.00, cacheWritePerMTok: 12.50, outputPerMTok:  50.00, contextWindowTokens: 1_000_000 },
   'claude-fable-5':      { inputPerMTok: 10.00, cacheReadPerMTok: 1.00, cacheWritePerMTok: 12.50, outputPerMTok:  50.00, contextWindowTokens: 1_000_000 },
   // claude-mythos-5: limited-availability preview (anthropic.com/glasswing), same rates as Fable 5.
   'claude-mythos-5':     { inputPerMTok: 10.00, cacheReadPerMTok: 1.00, cacheWritePerMTok: 12.50, outputPerMTok:  50.00, contextWindowTokens: 1_000_000 },
@@ -72,6 +85,8 @@ const RATES: Record<string, ModelRates> = {
   'gemini-3-pro':    { inputPerMTok: 2.00, cacheReadPerMTok: 0.20,  cacheWritePerMTok: 0, outputPerMTok: 12.00, contextWindowTokens: 1_000_000 },
   'gemini-3.1-pro':  { inputPerMTok: 2.00, cacheReadPerMTok: 0.20,  cacheWritePerMTok: 0, outputPerMTok: 12.00, contextWindowTokens: 1_000_000 },
   'gemini-3.5-flash':{ inputPerMTok: 1.50, cacheReadPerMTok: 0.15,  cacheWritePerMTok: 0, outputPerMTok:  9.00, contextWindowTokens: 1_000_000 },
+  // gemini-3.6-flash: added 2026-08-07, new on the Copilot pricing page.
+  'gemini-3.6-flash':{ inputPerMTok: 1.50, cacheReadPerMTok: 0.15,  cacheWritePerMTok: 0, outputPerMTok:  7.50, contextWindowTokens: 1_000_000 },
   // ── Fine-tuned ─────────────────────────────────────────────────────────────
   // raptor-mini: no longer an included/$0 model as of the 2026-07-19 Copilot pricing page — now billed at standard rates.
   'raptor-mini': { inputPerMTok: 0.25, cacheReadPerMTok: 0.025, cacheWritePerMTok: 0, outputPerMTok:  2.00,  contextWindowTokens: 0 },

--- a/src/test/pricing.test.ts
+++ b/src/test/pricing.test.ts
@@ -40,8 +40,8 @@ suite('pricing', () => {
   })
 
   test('calcTokenCostUsd returns 0 for included (free) model', () => {
-    // gpt-4.1 has all-zero rates
-    const cost = calcTokenCostUsd(100_000, 0, 0, 10_000, 'gpt-4.1')
+    // big-pickle is free during its OpenCode Zen evaluation period — all-zero rates
+    const cost = calcTokenCostUsd(100_000, 0, 0, 10_000, 'big-pickle')
     assert.strictEqual(cost, 0)
   })
 


### PR DESCRIPTION
## Summary

Followed the `PRICING_SOURCES.md` refresh runbook: fetched each source URL, compared against the current `RATES` tables in `src/pricing.ts` and `media/src/pricing.ts`, and updated both plus the runbook itself.

**Real corrections** (not just new-model additions):
- `gpt-5.6-luna` and `gpt-5.6-terra` were repriced down — confirmed independently across 3 sources (Copilot docs, OpenAI's own pricing page, and the Codex credits page via the known 25-credits-per-$1 conversion). The whole `gpt-5.6` family also gained real cache-write pricing (1.25x input) that was previously modeled as $0.
- `gpt-5.1` corrected from $1.75/$14.00 to $1.25/$10.00 input/output (double-confirmed on OpenAI's pricing page).
- `gpt-4.1` is back on the pricing page at real rates ($2.00/$0.50/$8.00) — reverses a prior "delisted, kept at $0" assumption that turned out to be wrong or stale.
- Opus 4.7 fast mode is now confirmed dead (`speed: "fast"` returns an error) rather than just "scheduled for removal 2026-07-24".

**New models added:**
- Claude Opus 5 (now GA, same rate as Opus 4.8) + its fast-mode variant
- Gemini 3.6 Flash
- Two new Copilot-marketplace-only models: Grok 4.5, Kimi K3 (`media/src/pricing.ts` only, matching how other Copilot-exclusive third-party models are scoped — telemetry model-ID slug unconfirmed, flagged as a known gap)

**Deliberately left alone / flagged instead of guessed** (per the runbook's own policy — "if a rate or model can't be confirmed, add it to Known gaps instead of guessing"):
- `gpt-5.1-codex`, `gpt-5.1-codex-mini`, `gpt-5.1-codex-max` — absent from the general API pricing page this round, not independently re-confirmed.
- The long-context surcharge tier for `gpt-5.4`/`gpt-5.5`/`gpt-5.6` family — the multiplier pattern is now confirmed (2x input/cache, 1.5x output) but the token threshold that triggers it is still unpublished, so it isn't wired up in code.
- 3 new OpenCode Zen free models (Laguna S 2.1, Ling-3.0-tiny, LongCat-2.0) — noted in Known gaps, not added to `RATES` since their exact SQLite `id` slug isn't confirmed from real telemetry.

Updated `PRICING_LAST_UPDATED` in `media/src/pricing.ts` and all "verified" dates in `PRICING_SOURCES.md` to 2026-08-07.

## Test plan
- [x] `pnpm run check-types` passes (both root and `media/tsconfig.json`)
- [x] `pnpm run lint` — 0 errors (pre-existing unrelated warnings only)
- [x] `src/test/pricing.test.ts` passes (11/11), run via mocha's programmatic API — the `mocha` CLI itself is broken under Node v26 in this dev environment (unrelated pre-existing issue, not this PR)
- [x] Fixed one existing test that asserted `gpt-4.1` had all-zero rates (no longer true after the correction) — switched it to `big-pickle`, which is actually still free

🤖 Generated with [Claude Code](https://claude.com/claude-code)