### PR TITLE
feat: correlate session file changes with git outcome

### DIFF
--- a/media/src/App.tsx
+++ b/media/src/App.tsx
@@ -3,7 +3,7 @@ import { useEffect, useRef, useState } from 'preact/hooks'
 import {
   sessionSummary, toolCalls,
   selectedAgentFilter, initiatorFilter, dataSourceFilter, sessionLimit, activeTab,
-  sessionTimelines, blobCache,
+  sessionTimelines, blobCache, gitOutcomes,
   dailyStats, lifetimeStats, burnRateData, searchResults, rangedSearchResults,
   timeRange, makeTimeRange, TIME_PRESETS, CHART_MAX,
   vscode, displaySessions, rangedSessions,
@@ -12,7 +12,7 @@ import {
   workspaceFilter, availableWorkspaces, shortWorkspaceName,
   enableOtelIngestion, enableLogIngestion, otlpPort, otelReconfigureResult, type OtelReconfigureResult,
 } from './state'
-import type { TimelineEntry, AgentFilter, InitiatorFilter, DataSourceFilter, WorkspaceFilter, DailyStatRow, LifetimeStats, BurnRate, Projection, SessionSummaryCard } from './types'
+import type { TimelineEntry, AgentFilter, InitiatorFilter, DataSourceFilter, WorkspaceFilter, DailyStatRow, LifetimeStats, BurnRate, Projection, SessionSummaryCard, GitOutcome } from './types'
 
 // Tab components
 import { Sessions } from './tabs/Sessions'
@@ -294,6 +294,7 @@ export function App() {
         sessionLimit?: number
         sessionId?: string
         timeline?: TimelineEntry[]
+        outcome?: GitOutcome | null
         spanId?: string
         field?: string
         content?: string | null
@@ -340,6 +341,8 @@ export function App() {
         }
       } else if (msg.type === 'sessionDetail' && msg.sessionId) {
         sessionTimelines.value = { ...sessionTimelines.value, [msg.sessionId]: msg.timeline ?? [] }
+      } else if (msg.type === 'gitOutcome' && msg.sessionId) {
+        gitOutcomes.value = { ...gitOutcomes.value, [msg.sessionId]: msg.outcome ?? null }
       } else if (msg.type === 'blobContent' && msg.spanId && msg.field) {
         const key = `${msg.spanId}:${msg.field}`
         if (msg.content != null) {

--- a/media/src/state.ts
+++ b/media/src/state.ts
@@ -1,7 +1,7 @@
 import { signal, computed } from '@preact/signals'
 import { calcSessionCost } from './sessionMetrics'
 import type {
-  FullSummary, SessionSummaryCard, TimelineEntry,
+  FullSummary, SessionSummaryCard, TimelineEntry, GitOutcome,
   AgentFilter, InitiatorFilter, DataSourceFilter, InsightFilter, WorkspaceFilter, VsCodeApi,
   DailyStatRow, LifetimeStats, BurnRate, Projection,
 } from './types'
@@ -96,6 +96,10 @@ export const toolCalls = signal<Record<string, number>>(window.__INITIAL_TOOL_CA
 
 export const sessionTimelines = signal<Record<string, TimelineEntry[]>>({})
 export const blobCache = signal<Record<string, string>>({})
+
+// Lazy git-outcome cache: sessionId → classification, or null once fetched but not applicable
+// (no git repo, no changed files, etc). Absent key = not yet requested. See gitOutcome.ts.
+export const gitOutcomes = signal<Record<string, GitOutcome | null>>({})
 
 // ── UI control signals ────────────────────────────────────────────────────────
 

--- a/media/src/tabs/Sessions.tsx
+++ b/media/src/tabs/Sessions.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef } from 'preact/hooks'
 import {
-  filteredSessions, sessionSummary, sessionTimelines, burnRateData,
+  filteredSessions, sessionSummary, sessionTimelines, gitOutcomes, burnRateData,
   focusedSessionId, vscode, ignoredInsightKeys,
   sessionSortKey, sessionSortDir, type SortKey,
   workspaceFilter, shortWorkspaceName, goToHelp,
@@ -17,11 +17,18 @@ import { Step, StepRow } from './Traces'
 import { FlowCanvas } from './Flow'
 import { ToolsChart } from './Tools'
 import { LogIngestionNote } from './IngestionNote'
-import type { SessionSummaryCard } from '../types'
+import type { SessionSummaryCard, FileOutcome } from '../types'
 
 // ── Session detail panel (shown in expanded row) ──────────────────────────────
 
 type Section = 'overview' | 'trace' | 'files' | 'flow' | 'tools'
+
+const OUTCOME_META: Record<FileOutcome, { icon: string; color: string; label: string }> = {
+  productive: { icon: '✓', color: 'var(--vscode-charts-green,#81c784)', label: 'Committed' },
+  reverted:   { icon: '↺', color: 'var(--error)',                       label: 'Reverted' },
+  abandoned:  { icon: '◑', color: '#f6a623',                            label: 'Uncommitted' },
+  ambiguous:  { icon: '?', color: 'var(--muted)',                       label: 'Unknown' },
+}
 
 function PromptBlock({ text }: { text: string }) {
   const [expanded, setExpanded] = useState(false)
@@ -53,10 +60,28 @@ function SessionDetail({ sess }: { sess: SessionSummaryCard }) {
   const cost = calcSessionCost(sess, 'token')
   const cacheRate = sess.inputTokens > 0 ? Math.round(sess.cacheReadTokens / sess.inputTokens * 100) : 0
   const burnRate = burnRateData.value
+  const gitOutcome = gitOutcomes.value[sess.sessionId]
 
   useEffect(() => {
     if (!timelines[sess.sessionId] && vscode) {
       vscode.postMessage({ type: 'loadSessionDetail', sessionId: sess.sessionId })
+    }
+  }, [sess.sessionId])
+
+  useEffect(() => {
+    // undefined = not yet requested; null = requested but not applicable (no repo, no files, etc)
+    if (gitOutcomes.value[sess.sessionId] === undefined && sess.filesChanged.length > 0 && vscode) {
+      const endTime = sess.startTime && sess.durationMs
+        ? new Date(new Date(sess.startTime).getTime() + sess.durationMs).toISOString()
+        : sess.startTime
+      vscode.postMessage({
+        type: 'getGitOutcome',
+        sessionId: sess.sessionId,
+        workspace: sess.workspace,
+        filesChanged: sess.filesChanged,
+        startTime: sess.startTime,
+        endTime,
+      })
     }
   }, [sess.sessionId])
 
@@ -239,17 +264,33 @@ function SessionDetail({ sess }: { sess: SessionSummaryCard }) {
               )
               : (
                 <div style="display:flex;flex-direction:column;gap:3px">
-                  {sess.filesChanged.map(f => (
+                  {gitOutcome && (
                     <div
-                      key={f}
-                      style={`display:flex;align-items:center;gap:8px;padding:4px 8px;background:var(--hover);border-radius:4px;font-size:11px${vscode ? ';cursor:pointer' : ''}`}
-                      onClick={() => vscode?.postMessage({ type: 'openFile', filePath: f })}
-                      title={vscode ? 'Click to open in editor' : f}
+                      data-tip="Estimated from local git history: compares each file's content right before this session against its content now. Not available without a local git repo, and doesn't cover files git can't see (e.g. gitignored)."
+                      style={`display:flex;align-items:center;gap:6px;padding:5px 8px;margin-bottom:2px;font-size:11px;color:${OUTCOME_META[gitOutcome.overall].color};cursor:help`}
                     >
-                      <span style="color:var(--vscode-charts-green,#81c784);font-size:10px;flex-shrink:0">M</span>
-                      <span style={`font-family:monospace;overflow:hidden;text-overflow:ellipsis;white-space:nowrap${vscode ? ';color:var(--vscode-textLink-foreground,#4fc3f7)' : ''}`}>{f}</span>
+                      <span>{OUTCOME_META[gitOutcome.overall].icon}</span>
+                      <span>{gitOutcome.reason}</span>
                     </div>
-                  ))}
+                  )}
+                  {sess.filesChanged.map(f => {
+                    const fileOutcome = gitOutcome?.files[f]
+                    const meta = fileOutcome ? OUTCOME_META[fileOutcome] : null
+                    return (
+                      <div
+                        key={f}
+                        style={`display:flex;align-items:center;gap:8px;padding:4px 8px;background:var(--hover);border-radius:4px;font-size:11px${vscode ? ';cursor:pointer' : ''}`}
+                        onClick={() => vscode?.postMessage({ type: 'openFile', filePath: f })}
+                        title={vscode ? 'Click to open in editor' : f}
+                      >
+                        <span style="color:var(--vscode-charts-green,#81c784);font-size:10px;flex-shrink:0">M</span>
+                        <span style={`font-family:monospace;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;flex:1${vscode ? ';color:var(--vscode-textLink-foreground,#4fc3f7)' : ''}`}>{f}</span>
+                        {meta && (
+                          <span style={`color:${meta.color};font-size:10px;flex-shrink:0`} title={meta.label}>{meta.icon} {meta.label}</span>
+                        )}
+                      </div>
+                    )
+                  })}
                   {sess.filesChangedNote && (
                     <div style="font-size:10px;color:var(--muted);margin-top:3px">{sess.filesChangedNote}</div>
                   )}

--- a/media/src/types.ts
+++ b/media/src/types.ts
@@ -47,6 +47,16 @@ export interface LoopSignal {
   action: string
 }
 
+// Mirrors src/gitOutcome.ts. Fetched lazily per session (see sessionTimelines in state.ts for the
+// same lazy-cache pattern) — never eagerly computed for every loaded session.
+export type FileOutcome = 'productive' | 'reverted' | 'abandoned' | 'ambiguous'
+
+export interface GitOutcome {
+  overall: FileOutcome
+  files: Record<string, FileOutcome>
+  reason: string
+}
+
 export interface SessionSummaryCard {
   sessionId: string
   traceId: string

--- a/src/dashboardPanel.ts
+++ b/src/dashboardPanel.ts
@@ -5,12 +5,16 @@ import { InstructionRepository } from './database/instructionRepository'
 import { detectInstructionFiles, appendSuggestion, removeSuggestion } from './instructionFiles'
 import { computeBaseline } from './instructionEffectiveness'
 import { autoConfigureCopilot, autoConfigureClaudeCode, autoConfigureCodex } from './autoConfig'
+import { classifySessionOutcome, type GitOutcome } from './gitOutcome'
 
 export class DashboardPanel {
   public static currentPanel: DashboardPanel | undefined
   private readonly panel: vscode.WebviewPanel
   private disposables: vscode.Disposable[] = []
   private pendingUpdate: ReturnType<typeof setTimeout> | undefined
+  // On-demand, computed once per session per panel lifetime — see gitOutcome.ts for why this
+  // isn't computed eagerly for every loaded session.
+  private gitOutcomeCache = new Map<string, GitOutcome | null>()
 
   static show(context: vscode.ExtensionContext, repo: SessionRepository, sidebarProvider?: SidebarPanel, instructionRepo?: InstructionRepository) {
     if (DashboardPanel.currentPanel) {
@@ -65,6 +69,14 @@ export class DashboardPanel {
       if (msg.type === 'loadSessionDetail' && msg.sessionId) {
         const timeline = this.repo.loadSessionTimeline(msg.sessionId as string)
         this.panel.webview.postMessage({ type: 'sessionDetail', sessionId: msg.sessionId, timeline })
+      } else if (msg.type === 'getGitOutcome' && msg.sessionId) {
+        void this.sendGitOutcome(
+          msg.sessionId as string,
+          (msg.workspace as string) || '',
+          Array.isArray(msg.filesChanged) ? msg.filesChanged as string[] : [],
+          (msg.startTime as string) || '',
+          (msg.endTime as string) || '',
+        )
       } else if (msg.type === 'loadBlob' && msg.spanId && msg.field) {
         const content = await this.repo.loadBlob(
           msg.spanId as string,
@@ -260,6 +272,16 @@ export class DashboardPanel {
     } catch (err) {
       this.panel.webview.postMessage({ type: 'importError', message: String(err) })
     }
+  }
+
+  private async sendGitOutcome(sessionId: string, workspace: string, filesChanged: string[], startTime: string, endTime: string): Promise<void> {
+    if (this.gitOutcomeCache.has(sessionId)) {
+      this.panel.webview.postMessage({ type: 'gitOutcome', sessionId, outcome: this.gitOutcomeCache.get(sessionId) })
+      return
+    }
+    const outcome = await classifySessionOutcome(workspace, filesChanged, startTime, endTime)
+    this.gitOutcomeCache.set(sessionId, outcome)
+    this.panel.webview.postMessage({ type: 'gitOutcome', sessionId, outcome })
   }
 
   private async exportSessions(redact: boolean, ids: Set<string> | null = null): Promise<void> {

--- a/src/gitOutcome.ts
+++ b/src/gitOutcome.ts
@@ -1,0 +1,144 @@
+/**
+ * Session-outcome correlation with git — did a session's file changes survive?
+ *
+ * Local git only, on-demand (called per session when its detail view is opened, not eagerly for
+ * every loaded session — see .staged-issues/03-git-outcome-correlation.md for why). Classifies
+ * each changed file by comparing its content immediately before the session started against its
+ * content right now, using git history as the source of truth rather than AgentLens's own
+ * recorded diff snippets (which only capture partial before/after strings, not full file content).
+ */
+
+import { execFile } from 'child_process'
+import { promisify } from 'util'
+import * as fs from 'fs'
+import * as path from 'path'
+
+const execFileAsync = promisify(execFile)
+
+export type FileOutcome = 'productive' | 'reverted' | 'abandoned' | 'ambiguous'
+
+export interface GitOutcome {
+  overall: FileOutcome
+  files: Record<string, FileOutcome>
+  reason: string
+}
+
+const GIT_TIMEOUT_MS = 5000
+const MAX_FILES = 25 // cap subprocess fan-out for sessions that touched an unusually large number of files
+
+async function runGit(cwd: string, args: string[]): Promise<string | null> {
+  try {
+    const { stdout } = await execFileAsync('git', args, { cwd, timeout: GIT_TIMEOUT_MS, maxBuffer: 10 * 1024 * 1024 })
+    return stdout
+  } catch {
+    return null
+  }
+}
+
+async function findRepoRoot(workspace: string): Promise<string | null> {
+  const out = await runGit(workspace, ['rev-parse', '--show-toplevel'])
+  return out?.trim() || null
+}
+
+// Resolves symlinks where possible so paths compare consistently — `git rev-parse --show-toplevel`
+// always returns a fully-resolved path, but a workspace/file path from elsewhere may not (notably
+// macOS, where the default tmpdir and often the home directory sit behind a symlink).
+function realpathBestEffort(p: string): string {
+  try {
+    return fs.realpathSync(p)
+  } catch {
+    try {
+      return path.join(fs.realpathSync(path.dirname(p)), path.basename(p))
+    } catch {
+      return path.resolve(p)
+    }
+  }
+}
+
+// Relative path (posix separators) of `absPath` under `root`, or null if outside the repo.
+function relativeToRoot(root: string, absPath: string): string | null {
+  const rel = path.relative(realpathBestEffort(root), realpathBestEffort(absPath))
+  if (!rel || rel.startsWith('..') || path.isAbsolute(rel)) return null
+  return rel.split(path.sep).join('/')
+}
+
+// Content of `relPath` at the last commit strictly before `sinceIso`, or null if no such commit.
+async function contentBeforeSession(root: string, relPath: string, sinceIso: string): Promise<string | null> {
+  const hash = await runGit(root, ['log', '--format=%H', '-1', '--before=' + sinceIso, '--', relPath])
+  const commitHash = hash?.trim()
+  if (!commitHash) return null
+  return runGit(root, ['show', commitHash + ':' + relPath])
+}
+
+// Content of `relPath` right now: working tree if present on disk, else HEAD, else null.
+function currentContentOnDisk(root: string, relPath: string): string | null {
+  try {
+    return fs.readFileSync(path.join(root, relPath), 'utf-8')
+  } catch {
+    return null
+  }
+}
+
+// Is there a commit touching `relPath` at or after `sinceIso`?
+async function hasCommitSince(root: string, relPath: string, sinceIso: string): Promise<boolean> {
+  const out = await runGit(root, ['log', '--format=%H', '--since=' + sinceIso, '--', relPath])
+  return Boolean(out?.trim())
+}
+
+async function classifyFile(root: string, relPath: string, sessionStartIso: string, sessionEndIso: string): Promise<FileOutcome> {
+  const onDisk = currentContentOnDisk(root, relPath)
+  const after = onDisk !== null ? onDisk : await runGit(root, ['show', 'HEAD:' + relPath])
+  if (after === null) return 'ambiguous' // deleted, moved, or never committed and gone
+
+  const before = await contentBeforeSession(root, relPath, sessionStartIso)
+  if (before !== null && before === after) return 'reverted' // net no-op vs. pre-session state
+
+  return (await hasCommitSince(root, relPath, sessionEndIso)) ? 'productive' : 'abandoned'
+}
+
+const OUTCOME_PRIORITY: FileOutcome[] = ['reverted', 'abandoned', 'ambiguous', 'productive']
+
+function summarize(overall: FileOutcome, files: Record<string, FileOutcome>): string {
+  const total = Object.keys(files).length
+  const count = Object.values(files).filter(v => v === overall).length
+  switch (overall) {
+    case 'reverted':   return `${count}/${total} file(s) reverted to their pre-session state`
+    case 'abandoned':  return `${count}/${total} file(s) still uncommitted since the session`
+    case 'productive': return `${total} file(s) committed after the session`
+    default:           return `Could not determine the outcome for ${count}/${total} file(s)`
+  }
+}
+
+/**
+ * Returns null (rather than an "ambiguous" result) when there's nothing meaningful to classify —
+ * no workspace, no changed files, the workspace path doesn't exist, or it isn't a git repo at all.
+ * Callers should treat null as "not applicable," distinct from a computed-but-inconclusive result.
+ */
+export async function classifySessionOutcome(
+  workspace: string,
+  filesChanged: string[],
+  startTime: string,
+  endTime: string,
+): Promise<GitOutcome | null> {
+  if (!workspace || filesChanged.length === 0) return null
+  if (!fs.existsSync(workspace)) return null
+
+  const root = await findRepoRoot(workspace)
+  if (!root) return null
+
+  const sessionStartIso = startTime || endTime
+  const sessionEndIso = endTime || startTime
+  if (!sessionStartIso) return null
+
+  const files: Record<string, FileOutcome> = {}
+  for (const absPath of filesChanged.slice(0, MAX_FILES)) {
+    const rel = relativeToRoot(root, absPath)
+    if (!rel) { files[absPath] = 'ambiguous'; continue }
+    files[absPath] = await classifyFile(root, rel, sessionStartIso, sessionEndIso)
+  }
+
+  const values = Object.values(files)
+  const overall = OUTCOME_PRIORITY.find(p => values.includes(p)) ?? 'ambiguous'
+
+  return { overall, files, reason: summarize(overall, files) }
+}

--- a/src/test/gitOutcome.test.ts
+++ b/src/test/gitOutcome.test.ts
@@ -1,0 +1,155 @@
+import * as assert from 'assert'
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+import { execFileSync } from 'child_process'
+import { classifySessionOutcome } from '../gitOutcome'
+
+// Builds a throwaway git repo per test so the classifier can be exercised against real git
+// history instead of mocks — commit timestamps are pinned via GIT_AUTHOR_DATE/GIT_COMMITTER_DATE
+// so before/since date filtering is deterministic regardless of how fast the test runs.
+
+let repoDir: string
+let fileCounter = 0
+
+function git(args: string[], isoDate?: string): string {
+  const env = isoDate
+    ? { ...process.env, GIT_AUTHOR_DATE: isoDate, GIT_COMMITTER_DATE: isoDate }
+    : process.env
+  return execFileSync('git', args, { cwd: repoDir, env, encoding: 'utf-8' })
+}
+
+function writeFile(relPath: string, content: string): void {
+  const abs = path.join(repoDir, relPath)
+  fs.mkdirSync(path.dirname(abs), { recursive: true })
+  fs.writeFileSync(abs, content)
+}
+
+function commitAll(message: string, isoDate: string): void {
+  git(['add', '-A'])
+  git(['commit', '-m', message, '--allow-empty'], isoDate)
+}
+
+suite('gitOutcome', () => {
+  setup(() => {
+    repoDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agentlens-gitoutcome-'))
+    git(['init', '-q'])
+    git(['config', 'user.email', 'test@agentlens.local'])
+    git(['config', 'user.name', 'AgentLens Test'])
+    fileCounter++
+  })
+
+  teardown(() => {
+    fs.rmSync(repoDir, { recursive: true, force: true })
+  })
+
+  test('classifies a file as productive when a later commit kept the session\'s change', async () => {
+    const file = `file${fileCounter}.txt`
+    writeFile(file, 'v1')
+    commitAll('initial', '2026-01-01T00:00:00Z')
+
+    // Session runs 01-02 to 01-03; the change is committed afterward, at 01-04.
+    const sessionStart = '2026-01-02T00:00:00Z'
+    const sessionEnd = '2026-01-03T00:00:00Z'
+    writeFile(file, 'v2')
+    commitAll('session change kept', '2026-01-04T00:00:00Z')
+
+    const result = await classifySessionOutcome(repoDir, [path.join(repoDir, file)], sessionStart, sessionEnd)
+    assert.ok(result, 'expected a non-null result')
+    assert.strictEqual(result!.overall, 'productive')
+  })
+
+  test('classifies a file as reverted when a later commit restored the pre-session content', async () => {
+    const file = `file${fileCounter}.txt`
+    writeFile(file, 'v1')
+    commitAll('initial', '2026-01-01T00:00:00Z')
+
+    const sessionStart = '2026-01-02T00:00:00Z'
+    const sessionEnd = '2026-01-03T00:00:00Z'
+    writeFile(file, 'v2')
+    commitAll('session change', '2026-01-04T00:00:00Z')
+    writeFile(file, 'v1')
+    commitAll('revert back to v1', '2026-01-05T00:00:00Z')
+
+    const result = await classifySessionOutcome(repoDir, [path.join(repoDir, file)], sessionStart, sessionEnd)
+    assert.ok(result)
+    assert.strictEqual(result!.overall, 'reverted')
+  })
+
+  test('classifies a file as abandoned when it is still uncommitted after the session', async () => {
+    const file = `file${fileCounter}.txt`
+    writeFile(file, 'v1')
+    commitAll('initial', '2026-01-01T00:00:00Z')
+
+    const sessionStart = '2026-01-02T00:00:00Z'
+    const sessionEnd = '2026-01-03T00:00:00Z'
+    writeFile(file, 'v2') // left modified on disk, never committed
+
+    const result = await classifySessionOutcome(repoDir, [path.join(repoDir, file)], sessionStart, sessionEnd)
+    assert.ok(result)
+    assert.strictEqual(result!.overall, 'abandoned')
+  })
+
+  test('classifies a file as ambiguous when it was never tracked and does not exist on disk', async () => {
+    writeFile('unrelated.txt', 'x')
+    commitAll('initial', '2026-01-01T00:00:00Z')
+
+    const missingFile = path.join(repoDir, 'never-existed.txt')
+    const result = await classifySessionOutcome(repoDir, [missingFile], '2026-01-02T00:00:00Z', '2026-01-03T00:00:00Z')
+    assert.ok(result)
+    assert.strictEqual(result!.overall, 'ambiguous')
+  })
+
+  test('returns null for a workspace that does not exist', async () => {
+    const result = await classifySessionOutcome(
+      path.join(repoDir, 'does-not-exist'),
+      ['whatever.txt'],
+      '2026-01-01T00:00:00Z',
+      '2026-01-02T00:00:00Z',
+    )
+    assert.strictEqual(result, null)
+  })
+
+  test('returns null for a workspace that is not a git repo', async () => {
+    const notARepo = fs.mkdtempSync(path.join(os.tmpdir(), 'agentlens-not-a-repo-'))
+    try {
+      const result = await classifySessionOutcome(notARepo, ['whatever.txt'], '2026-01-01T00:00:00Z', '2026-01-02T00:00:00Z')
+      assert.strictEqual(result, null)
+    } finally {
+      fs.rmSync(notARepo, { recursive: true, force: true })
+    }
+  })
+
+  test('returns null when there are no changed files', async () => {
+    commitAll('initial', '2026-01-01T00:00:00Z')
+    const result = await classifySessionOutcome(repoDir, [], '2026-01-01T00:00:00Z', '2026-01-02T00:00:00Z')
+    assert.strictEqual(result, null)
+  })
+
+  test('overall status prioritizes reverted over productive across multiple files', async () => {
+    const keptFile = `kept${fileCounter}.txt`
+    const revertedFile = `reverted${fileCounter}.txt`
+    writeFile(keptFile, 'v1')
+    writeFile(revertedFile, 'v1')
+    commitAll('initial', '2026-01-01T00:00:00Z')
+
+    const sessionStart = '2026-01-02T00:00:00Z'
+    const sessionEnd = '2026-01-03T00:00:00Z'
+    writeFile(keptFile, 'v2')
+    writeFile(revertedFile, 'v2')
+    commitAll('session changes', '2026-01-04T00:00:00Z')
+    writeFile(revertedFile, 'v1')
+    commitAll('revert one of them', '2026-01-05T00:00:00Z')
+
+    const result = await classifySessionOutcome(
+      repoDir,
+      [path.join(repoDir, keptFile), path.join(repoDir, revertedFile)],
+      sessionStart,
+      sessionEnd,
+    )
+    assert.ok(result)
+    assert.strictEqual(result!.overall, 'reverted')
+    assert.strictEqual(result!.files[path.join(repoDir, keptFile)], 'productive')
+    assert.strictEqual(result!.files[path.join(repoDir, revertedFile)], 'reverted')
+  })
+})


### PR DESCRIPTION
## Summary

Session-outcome correlation with git (`.staged-issues/03-git-outcome-correlation.md`) — loop
detection tells you a session went wrong *during* the run, but nothing previously told you whether
it mattered *afterward*. A session with zero loop signals that got fully reverted an hour later is
just as worth surfacing as one that looped.

New `src/gitOutcome.ts` classifies each of a session's changed files by comparing git history rather
than AgentLens's own recorded diff snippets (which only capture partial before/after strings, not
full file content):
- content immediately before the session started (last commit before `startTime`)
- content right now (working tree, falling back to `HEAD`)
- same content → **reverted**; different + committed since session end → **productive**; different +
  still uncommitted → **abandoned**; can't determine → **ambiguous**

Computed on-demand when a session's detail view is opened (not eagerly for every loaded session —
running git per file per session for potentially thousands of sessions would repeat the mistake the
recent span-store fix cleaned up), and cached per-panel-lifetime in `DashboardPanel`. Surfaced as a
summary banner + per-file badges in the Sessions tab's Files section.

**Scoped to the VS Code extension only** for this pass — the standalone server has no handler for the
new `getGitOutcome` message, so it safely no-ops there (confirmed `standalone/server.ts`'s message
dispatch is a plain if/else-if chain with no default throw — the shared `Sessions.tsx` component just
never receives a response in standalone mode, so the badges simply don't appear, no crash). Local git
only — no GitHub-hosted PR-attribution matching.

8 unit tests build real temporary git repos (pinned commit dates via `GIT_AUTHOR_DATE`/
`GIT_COMMITTER_DATE`) to exercise the classifier against actual git history rather than mocks. This
caught a real bug, not just a test artifact: the initial implementation computed relative paths
without resolving symlinks, which broke silently whenever the workspace or OS temp dir sits behind
one (e.g. macOS's `/var/folders` → `/private/var/folders`, or a symlinked home directory), since
`git rev-parse --show-toplevel` always returns the fully-resolved path.

## Test plan
- [x] `pnpm run check-types` passes
- [x] `pnpm run lint` — 0 errors (pre-existing unrelated warnings only)
- [x] 8/8 new `gitOutcome.test.ts` tests pass against real temp git repos, run via mocha's
  programmatic API (the `mocha` CLI itself is broken under Node v26 in this dev environment —
  pre-existing, unrelated)
- [x] Full non-`vscode`-dependent test suite re-run (146 tests) — no regressions
- [ ] **Not visually verified** — this feature only activates inside the VS Code extension's
  webview, and this environment can't launch the VS Code Extension Development Host (same
  limitation as `vscode-test` generally). Worth a manual check: open a session with file changes in
  a real git workspace and confirm the Files section shows the outcome banner/badges correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)