### PR TITLE
feat: add daily cost threshold alert

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
 - **Advisor** — Project-scoped suggestions for improving your agent instruction file (CLAUDE.md, AGENTS.md, or similar): detects hot files the agent rediscovers every session, loop patterns, high turn-count trends, and scope problems — each suggestion includes ready-to-copy instruction text and an inquiry prompt you can paste directly into your agent. Also includes an efficiency scatter plot (cost vs. LLM calls, colored by cache hit rate) and hot files ranked by access frequency. Select a specific project from the filter for tailored suggestions; all-projects view surfaces only universal patterns.
 - **Cost Estimation** — Estimates session cost for Copilot (three billing models), Claude Code, and Codex, broken down by model in a day-grouped table
 - **Efficiency & Inefficiency Detection** — Surfaces context bloat, redundant tool calls, cache misses, and five loop/malfunction patterns with suggested prompts to correct course
-- **Configurable Alerts** — Threshold-based notifications for turns, errors, active time, and repeat tool calls — per-agent or shared
+- **Configurable Alerts** — Threshold-based notifications for turns, errors, active time, repeat tool calls, and estimated daily cost — per-agent or shared
 - **Export** — Export filtered sessions as JSON (full or redacted); respects the active agent, source, time range, and text filters
 - **Import** — Import sessions from a previous AgentLens JSON export; drag-drop or file-pick, shows a preview with session count by source and date range, imports with live progress and automatic deduplication (existing sessions are skipped)
 

--- a/media/src/AgentThresholdInputs.tsx
+++ b/media/src/AgentThresholdInputs.tsx
@@ -60,7 +60,7 @@ function thresholdInputStyle(width: number, invalid: boolean): string {
     + ';border-radius:3px;padding:2px 6px;font-size:12px'
 }
 
