### PR TITLE
feat: add one-shot / retry-rate metric

### DIFF
--- a/media/src/sessionMetrics.ts
+++ b/media/src/sessionMetrics.ts
@@ -1,6 +1,18 @@
-import type { SessionSummaryCard, TimelineEntry } from './types'
+import type { SessionSummaryCard, TimelineEntry, OneShotStats } from './types'
 import { getAgentProfiles, resolveAgentProfile, type AgentThresholdProfiles } from './agentProfiles'
 import { lookupRates, calcTokenCost, type PricingMode } from './pricing'
+
+// Mirrors src/oneShotRate.ts — see there for why this metric exists and its honest limitations
+// (edit-pass counting, not a correctness signal).
+export const MIN_FILES_FOR_RATE = 2
+
+export function oneShotRate(stats: Pick<OneShotStats, 'filesConsidered' | 'oneShotFiles'>): number | null {
+  return stats.filesConsidered >= MIN_FILES_FOR_RATE ? stats.oneShotFiles / stats.filesConsidered : null
+}
+
+export function avgEditsPerFile(stats: Pick<OneShotStats, 'filesConsidered' | 'totalEdits'>): number | null {
+  return stats.filesConsidered > 0 ? stats.totalEdits / stats.filesConsidered : null
+}
 
 export function fmtUsd(usd: number): string {
   if (usd === 0) return '$0.00'

--- a/media/src/tabs/Agents.tsx
+++ b/media/src/tabs/Agents.tsx
@@ -1,10 +1,12 @@
 import { sessionSummary, timeRange } from '../state'
 import { formatMs, formatCompact } from '../utils'
+import { oneShotRate, avgEditsPerFile } from '../sessionMetrics'
 import type { SessionSummaryCard } from '../types'
 
 export function computeStats(sessions: SessionSummaryCard[]) {
   let totalInput = 0, totalOutput = 0, totalCache = 0
   let totalLlm = 0, totalTools = 0, ttftSum = 0, ttftCount = 0, durSum = 0
+  let filesConsidered = 0, oneShotFiles = 0, totalEdits = 0
   const toolCounts: Record<string, number> = {}
   sessions.forEach(s => {
     totalInput += s.inputTokens ?? 0
@@ -19,7 +21,16 @@ export function computeStats(sessions: SessionSummaryCard[]) {
     ;(s.timeline ?? []).forEach(e => {
       if (e.type === 'llm' && e.ttft) { ttftSum += e.ttft; ttftCount++ }
     })
+    if (s.oneShotStats) {
+      filesConsidered += s.oneShotStats.filesConsidered
+      oneShotFiles += s.oneShotStats.oneShotFiles
+      totalEdits += s.oneShotStats.totalEdits
+    }
   })
+  // File-level aggregate, not an average of per-session rates — a 1-file session shouldn't
+  // weigh the same as a 20-file session. Same MIN_FILES_FOR_RATE gate as the per-session display.
+  const oneShot = oneShotRate({ filesConsidered, oneShotFiles })
+  const editsPerFile = avgEditsPerFile({ filesConsidered, totalEdits })
   return {
     sessions: sessions.length,
     totalInput, totalOutput, totalCache, totalLlm, totalTools,
@@ -27,6 +38,9 @@ export function computeStats(sessions: SessionSummaryCard[]) {
     avgDuration: sessions.length > 0 ? Math.round(durSum / sessions.length) : 0,
     cacheHitRate: totalInput > 0 ? totalCache / totalInput : 0,
     toolCounts,
+    oneShotRate: oneShot,
+    avgEditsPerFile: editsPerFile,
+    oneShotFilesConsidered: filesConsidered,
   }
 }
 

--- a/media/src/tabs/Analytics.tsx
+++ b/media/src/tabs/Analytics.tsx
@@ -61,6 +61,11 @@ function AgentCard({ source, sessions }: { source: string; sessions: SessionSumm
         <div><span style="color:var(--muted)">Cache hit</span> <strong>{(s.cacheHitRate * 100).toFixed(0)}%</strong></div>
         <div><span style="color:var(--muted)">Avg dur</span> <strong>{formatMs(s.avgDuration)}</strong></div>
         {s.avgTtft > 0 && <div><span style="color:var(--muted)">Avg TTFT</span> <strong>{formatMs(s.avgTtft)}</strong></div>}
+        {s.oneShotRate !== null && (
+          <div data-tip="Files edited exactly once vs. files that needed a retry, across all sessions in this view. Edit-pass count, not a signal the code actually worked.">
+            <span style="color:var(--muted)">One-shot</span> <strong>{Math.round(s.oneShotRate * 100)}%</strong>
+          </div>
+        )}
       </div>
       {topTools.length > 0 && (
         <div style="margin-top:8px;padding-top:8px;border-top:1px solid var(--border);font-size:10px;color:var(--muted)">

--- a/media/src/tabs/Sessions.tsx
+++ b/media/src/tabs/Sessions.tsx
@@ -9,7 +9,7 @@ import {
   getAgentColor, getAgentSourceLabel, formatMs, formatCompact, formatSessionTime,
   getDataSourceBadgeHtml, getInitiatorBadgeHtml,
 } from '../utils'
-import { calcSessionCost } from '../sessionMetrics'
+import { calcSessionCost, oneShotRate, avgEditsPerFile } from '../sessionMetrics'
 import { fmtUsd } from './Cost'
 import { generateInsights, InsightCard } from './Insights'
 import { buildDisplaySummary } from '../utils'
@@ -239,6 +239,22 @@ function SessionDetail({ sess }: { sess: SessionSummaryCard }) {
               )
               : (
                 <div style="display:flex;flex-direction:column;gap:3px">
+                  {sess.oneShotStats && (() => {
+                    const rate = oneShotRate(sess.oneShotStats)
+                    const avg = avgEditsPerFile(sess.oneShotStats)
+                    return (
+                      <div
+                        data-tip="Counts edit passes per file — a file edited once is 'one-shot', edited again is a retry. This is a proxy for correction effort, not a signal that the code actually worked."
+                        style="display:flex;align-items:center;gap:6px;padding:5px 8px;margin-bottom:2px;font-size:11px;color:var(--muted);cursor:help"
+                      >
+                        <span>
+                          {rate === null
+                            ? `Not enough edited files for a one-shot rate (${sess.oneShotStats.filesConsidered} considered)`
+                            : `${Math.round(rate * 100)}% one-shot (${sess.oneShotStats.oneShotFiles}/${sess.oneShotStats.filesConsidered} files, avg ${avg?.toFixed(1)} edit passes/file)`}
+                        </span>
+                      </div>
+                    )
+                  })()}
                   {sess.filesChanged.map(f => (
                     <div
                       key={f}

--- a/media/src/types.ts
+++ b/media/src/types.ts
@@ -82,6 +82,15 @@ export interface SessionSummaryCard {
   loopSignals: LoopSignal[]
   peakContextPerTurn?: number
   filesWritten: string[]
+  /** Mirrors src/oneShotRate.ts's OneShotStats. Absent on cards computed before this field existed. */
+  oneShotStats?: OneShotStats
+}
+
+export interface OneShotStats {
+  filesConsidered: number
+  oneShotFiles: number
+  retriedFiles: number
+  totalEdits: number
 }
 
 export interface TimelineEntry {

--- a/src/database/db.ts
+++ b/src/database/db.ts
@@ -94,6 +94,9 @@ function applyMigrations(db: SqlDatabase): void {
   if (!colNames.includes('models')) {
     db.run("ALTER TABLE sessions ADD COLUMN models TEXT NOT NULL DEFAULT '[]'")
   }
+  if (!colNames.includes('one_shot_stats')) {
+    db.run("ALTER TABLE sessions ADD COLUMN one_shot_stats TEXT NOT NULL DEFAULT '{}'")
+  }
 
   // timeline_entries cache token columns
   const teCols = db.exec('PRAGMA table_info(timeline_entries)')

--- a/src/database/reader.ts
+++ b/src/database/reader.ts
@@ -2,6 +2,7 @@ import * as path from 'path'
 import * as fs from 'fs'
 import * as vscode from 'vscode'
 import type { SessionSummaryCard, TimelineEntry, EditDetail } from '../summarizers/summarizerTypes'
+import type { OneShotStats } from '../oneShotRate'
 import { lookupRates, calcTokenCostUsd } from '../pricing'
 
 export interface DailyStatRow {
@@ -116,6 +117,7 @@ export class DatabaseReader {
         errors:           (col(row, 'errors') as number) ?? 0,
         outcome:          (col(row, 'outcome') as 'text_response' | 'tool_calls' | 'unknown') ?? 'unknown',
         loopSignals:      this._parseJson(col(row, 'loop_signals') as string, []),
+        oneShotStats:     this._parseJson<OneShotStats | undefined>(col(row, 'one_shot_stats') as string, undefined),
         timeline:         [],
         backgroundSpans:  [],
       } satisfies SessionSummaryCard
@@ -352,6 +354,7 @@ export class DatabaseReader {
         errors:           (col(row, 'errors') as number) ?? 0,
         outcome:          (col(row, 'outcome') as 'text_response' | 'tool_calls' | 'unknown') ?? 'unknown',
         loopSignals:      this._parseJson(col(row, 'loop_signals') as string, []),
+        oneShotStats:     this._parseJson<OneShotStats | undefined>(col(row, 'one_shot_stats') as string, undefined),
         timeline:         [],
         backgroundSpans:  [],
       } satisfies SessionSummaryCard

--- a/src/database/schema.ts
+++ b/src/database/schema.ts
@@ -34,6 +34,7 @@ CREATE TABLE IF NOT EXISTS sessions (
   cost_usd            REAL    NOT NULL DEFAULT 0,
   data_source         TEXT    NOT NULL DEFAULT 'otel',
   models              TEXT    NOT NULL DEFAULT '[]',
+  one_shot_stats      TEXT    NOT NULL DEFAULT '{}',
   created_at          INTEGER NOT NULL DEFAULT (CAST(strftime('%s', 'now') AS INTEGER) * 1000)
 );
 

--- a/src/database/writer.ts
+++ b/src/database/writer.ts
@@ -158,8 +158,8 @@ export class DatabaseWriter {
         total_tool_calls, total_llm_calls, errors, outcome,
         is_sidechain, speed, user_request, tool_counts, loop_signals,
         files_read, files_changed, files_written, files_searched, files_changed_note, cost_usd,
-        data_source, models
-      ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+        data_source, models, one_shot_stats
+      ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
       [
         card.sessionId,
         card.traceId,
@@ -192,6 +192,7 @@ export class DatabaseWriter {
         costUsd,
         card.dataSource,
         JSON.stringify(card.models ?? (card.model ? [card.model] : [])),
+        JSON.stringify(card.oneShotStats ?? {}),
       ]
     )
   }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -17,6 +17,7 @@ import { SessionRepository } from './sessionRepository'
 import { summarizeSpans } from './spanSummarizer'
 import { LogReader } from './logReader'
 import { detectLoopSignals } from './loopDetector'
+import { computeOneShotStats } from './oneShotRate'
 import { startMcpHttpServer } from './mcpServer'
 import { InstructionRepository } from './database/instructionRepository'
 
@@ -239,6 +240,7 @@ export async function activate(context: vscode.ExtensionContext) {
       const ws = fallbackWorkspace()
       for (const { card, workspace } of results) {
         card.loopSignals = detectLoopSignals(card)
+        card.oneShotStats = computeOneShotStats(card)
         writer!.enqueue(card, workspace || ws)
       }
       void writer!.drain().then(() => {
@@ -294,6 +296,7 @@ export async function activate(context: vscode.ExtensionContext) {
               const result = lr.parseFile(files[i].filePath, files[i].agentKey)
               if (result) {
                 result.card.loopSignals = detectLoopSignals(result.card)
+                result.card.oneShotStats = computeOneShotStats(result.card)
                 writer!.enqueue(result.card, result.workspace || ws)
                 const dk = files[i].agentKey === 'copilot_vscode_json' ? 'copilot_vscode' : files[i].agentKey
                 countByKey.set(dk, (countByKey.get(dk) ?? 0) + 1)
@@ -324,6 +327,7 @@ export async function activate(context: vscode.ExtensionContext) {
         const ws = fallbackWorkspace()
         for (const { card, workspace } of ocResults) {
           card.loopSignals = detectLoopSignals(card)
+          card.oneShotStats = computeOneShotStats(card)
           writer!.enqueue(card, workspace || ws)
         }
         countByKey.set('opencode', (countByKey.get('opencode') ?? 0) + ocResults.length)

--- a/src/loopDetector.ts
+++ b/src/loopDetector.ts
@@ -103,16 +103,14 @@ export function detectExactToolRepeat(session: SessionSummaryCard, signals: Loop
   })
 }
 
-// ── Detector 2: Edit-revert cycle ────────────────────────────────────────────
+// ── Shared: per-file edit extraction ─────────────────────────────────────────
 
 /**
- * Detects when a file is edited (A→B) and later reverted to its prior state
- * (B→A). Checks every pair of edits on the same file for exact string reversal.
- *
- * Always critical when detected — there is no legitimate reason for an agent to
- * undo its own edit unless it is oscillating.
+ * Walks a session's timeline and groups every (oldString, newString) edit pair by the file it
+ * touched. Shared by detectEditRevertCycle below and by oneShotRate.ts's retry-rate metric — both
+ * need the same "how many times, and how, was each file edited" data, just aggregated differently.
  */
-export function detectEditRevertCycle(session: SessionSummaryCard, signals: LoopSignal[]): void {
+export function getFileEditCounts(session: SessionSummaryCard): Record<string, Array<{ old: string; new: string }>> {
   const fileEdits: Record<string, Array<{ old: string; new: string }>> = {}
 
   for (const entry of session.timeline) {
@@ -123,6 +121,21 @@ export function detectEditRevertCycle(session: SessionSummaryCard, signals: Loop
       fileEdits[detail.filePath].push({ old: detail.oldString, new: detail.newString })
     }
   }
+
+  return fileEdits
+}
+
+// ── Detector 2: Edit-revert cycle ────────────────────────────────────────────
+
+/**
+ * Detects when a file is edited (A→B) and later reverted to its prior state
+ * (B→A). Checks every pair of edits on the same file for exact string reversal.
+ *
+ * Always critical when detected — there is no legitimate reason for an agent to
+ * undo its own edit unless it is oscillating.
+ */
+export function detectEditRevertCycle(session: SessionSummaryCard, signals: LoopSignal[]): void {
+  const fileEdits = getFileEditCounts(session)
 
   const revertedFiles: string[] = []
 

--- a/src/oneShotRate.ts
+++ b/src/oneShotRate.ts
@@ -1,0 +1,48 @@
+/**
+ * One-shot / retry-rate metric — did each file the agent touched get it right on the first edit?
+ *
+ * File-edit-count based, not semantic: this counts edit passes per file, not whether the resulting
+ * code actually worked. A one-character retry counts the same as a full rewrite. Reasonable proxy,
+ * not a correctness signal — don't oversell it as one.
+ */
+
+import type { SessionSummaryCard } from './summarizers/summarizerTypes'
+import { getFileEditCounts } from './loopDetector'
+
+export interface OneShotStats {
+  filesConsidered: number // files edited at least once
+  oneShotFiles: number    // of those, edited exactly once
+  retriedFiles: number    // of those, edited 2+ times
+  totalEdits: number      // sum of edit passes across all considered files
+}
+
+const EMPTY_STATS: OneShotStats = { filesConsidered: 0, oneShotFiles: 0, retriedFiles: 0, totalEdits: 0 }
+
+export function computeOneShotStats(session: SessionSummaryCard): OneShotStats {
+  const fileEdits = getFileEditCounts(session)
+  const files = Object.values(fileEdits)
+  if (files.length === 0) return EMPTY_STATS
+
+  const oneShotFiles = files.filter(edits => edits.length === 1).length
+  const totalEdits = files.reduce((sum, edits) => sum + edits.length, 0)
+
+  return {
+    filesConsidered: files.length,
+    oneShotFiles,
+    retriedFiles: files.length - oneShotFiles,
+    totalEdits,
+  }
+}
+
+// Minimum edited-file sample size before a rate is meaningful rather than a coin flip dressed up
+// as a percentage. Below this, callers should show "insufficient data" instead of a rate.
+export const MIN_FILES_FOR_RATE = 2
+
+/** Null when there's not enough data to be meaningful — never a misleadingly perfect 0% or 100%. */
+export function oneShotRate(stats: Pick<OneShotStats, 'filesConsidered' | 'oneShotFiles'>): number | null {
+  return stats.filesConsidered >= MIN_FILES_FOR_RATE ? stats.oneShotFiles / stats.filesConsidered : null
+}
+
+export function avgEditsPerFile(stats: Pick<OneShotStats, 'filesConsidered' | 'totalEdits'>): number | null {
+  return stats.filesConsidered > 0 ? stats.totalEdits / stats.filesConsidered : null
+}

--- a/src/spanSummarizer.ts
+++ b/src/spanSummarizer.ts
@@ -10,6 +10,7 @@
 
 import { Span } from './types'
 import { detectLoopSignals } from './loopDetector'
+import { computeOneShotStats } from './oneShotRate'
 import { buildCopilotSessions } from './summarizers/copilot'
 import { buildClaudeSessions } from './summarizers/claude'
 import { buildCodexSessions } from './summarizers/codex'
@@ -141,6 +142,7 @@ export function summarizeSpans(spans: Span[]) {
   const sessions = allSorted
 
   sessions.forEach(s => { s.loopSignals = detectLoopSignals(s) })
+  sessions.forEach(s => { s.oneShotStats = computeOneShotStats(s) })
 
   // Background/orphan spans — associate with sessions by traceId
   const bgByTraceId: Record<string, Array<{ name: string; model: string; purpose: string; inputTokens: number; outputTokens: number }>> = {}

--- a/src/summarizers/summarizerTypes.ts
+++ b/src/summarizers/summarizerTypes.ts
@@ -1,4 +1,5 @@
 import { LoopSignal } from '../types'
+import type { OneShotStats } from '../oneShotRate'
 
 export interface SessionSummaryCard {
   sessionId: string
@@ -35,6 +36,10 @@ export interface SessionSummaryCard {
   loopSignals: LoopSignal[]
   peakContextPerTurn?: number   // max single-turn (input + cacheRead + cacheCreate); undefined for single-turn sessions
   filesWritten: string[]        // files fully written (Write / create_file tools); subset of filesChanged
+  /** One-shot/retry edit-pass stats, derived from timeline editDetails. Computed during
+   *  summarization (see spanSummarizer.ts), same lifecycle as loopSignals — absent on
+   *  synthetic/in-progress cards built before that pass runs. */
+  oneShotStats?: OneShotStats
 }
 
 export interface TimelineEntry {

--- a/src/test/oneShotRate.test.ts
+++ b/src/test/oneShotRate.test.ts
@@ -1,0 +1,132 @@
+import * as assert from 'assert'
+import { computeOneShotStats, oneShotRate, avgEditsPerFile, MIN_FILES_FOR_RATE } from '../oneShotRate'
+import { SessionSummaryCard, TimelineEntry } from '../spanSummarizer'
+
+// ── Factories (mirrors loopDetector.test.ts) ───────────────────────────────────
+
+function makeSession(overrides: Partial<SessionSummaryCard> = {}): SessionSummaryCard {
+  return {
+    sessionId: 'sess-1',
+    traceId: 'trace-1',
+    source: 'claude_code',
+    dataSource: 'otel',
+    workspace: '',
+    userRequest: 'fix the bug',
+    model: 'claude-3-5-sonnet',
+    turns: 3,
+    inputTokens: 5000,
+    outputTokens: 800,
+    cacheReadTokens: 0,
+    cacheCreateTokens: 0,
+    cacheHitRate: 0,
+    durationMs: 12000,
+    startTime: new Date().toISOString(),
+    filesRead: [],
+    filesSearched: [],
+    filesChanged: [],
+    filesWritten: [],
+    toolCounts: {},
+    totalToolCalls: 5,
+    totalLlmCalls: 3,
+    errors: 0,
+    outcome: 'unknown',
+    timeline: [],
+    backgroundSpans: [],
+    loopSignals: [],
+    ...overrides,
+  }
+}
+
+function makeEdit(filePath: string, oldString: string, newString: string): TimelineEntry {
+  return {
+    type: 'tool',
+    spanId: 'span-' + Math.random().toString(36).slice(2, 8),
+    label: 'edit_file',
+    durationMs: 100,
+    isError: false,
+    timestamp: new Date().toISOString(),
+    editDetails: [{ filePath, oldString, newString }],
+  }
+}
+
+suite('oneShotRate', () => {
+  suite('computeOneShotStats', () => {
+    test('empty timeline yields all-zero stats', () => {
+      const stats = computeOneShotStats(makeSession({ timeline: [] }))
+      assert.deepStrictEqual(stats, { filesConsidered: 0, oneShotFiles: 0, retriedFiles: 0, totalEdits: 0 })
+    })
+
+    test('counts a file edited exactly once as one-shot', () => {
+      const stats = computeOneShotStats(makeSession({
+        timeline: [makeEdit('a.ts', 'old', 'new')],
+      }))
+      assert.strictEqual(stats.filesConsidered, 1)
+      assert.strictEqual(stats.oneShotFiles, 1)
+      assert.strictEqual(stats.retriedFiles, 0)
+      assert.strictEqual(stats.totalEdits, 1)
+    })
+
+    test('counts a file edited multiple times as retried, not one-shot', () => {
+      const stats = computeOneShotStats(makeSession({
+        timeline: [
+          makeEdit('a.ts', 'v1', 'v2'),
+          makeEdit('a.ts', 'v2', 'v3'),
+          makeEdit('a.ts', 'v3', 'v4'),
+        ],
+      }))
+      assert.strictEqual(stats.filesConsidered, 1)
+      assert.strictEqual(stats.oneShotFiles, 0)
+      assert.strictEqual(stats.retriedFiles, 1)
+      assert.strictEqual(stats.totalEdits, 3)
+    })
+
+    test('mixed session: some files one-shot, some retried', () => {
+      const stats = computeOneShotStats(makeSession({
+        timeline: [
+          makeEdit('a.ts', 'x', 'y'),          // one-shot
+          makeEdit('b.ts', '1', '2'),
+          makeEdit('b.ts', '2', '3'),           // retried
+          makeEdit('c.ts', 'foo', 'bar'),       // one-shot
+        ],
+      }))
+      assert.strictEqual(stats.filesConsidered, 3)
+      assert.strictEqual(stats.oneShotFiles, 2)
+      assert.strictEqual(stats.retriedFiles, 1)
+      assert.strictEqual(stats.totalEdits, 4)
+    })
+
+    test('ignores tool entries without editDetails', () => {
+      const stats = computeOneShotStats(makeSession({
+        timeline: [
+          { type: 'tool', spanId: 's1', label: 'read_file', durationMs: 10, isError: false, timestamp: new Date().toISOString() },
+          makeEdit('a.ts', 'x', 'y'),
+        ],
+      }))
+      assert.strictEqual(stats.filesConsidered, 1)
+    })
+  })
+
+  suite('oneShotRate', () => {
+    test('returns null below the minimum file sample size', () => {
+      assert.strictEqual(MIN_FILES_FOR_RATE, 2, 'sanity check the threshold this test assumes')
+      assert.strictEqual(oneShotRate({ filesConsidered: 0, oneShotFiles: 0 }), null)
+      assert.strictEqual(oneShotRate({ filesConsidered: 1, oneShotFiles: 1 }), null)
+    })
+
+    test('computes a rate once the minimum is met', () => {
+      assert.strictEqual(oneShotRate({ filesConsidered: 4, oneShotFiles: 3 }), 0.75)
+      assert.strictEqual(oneShotRate({ filesConsidered: 2, oneShotFiles: 0 }), 0)
+      assert.strictEqual(oneShotRate({ filesConsidered: 2, oneShotFiles: 2 }), 1)
+    })
+  })
+
+  suite('avgEditsPerFile', () => {
+    test('returns null when no files were considered', () => {
+      assert.strictEqual(avgEditsPerFile({ filesConsidered: 0, totalEdits: 0 }), null)
+    })
+
+    test('computes the average otherwise', () => {
+      assert.strictEqual(avgEditsPerFile({ filesConsidered: 4, totalEdits: 6 }), 1.5)
+    })
+  })
+})


### PR DESCRIPTION
## Summary

One-shot / retry-rate metric (`.staged-issues/05-one-shot-retry-rate.md`) — AgentLens had
efficiency signals (context bloat, cache misses) but nothing answering "did it solve this on the
first try." A cheap, concrete proxy for correction effort that was previously invisible in the
dashboard.

File-edit-count based, not semantic — a proxy for correction effort, not a signal the resulting
code actually worked.

- Extracted the per-file edit-pair parsing already living in `loopDetector.ts`'s
  `detectEditRevertCycle` into a shared `getFileEditCounts()` helper, so both the loop detector and
  the new `src/oneShotRate.ts` consume the same timeline walk instead of duplicating it.
- Computed during summarization (`spanSummarizer.ts` for OTEL, three call sites in `extension.ts`
  for log ingestion — same lifecycle as `loopSignals`) and persisted as a new `one_shot_stats` DB
  column (`schema.ts` for fresh DBs, an `ALTER TABLE` migration in `db.ts` for existing ones,
  following this repo's existing `PRAGMA table_info`-guarded migration pattern). This is what makes
  the per-model Analytics aggregate work for **historical** sessions, not just live ones —
  bulk-listed sessions never carry full timeline data (`listSessions` always sets `timeline: []`),
  so the per-session file-edit counts have to survive as a precomputed field.
- Surfaced in two places, both file-level aggregates rather than averages of per-session rates (a
  1-file session shouldn't weigh the same as a 20-file one): a one-shot/retry line in the Sessions
  tab's Files section, and a "One-shot" stat tile in Analytics' per-agent breakdown cards. Both
  apply the same minimum-sample-size gate (2+ edited files) before showing a rate, so a 1-file
  session shows "not enough data" rather than a misleading 0%/100%.

## Test plan
- [x] `pnpm run check-types` passes
- [x] `pnpm run lint` — 0 errors (pre-existing unrelated warnings only)
- [x] 9 new `oneShotRate.test.ts` tests pass
- [x] Full 197-test suite passes locally, including the `DatabaseWriter`/`DatabaseReader`/migration
  tests exercising the exact schema change this PR depends on — fixed a gap in my own local
  verification along the way: running mocha programmatically without first requiring
  `src/test/setup.js` silently skips every test that touches the `vscode` module mock (most of
  `src/database/*` and `extension.test.ts`), which I hadn't been loading in the last two PRs.
  Documented in memory so this doesn't recur.
- [ ] Not visually verified — same reasoning as the last PR (no VS Code Extension Development Host
  available in this environment), plus this time avoided starting another standalone server smoke
  test given the DB migration risk if run against a live session and to avoid repeating the
  port-conflict/config-pollution issue from earlier sessions. Worth a manual check on both an
  existing (migrated) DB and a fresh one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)