-function ThresholdNumberTextInput({ value, min, max, width, ariaLabel, onChange }: ThresholdNumberTextInputProps) {
+export function ThresholdNumberTextInput({ value, min, max, width, ariaLabel, onChange }: ThresholdNumberTextInputProps) {
   const [draft, setDraft] = useState(String(value))
 
   useEffect(() => {

--- a/media/src/sessionMetrics.ts
+++ b/media/src/sessionMetrics.ts
@@ -108,17 +108,54 @@ export function sessionCostMode(session: SessionSummaryCard, mode: PricingMode):
 
 // 'YYYY-MM-DD', UTC — matches the day-grouping convention used by the Cost tab's daily chart.
 export function dayKeyUtc(t: string | undefined): string {
-  return t ? new Date(t).toISOString().slice(0, 10) : 'none'
+  return t ? new Date(t).toISOString().slice(0, 10) : 'unknown'
 }
 
-// Sum of estimated cost across sessions that started on the given UTC day key.
-// Defaults every session to token-based pricing (Copilot's AI Credits model) since this runs in
-// contexts (alerts) with no user-facing pricing-mode toggle to plumb through.
+export interface AgentDayCost {
+  source: string
+  input: number
+  output: number
+  cacheCreate: number
+  cacheRead: number
+  cost: number
+  models: Set<string>
+}
+
+export interface DayCost {
+  input: number
+  output: number
+  cacheCreate: number
+  cacheRead: number
+  cost: number
+  agents: Map<string, AgentDayCost>
+}
+
+// Day → agent cost/token breakdown. The single source of truth for "daily cost" — the Analytics
+// tab's cost table, the daily_cost alert, and anything else that needs a per-day total should
+// build on this rather than re-deriving their own day-grouping and summing.
+export function buildDailyCostMap(sessions: SessionSummaryCard[], mode: PricingMode): Map<string, DayCost> {
+  const dayMap = new Map<string, DayCost>()
+  for (const sess of sessions) {
+    const day = dayKeyUtc(sess.startTime)
+    const cost = calcSessionCost(sess, sessionCostMode(sess, mode)).totalUsd
+    if (!dayMap.has(day)) dayMap.set(day, { input: 0, output: 0, cacheCreate: 0, cacheRead: 0, cost: 0, agents: new Map() })
+    const de = dayMap.get(day)!
+    de.input += sess.inputTokens; de.output += sess.outputTokens
+    de.cacheCreate += sess.cacheCreateTokens ?? 0; de.cacheRead += sess.cacheReadTokens; de.cost += cost
+    if (!de.agents.has(sess.source)) de.agents.set(sess.source, { source: sess.source, input: 0, output: 0, cacheCreate: 0, cacheRead: 0, cost: 0, models: new Set() })
+    const ae = de.agents.get(sess.source)!
+    ae.input += sess.inputTokens; ae.output += sess.outputTokens
+    ae.cacheCreate += sess.cacheCreateTokens ?? 0; ae.cacheRead += sess.cacheReadTokens; ae.cost += cost
+    if (sess.model) ae.models.add(sess.model)
+  }
+  return dayMap
+}
+
+// Estimated cost across sessions that started on the given UTC day key. Defaults to token-based
+// pricing (Copilot's AI Credits model) since this runs in contexts (alerts) with no user-facing
+// pricing-mode toggle to plumb through. Built on buildDailyCostMap, not a separate calculation.
 export function getDailyCostUsd(sessions: SessionSummaryCard[], dayKey: string): number {
-  return sessions.reduce((sum, s) => {
-    if (dayKeyUtc(s.startTime) !== dayKey) return sum
-    return sum + calcSessionCost(s, sessionCostMode(s, 'token')).totalUsd
-  }, 0)
+  return buildDailyCostMap(sessions, 'token').get(dayKey)?.cost ?? 0
 }
 
 export function sessionDisplayName(session: SessionSummaryCard): string {

--- a/media/src/sessionMetrics.ts
+++ b/media/src/sessionMetrics.ts
@@ -101,6 +101,26 @@ export interface ErrorHealth {
   recentErrors: string[]
 }
 
+export function sessionCostMode(session: SessionSummaryCard, mode: PricingMode): PricingMode {
+  // Codex and Claude Code are always token-based; the mode toggle only applies to Copilot
+  return (session.source === 'codex' || session.source === 'claude_code') ? 'token' : mode
+}
+
+// 'YYYY-MM-DD', UTC — matches the day-grouping convention used by the Cost tab's daily chart.
+export function dayKeyUtc(t: string | undefined): string {
+  return t ? new Date(t).toISOString().slice(0, 10) : 'none'
+}
+
+// Sum of estimated cost across sessions that started on the given UTC day key.
+// Defaults every session to token-based pricing (Copilot's AI Credits model) since this runs in
+// contexts (alerts) with no user-facing pricing-mode toggle to plumb through.
+export function getDailyCostUsd(sessions: SessionSummaryCard[], dayKey: string): number {
+  return sessions.reduce((sum, s) => {
+    if (dayKeyUtc(s.startTime) !== dayKey) return sum
+    return sum + calcSessionCost(s, sessionCostMode(s, 'token')).totalUsd
+  }, 0)
+}
+
 export function sessionDisplayName(session: SessionSummaryCard): string {
   const req = (session.userRequest ?? '').trim()
   if (!req || req === '[session in progress]') return '[session in progress]'

--- a/media/src/tabs/Alerts.tsx
+++ b/media/src/tabs/Alerts.tsx
@@ -2,7 +2,9 @@ import { useState } from 'preact/hooks'
 import { displaySessions } from '../state'
 import { buildDisplaySummary, formatMs } from '../utils'
 import {
+  fmtUsd,
   getActiveComputeMs,
+  getDailyCostUsd,
   getErrorHealth,
   getIdenticalToolRepeat,
   getPeakContextUsage,
@@ -11,6 +13,7 @@ import {
 import {
   AgentThresholdInputs,
   AgentThresholdNumberInputs,
+  ThresholdNumberTextInput,
 } from '../AgentThresholdInputs'
 import {
   AGENT_ORDER,
@@ -31,6 +34,7 @@ const ALERT_TOOLTIPS: Record<string, string> = {
   long_session:   'Uses active LLM/tool compute time, not wall-clock waiting time.',
   no_cache:       'Only checks sessions above the input-token gate. Cache can be low for small sessions without being a problem.',
   tool_loop:      'Counts identical tool plus argument repeats, not just the same tool name.',
+  daily_cost:     'Estimated cost only, not a real billing figure. Sums today (UTC) across every agent using token-based pricing, so it will overcount for Copilot plans on legacy request-based billing.',
 }
 
 type AgentThresholdMap = Record<AgentSource, number>
@@ -62,6 +66,7 @@ const DEFAULT_CONFIGS: AlertConfig[] = [
   { id: 'long_session', label: 'Long Active Session', severity: 'info', description: 'Fires when active LLM/tool compute time exceeds the agent-specific threshold. Wall-clock idle time does not count.', enabled: true, threshold: 60, unit: 'agent profile', min: 10, max: 240, step: 10 },
   { id: 'no_cache', label: 'Zero Cache Utilization', severity: 'info', description: 'Fires when any session above that agent\'s input-token gate has 0% cache hit rate.', enabled: true, threshold: 30000, unit: 'tokens', min: 5000, max: 200000, step: 5000, agentThresholds: { claude_code: 30000, copilot: 30000, codex: 30000, opencode: 30000 } },
   { id: 'tool_loop', label: 'Identical Tool Repeat', severity: 'warning', description: 'Fires when the same tool with identical arguments repeats beyond the agent-specific threshold without a file change between repeats.', enabled: true, threshold: 5, unit: 'agent profile', min: 3, max: 20, step: 1 },
+  { id: 'daily_cost', label: 'Daily Cost Threshold', severity: 'warning', description: 'Fires when today\'s total estimated cost across all agents crosses the configured dollar threshold.', enabled: false, threshold: 20, unit: 'usd', min: 1, max: 500, step: 1 },
 ]
 
 type EffSummary = ReturnType<typeof buildDisplaySummary>['efficiency']
@@ -288,6 +293,18 @@ function evaluateAlert(
           + worst.profile.label + ' alert ' + worst.profile.identicalRepeatAlert + ' — "' + sessionDisplayName(worst.session) + '"',
       }
     }
+    case 'daily_cost': {
+      // Aggregate across the full session set, not the `sessions` param — callers may pass a
+      // narrowed slice (e.g. checkAlerts()'s 30-second-recent window), which would undercount.
+      const today = new Date().toISOString().slice(0, 10)
+      const total = getDailyCostUsd(buildDisplaySummary().sessions, today)
+      if (total < cfg.threshold) return { triggered: false }
+      return {
+        triggered: true,
+        key: 'daily_cost:' + today,
+        detail: 'Estimated cost today: ' + fmtUsd(total) + ' vs threshold ' + fmtUsd(cfg.threshold),
+      }
+    }
     default: return { triggered: false }
   }
 }
@@ -472,14 +489,27 @@ export function Alerts() {
                 max={cfg.max}
                 onChange={(source, value) => updateConfigAgentThreshold(cfg, source, value)}
               />
+            ) : profileMetrics.length > 0 ? (
+              <AgentThresholdInputs
+                profiles={profiles}
+                metrics={profileMetrics}
+                onChange={updateAgentThreshold}
+              />
             ) : (
-              profileMetrics.length > 0 && (
-                <AgentThresholdInputs
-                  profiles={profiles}
-                  metrics={profileMetrics}
-                  onChange={updateAgentThreshold}
+              // Globally-scoped configs (e.g. daily_cost) — one flat threshold, not per-agent.
+              <div style="display:flex;align-items:center;gap:6px;font-size:12px;margin:8px 0">
+                <span class="muted" style="font-size:11px;text-transform:uppercase;letter-spacing:.4px;font-weight:700">Threshold</span>
+                {cfg.unit === 'usd' && <span style="color:var(--muted)">$</span>}
+                <ThresholdNumberTextInput
+                  value={cfg.threshold}
+                  min={cfg.min}
+                  max={cfg.max}
+                  width={70}
+                  ariaLabel={cfg.label + ' threshold'}
+                  onChange={value => updateConfig(cfg.id, { threshold: value })}
                 />
-              )
+                {cfg.unit !== 'usd' && <span style="color:var(--muted)">{cfg.unit}</span>}
+              </div>
             )}
           </div>
         )

--- a/media/src/tabs/Analytics.tsx
+++ b/media/src/tabs/Analytics.tsx
@@ -5,7 +5,7 @@ import {
   CHART_MAX, vscode, goToHelp,
 } from '../state'
 import { getAgentColor, getAgentSourceLabel, formatMs, formatCompact } from '../utils'
-import { calcSessionCost } from '../sessionMetrics'
+import { buildDailyCostMap } from '../sessionMetrics'
 import type { SessionSummaryCard } from '../types'
 import type { PricingMode } from '../sessionMetrics'
 import { PRICING_LAST_UPDATED } from '../pricing'
@@ -124,24 +124,9 @@ export function Analytics() {
     </div>
   )
 
-  // Multi-dimensional cost table: day → agent
-  interface AgentDay { source: string; input: number; output: number; cacheCreate: number; cacheRead: number; cost: number; models: Set<string> }
-  interface DayEntry { input: number; output: number; cacheCreate: number; cacheRead: number; cost: number; agents: Map<string, AgentDay> }
-  const dayMap = new Map<string, DayEntry>()
-  pricedSess.forEach(sess => {
-    const day = sess.startTime ? new Date(sess.startTime).toISOString().slice(0, 10) : 'unknown'
-    const effMode: PricingMode = (sess.source === 'codex' || sess.source === 'claude_code') ? 'token' : mode
-    const cost = calcSessionCost(sess, effMode).totalUsd
-    if (!dayMap.has(day)) dayMap.set(day, { input: 0, output: 0, cacheCreate: 0, cacheRead: 0, cost: 0, agents: new Map() })
-    const de = dayMap.get(day)!
-    de.input += sess.inputTokens; de.output += sess.outputTokens
-    de.cacheCreate += sess.cacheCreateTokens ?? 0; de.cacheRead += sess.cacheReadTokens; de.cost += cost
-    if (!de.agents.has(sess.source)) de.agents.set(sess.source, { source: sess.source, input: 0, output: 0, cacheCreate: 0, cacheRead: 0, cost: 0, models: new Set() })
-    const ae = de.agents.get(sess.source)!
-    ae.input += sess.inputTokens; ae.output += sess.outputTokens
-    ae.cacheCreate += sess.cacheCreateTokens ?? 0; ae.cacheRead += sess.cacheReadTokens; ae.cost += cost
-    if (sess.model) ae.models.add(sess.model)
-  })
+  // Multi-dimensional cost table: day → agent. Shared with the daily_cost alert in Alerts.tsx —
+  // see buildDailyCostMap in sessionMetrics.ts, the single source of truth for day-grouped cost.
+  const dayMap = buildDailyCostMap(pricedSess, mode)
   const dayRows = [...dayMap.entries()].sort((a, b) => a[0].localeCompare(b[0]))
   const grand = dayRows.reduce((g, [, d]) => ({
     input: g.input + d.input, output: g.output + d.output,

--- a/media/src/tabs/Cost.tsx
+++ b/media/src/tabs/Cost.tsx
@@ -3,7 +3,7 @@ import { useEffect, useRef } from 'preact/hooks'
 import { sessionSummary, displaySessions, filteredSessions, dailyStats, lifetimeStats, selectedAgentFilter, timeRange, makeTimeRange, focusedSessionId, activeTab } from '../state'
 import type { TimePreset } from '../state'
 import { getAgentColor, getSessionGlobalNumber, formatCompact, getAgentSourceLabel, formatSessionTime } from '../utils'
-import { calcSessionCost, sessionCostMode } from '../sessionMetrics'
+import { calcSessionCost, sessionCostMode, dayKeyUtc } from '../sessionMetrics'
 import { PRICING_LAST_UPDATED } from '../pricing'
 import type { PricingMode } from '../sessionMetrics'
 import type { SessionSummaryCard, DailyStatRow } from '../types'
@@ -239,9 +239,8 @@ export function CostBarChart({ sessions, mode }: { sessions: SessionSummaryCard[
     if (!canvas) return
 
     // Daily totals for the step-function line overlay
-    const dayKey = (t: string) => t ? new Date(t).toISOString().slice(0, 10) : 'none'
     const dayTotals = new Map<string, number>()
-    data.forEach(d => { const dk = dayKey(d.startTime); dayTotals.set(dk, (dayTotals.get(dk) ?? 0) + d.cost) })
+    data.forEach(d => { const dk = dayKeyUtc(d.startTime); dayTotals.set(dk, (dayTotals.get(dk) ?? 0) + d.cost) })
     const maxDailyTotal = Math.max(...Array.from(dayTotals.values()), 0.0001)
     const maxCost = Math.max(...data.map(d => d.cost), 0.0001)
 
@@ -309,7 +308,7 @@ export function CostBarChart({ sessions, mode }: { sessions: SessionSummaryCard[
     // Build day groups once — used by both the label pass and the line pass
     const dayGroups = new Map<string, { start: number; end: number }>()
     data.forEach((d, i) => {
-      const dk = dayKey(d.startTime)
+      const dk = dayKeyUtc(d.startTime)
       if (!dayGroups.has(dk)) dayGroups.set(dk, { start: i, end: i })
       dayGroups.get(dk)!.end = i
     })

--- a/media/src/tabs/Cost.tsx
+++ b/media/src/tabs/Cost.tsx
@@ -3,7 +3,7 @@ import { useEffect, useRef } from 'preact/hooks'
 import { sessionSummary, displaySessions, filteredSessions, dailyStats, lifetimeStats, selectedAgentFilter, timeRange, makeTimeRange, focusedSessionId, activeTab } from '../state'
 import type { TimePreset } from '../state'
 import { getAgentColor, getSessionGlobalNumber, formatCompact, getAgentSourceLabel, formatSessionTime } from '../utils'
-import { calcSessionCost } from '../sessionMetrics'
+import { calcSessionCost, sessionCostMode } from '../sessionMetrics'
 import { PRICING_LAST_UPDATED } from '../pricing'
 import type { PricingMode } from '../sessionMetrics'
 import type { SessionSummaryCard, DailyStatRow } from '../types'
@@ -21,11 +21,6 @@ function fmtCredits(credits: number): string {
   if (credits === 0) return '0'
   if (credits < 0.1) return '<0.1'
   return credits.toFixed(1)
-}
-
-function sessionCostMode(session: SessionSummaryCard, mode: PricingMode): PricingMode {
-  // Codex and Claude Code are always token-based; the mode toggle only applies to Copilot
-  return (session.source === 'codex' || session.source === 'claude_code') ? 'token' : mode
 }
 
 // ── 30-day history chart (SVG) ────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Phase 1 of the "spend enforcement, not just alerts" plan (`.staged-issues/02-budget-spend-alerts.md`)
— AgentLens's existing Configurable Alerts only covered turns/errors/active-time/repeat-calls, with
no cost threshold at all, leaving users on per-token billing no automatic warning before a session
or a day runs up an unexpectedly large bill.

- New **Daily Cost Threshold** alert in the Alerts tab (default disabled, $20/day default) — sums
  estimated cost across every agent for the current UTC day and fires through the same
  alert/notification plumbing every other threshold alert already uses.
- Extracted `sessionCostMode` (previously private to `Cost.tsx`) into the shared `sessionMetrics.ts`
  module, alongside new `getDailyCostUsd`/`dayKeyUtc` helpers, so the alert reuses the Cost tab's
  existing per-source pricing-mode resolution instead of duplicating it.
- Exported `ThresholdNumberTextInput` from `AgentThresholdInputs.tsx` so the new globally-scoped
  (non-per-agent) threshold control reuses the existing validated numeric input rather than a
  one-off.

**Not included:** Phase 2 (opt-in spend-cap *enforcement* via a blocking hook, mirroring the
existing `Stop`-hook infrastructure in `autoConfigNode.ts`) — intentionally separate, higher-risk
follow-up per the staged plan, not bundled with the alert.

## Test plan
- [x] `pnpm run check-types` passes
- [x] `pnpm run lint` — 0 errors (pre-existing unrelated warnings only)
- [x] Verified the compiled bundle contains the new alert and the standalone server boots/serves
  cleanly against a synthetic high-cost fixture
- [ ] Not visually verified in a browser (no screenshot tooling available in this environment) —
  worth a manual look at the Alerts tab before merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)