### PR TITLE
feat: add CSV and Markdown export formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
 - **Cost Estimation** — Estimates session cost for Copilot (three billing models), Claude Code, and Codex, broken down by model in a day-grouped table
 - **Efficiency & Inefficiency Detection** — Surfaces context bloat, redundant tool calls, cache misses, and five loop/malfunction patterns with suggested prompts to correct course
 - **Configurable Alerts** — Threshold-based notifications for turns, errors, active time, and repeat tool calls — per-agent or shared
-- **Export** — Export filtered sessions as JSON (full or redacted); respects the active agent, source, time range, and text filters
+- **Export** — Export filtered sessions as JSON, CSV, or Markdown (full or redacted); respects the active agent, source, time range, and text filters
 - **Import** — Import sessions from a previous AgentLens JSON export; drag-drop or file-pick, shows a preview with session count by source and date range, imports with live progress and automatic deduplication (existing sessions are skipped)
 
 ## Data Sources
@@ -149,10 +149,13 @@ All figures are estimates — not your actual bill. Rates are sourced from each 
 
 ### Export
 
-The **Export** tab writes session summary files to your workspace root:
+The **Export** tab writes session summary files to your workspace root, in your choice of three formats:
 
-- `export_sessions_<timestamp>.json` — full export including prompt text, token counts, tool usage, file changes, and cost estimates for every recorded session
-- `export_sessions_<timestamp>.json` (redacted) — same structure with prompt text (`userRequest`) removed
+- **JSON** (default) — full-fidelity structured export including prompt text, token counts, tool usage, file changes, and cost estimates for every recorded session. This is the only format the **Import** tab reads back in.
+- **CSV** — one row per session, with array/object fields (models, files, tool counts, loop signals) flattened into semicolon-joined cells. Built for dropping into a spreadsheet.
+- **Markdown** — one section per session with the same data laid out as a readable report, prompt included as a blockquote. Built for sharing.
+
+Each format is available both as the full export and as a redacted export (prompt text and file paths replaced with `[redacted]`) — filenames follow `export_sessions_<timestamp>.<ext>` (or `export_redacted_sessions_<timestamp>.<ext>` for the redacted version), with `<ext>` matching the format chosen (`json`, `csv`, or `md`).
 
 Exports draw from the full SQLite session history, not just the active window, so all past sessions are included regardless of when they ran.
 
@@ -160,7 +163,7 @@ Exports draw from the full SQLite session history, not just the active window, s
 
 ### Import
 
-The **Import** tab loads sessions from a previous AgentLens export file into the current installation — useful for migrating data to a new machine, sharing session history across team members, or restoring a local backup.
+The **Import** tab loads sessions from a previous AgentLens **JSON** export file into the current installation — useful for migrating data to a new machine, sharing session history across team members, or restoring a local backup. CSV and Markdown exports are one-way (for external consumption) and can't be imported back.
 
 1. Open the **Import** tab in the dashboard
 2. Drag-and-drop an `export_sessions_*.json` file onto the drop zone, or click **Choose file**

--- a/media/dashboard.css
+++ b/media/dashboard.css
@@ -1072,8 +1072,21 @@ body {
   font-weight: 600;
   margin-top: 6px;
 }
-.export-btn {
+.export-card-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
   margin-top: 4px;
+}
+.export-format-select {
+  padding: 6px 8px;
+  border-radius: 4px;
+  border: 1px solid var(--border);
+  background: var(--card-bg);
+  color: var(--fg);
+  font-size: 12px;
+}
+.export-btn {
   padding: 7px 14px;
   border-radius: 4px;
   border: none;

--- a/media/src/styles/export.css
+++ b/media/src/styles/export.css
@@ -116,8 +116,23 @@
   margin-top: 6px;
 }
 
-.export-btn {
+.export-card-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
   margin-top: 4px;
+}
+
+.export-format-select {
+  padding: 6px 8px;
+  border-radius: 4px;
+  border: 1px solid var(--border);
+  background: var(--card-bg);
+  color: var(--fg);
+  font-size: 12px;
+}
+
+.export-btn {
   padding: 7px 14px;
   border-radius: 4px;
   border: none;

--- a/media/src/tabs/Export.tsx
+++ b/media/src/tabs/Export.tsx
@@ -1,30 +1,52 @@
 import { useState } from 'preact/hooks'
 import { filteredSessions, vscode } from '../state'
 
-function send(type: string, sessionIds: string[]) {
+type ExportFormat = 'json' | 'csv' | 'markdown'
+const FORMAT_OPTIONS: Array<{ value: ExportFormat; label: string }> = [
+  { value: 'json', label: 'JSON' },
+  { value: 'csv', label: 'CSV' },
+  { value: 'markdown', label: 'Markdown' },
+]
+
+function send(type: string, sessionIds: string[], format: ExportFormat) {
   if (vscode) {
-    vscode.postMessage({ type, sessionIds })
+    vscode.postMessage({ type, sessionIds, format })
   } else {
-    window.dispatchEvent(new MessageEvent('message', { data: { type, sessionIds } }))
+    window.dispatchEvent(new MessageEvent('message', { data: { type, sessionIds, format } }))
   }
+}
+
+function FormatSelect({ value, onChange }: { value: ExportFormat; onChange: (f: ExportFormat) => void }) {
+  return (
+    <select
+      value={value}
+      onChange={e => onChange((e.target as HTMLSelectElement).value as ExportFormat)}
+      class="export-format-select"
+      aria-label="Export format"
+    >
+      {FORMAT_OPTIONS.map(opt => <option key={opt.value} value={opt.value}>{opt.label}</option>)}
+    </select>
+  )
 }
 
 export function Export() {
   const [rawDone, setRawDone] = useState(false)
   const [redactedDone, setRedactedDone] = useState(false)
+  const [rawFormat, setRawFormat] = useState<ExportFormat>('json')
+  const [redactedFormat, setRedactedFormat] = useState<ExportFormat>('json')
 
   const sessions = filteredSessions.value
   const empty = sessions.length === 0
   const scopeLabel = `${sessions.length} session${sessions.length === 1 ? '' : 's'} matching your current filters`
 
   const doExport = () => {
-    send('exportSessionData', sessions.map(s => s.sessionId))
+    send('exportSessionData', sessions.map(s => s.sessionId), rawFormat)
     setRawDone(true)
     setTimeout(() => setRawDone(false), 3000)
   }
 
   const doRedacted = () => {
-    send('exportSessionDataRedacted', sessions.map(s => s.sessionId))
+    send('exportSessionDataRedacted', sessions.map(s => s.sessionId), redactedFormat)
     setRedactedDone(true)
     setTimeout(() => setRedactedDone(false), 3000)
   }
@@ -40,8 +62,9 @@ export function Export() {
             <span class="export-card-badge export-badge-raw">Full</span>
           </div>
           <p class="export-card-desc">
-            Exported as JSON — includes prompt text, token counts,
-            tool usage, file changes, cost estimates, and efficiency signals.
+            Includes prompt text, token counts, tool usage, file changes, cost estimates, and
+            efficiency signals. JSON is the format the Import tab reads back in; CSV and Markdown
+            are for spreadsheets and shareable reports.
           </p>
           <ul class="export-card-includes">
             <li>Prompt text (userRequest)</li>
@@ -51,13 +74,16 @@ export function Export() {
           </ul>
           <div class="export-card-warning">Keep private — includes prompt text.</div>
           <div class="export-card-scope">{empty ? 'No sessions match your current filters' : scopeLabel}</div>
-          <button
-            class={'export-btn' + (rawDone ? ' export-btn-done' : '')}
-            onClick={doExport}
-            disabled={empty}
-          >
-            {rawDone ? '✓ Exported' : 'Export Session Data'}
-          </button>
+          <div class="export-card-actions">
+            <FormatSelect value={rawFormat} onChange={setRawFormat} />
+            <button
+              class={'export-btn' + (rawDone ? ' export-btn-done' : '')}
+              onClick={doExport}
+              disabled={empty}
+            >
+              {rawDone ? '✓ Exported' : 'Export Session Data'}
+            </button>
+          </div>
         </div>
 
         <div class="export-card export-card-redacted">
@@ -78,13 +104,16 @@ export function Export() {
           </ul>
           <div class="export-card-safe">Safer to share — no prompt text or file paths.</div>
           <div class="export-card-scope">{empty ? 'No sessions match your current filters' : scopeLabel}</div>
-          <button
-            class={'export-btn export-btn-secondary' + (redactedDone ? ' export-btn-done' : '')}
-            onClick={doRedacted}
-            disabled={empty}
-          >
-            {redactedDone ? '✓ Exported' : 'Export Session Data (Redacted)'}
-          </button>
+          <div class="export-card-actions">
+            <FormatSelect value={redactedFormat} onChange={setRedactedFormat} />
+            <button
+              class={'export-btn export-btn-secondary' + (redactedDone ? ' export-btn-done' : '')}
+              onClick={doRedacted}
+              disabled={empty}
+            >
+              {redactedDone ? '✓ Exported' : 'Export Session Data (Redacted)'}
+            </button>
+          </div>
         </div>
 
       </div>

--- a/media/src/tabs/Help.tsx
+++ b/media/src/tabs/Help.tsx
@@ -801,7 +801,7 @@ function ExportSection() {
     <div class="help-section" id="help-export">
       <h3 class="help-heading">{HELP_SECTIONS.export.heading}</h3>
       <div class="help-overview-body">
-        <p>The Export tab lets you download sessions as a JSON file. Exports respect all active filters — agent, source, time range, and text search — so what you export matches exactly what you see in the Sessions tab.</p>
+        <p>The Export tab lets you download sessions as JSON, CSV, or Markdown. Exports respect all active filters — agent, source, time range, and text search — so what you export matches exactly what you see in the Sessions tab.</p>
         <div class="glossary">
           <div class="glossary-item" style="flex-direction:column;gap:4px">
             <dt class="glossary-term">Full export</dt>
@@ -810,6 +810,18 @@ function ExportSection() {
           <div class="glossary-item" style="flex-direction:column;gap:4px">
             <dt class="glossary-term">Redacted export</dt>
             <dd class="glossary-def" style="display:block">Prompt text is removed; all other fields (tokens, cost, timing, tool names, file paths, span structure) are retained. Use this when sharing data for debugging or support without exposing conversation content.</dd>
+          </div>
+          <div class="glossary-item" style="flex-direction:column;gap:4px">
+            <dt class="glossary-term">Format: JSON</dt>
+            <dd class="glossary-def" style="display:block">Full-fidelity structured export. The only format the Import tab reads back in — use this if you plan to bring the data into AgentLens on another machine.</dd>
+          </div>
+          <div class="glossary-item" style="flex-direction:column;gap:4px">
+            <dt class="glossary-term">Format: CSV</dt>
+            <dd class="glossary-def" style="display:block">One row per session, for spreadsheets. Array/object fields (models, files, tool counts, loop signals) are flattened into semicolon-joined cells.</dd>
+          </div>
+          <div class="glossary-item" style="flex-direction:column;gap:4px">
+            <dt class="glossary-term">Format: Markdown</dt>
+            <dd class="glossary-def" style="display:block">One readable section per session — for sharing a report rather than raw data.</dd>
           </div>
         </div>
         <p style="font-size:12px;color:var(--muted);margin-top:12px">Raw OTEL span export for session replay is planned but not yet available.</p>

--- a/src/dashboardPanel.ts
+++ b/src/dashboardPanel.ts
@@ -5,6 +5,11 @@ import { InstructionRepository } from './database/instructionRepository'
 import { detectInstructionFiles, appendSuggestion, removeSuggestion } from './instructionFiles'
 import { computeBaseline } from './instructionEffectiveness'
 import { autoConfigureCopilot, autoConfigureClaudeCode, autoConfigureCodex } from './autoConfig'
+import { serializeExport, exportFileExtension, type ExportFormat } from './exportFormats'
+
+function isExportFormat(value: unknown): value is ExportFormat {
+  return value === 'json' || value === 'csv' || value === 'markdown'
+}
 
 export class DashboardPanel {
   public static currentPanel: DashboardPanel | undefined
@@ -100,7 +105,8 @@ export class DashboardPanel {
       } else if (msg.type === 'exportSessionData' || msg.type === 'exportSessionDataRedacted') {
         const redact = msg.type === 'exportSessionDataRedacted'
         const ids = Array.isArray(msg.sessionIds) ? new Set(msg.sessionIds as string[]) : null
-        void this.exportSessions(redact, ids)
+        const format = isExportFormat(msg.format) ? msg.format : 'json'
+        void this.exportSessions(redact, ids, format)
       } else if (msg.type === 'openSidebar') {
         vscode.commands.executeCommand('workbench.view.extension.agent-lens')
       } else if (msg.type === 'closeSidebar') {
@@ -262,7 +268,7 @@ export class DashboardPanel {
     }
   }
 
-  private async exportSessions(redact: boolean, ids: Set<string> | null = null): Promise<void> {
+  private async exportSessions(redact: boolean, ids: Set<string> | null = null, format: ExportFormat = 'json'): Promise<void> {
     const all = this.repo.listSessions()
     const sessions = ids ? all.filter(s => ids.has(s.sessionId)) : all
     if (sessions.length === 0) {
@@ -306,13 +312,13 @@ export class DashboardPanel {
     const pad = (n: number) => n.toString().padStart(2, '0')
     const ts = `${now.getFullYear()}${pad(now.getMonth() + 1)}${pad(now.getDate())}_${pad(now.getHours())}${pad(now.getMinutes())}${pad(now.getSeconds())}`
     const prefix = redact ? 'export_redacted' : 'export'
-    const filename = `${prefix}_sessions_${ts}.json`
+    const filename = `${prefix}_sessions_${ts}.${exportFileExtension(format)}`
 
     const workspaceFolder = vscode.workspace.workspaceFolders?.[0]
     const baseUri = workspaceFolder ? workspaceFolder.uri : this.context.globalStorageUri
     const fileUri = vscode.Uri.joinPath(baseUri, filename)
 
-    await vscode.workspace.fs.writeFile(fileUri, Buffer.from(JSON.stringify(exportable, null, 2)))
+    await vscode.workspace.fs.writeFile(fileUri, Buffer.from(serializeExport(exportable, format)))
     vscode.window.showInformationMessage(`AgentLens: Exported ${sessions.length} sessions to ${filename}`)
     const doc = await vscode.workspace.openTextDocument(fileUri)
     vscode.window.showTextDocument(doc, { preview: false })

--- a/src/exportFormats.ts
+++ b/src/exportFormats.ts
@@ -1,0 +1,143 @@
+/**
+ * CSV/Markdown serialization for session exports — generalizes the CSV pattern already used by
+ * the Analytics tab's cost-table export (media/src/tabs/Analytics.tsx) to the full session export.
+ *
+ * JSON stays the default/primary export format (and the only one Import reads back) — these are
+ * for external consumption: dropping into a spreadsheet, or sharing a readable report.
+ */
+
+import type { LoopSignal } from './types'
+
+export type ExportFormat = 'json' | 'csv' | 'markdown'
+
+// Matches the `exportable` shape built in DashboardPanel.exportSessions / standalone/server.ts's
+// browser-side export handler. Kept intentionally loose (readonly, no class) so both callers can
+// pass their own plain object literals without extra conversion.
+export interface ExportableSession {
+  sessionId: string
+  traceId: string
+  source: string
+  model: string
+  models: string[]
+  startTime: string
+  durationMs: number
+  turns: number
+  totalToolCalls: number
+  inputTokens: number
+  outputTokens: number
+  cacheReadTokens: number
+  cacheCreateTokens: number
+  cacheHitRate: number
+  errors: number
+  outcome: string
+  toolCounts: Record<string, number>
+  filesRead: string[]
+  filesChanged: string[]
+  loopSignals: Pick<LoopSignal, 'type' | 'severity'>[]
+  userRequest: string
+}
+
+export function exportFileExtension(format: ExportFormat): string {
+  return format === 'csv' ? 'csv' : format === 'markdown' ? 'md' : 'json'
+}
+
+// Every field quoted unconditionally (matches the existing Analytics CSV export's convention) —
+// simplest approach that's always correct, no need to special-case which fields might contain a
+// comma, quote, or newline.
+function csvCell(value: string): string {
+  return '"' + value.replace(/"/g, '""') + '"'
+}
+
+function joinList(items: string[]): string {
+  return items.join('; ')
+}
+
+function joinToolCounts(counts: Record<string, number>): string {
+  return Object.entries(counts).map(([tool, n]) => `${tool}:${n}`).join('; ')
+}
+
+function joinLoopSignals(signals: Pick<LoopSignal, 'type' | 'severity'>[]): string {
+  return signals.map(s => `${s.type}(${s.severity})`).join('; ')
+}
+
+const CSV_HEADERS = [
+  'Session ID', 'Trace ID', 'Source', 'Model', 'Models', 'Start Time', 'Duration (ms)', 'Turns',
+  'Tool Calls', 'Input Tokens', 'Output Tokens', 'Cache Read Tokens', 'Cache Create Tokens',
+  'Cache Hit Rate', 'Errors', 'Outcome', 'Tool Counts', 'Files Read', 'Files Changed',
+  'Loop Signals', 'User Request',
+]
+
+export function toCsv(sessions: ExportableSession[]): string {
+  const rows = sessions.map(s => [
+    s.sessionId,
+    s.traceId,
+    s.source,
+    s.model,
+    joinList(s.models),
+    s.startTime,
+    String(s.durationMs),
+    String(s.turns),
+    String(s.totalToolCalls),
+    String(s.inputTokens),
+    String(s.outputTokens),
+    String(s.cacheReadTokens),
+    String(s.cacheCreateTokens),
+    s.cacheHitRate.toFixed(4),
+    String(s.errors),
+    s.outcome,
+    joinToolCounts(s.toolCounts),
+    joinList(s.filesRead),
+    joinList(s.filesChanged),
+    joinLoopSignals(s.loopSignals),
+    s.userRequest,
+  ])
+  return [CSV_HEADERS, ...rows].map(row => row.map(csvCell).join(',')).join('\r\n') + '\r\n'
+}
+
+function mdEscape(text: string): string {
+  return text.replace(/\|/g, '\\|')
+}
+
+export function toMarkdown(sessions: ExportableSession[]): string {
+  const parts: string[] = [
+    `# AgentLens Session Export`,
+    ``,
+    `${sessions.length} session${sessions.length === 1 ? '' : 's'}, exported ${new Date().toISOString()}`,
+    ``,
+  ]
+
+  for (const s of sessions) {
+    parts.push(`## ${s.model || 'unknown model'} — ${s.startTime || 'unknown time'}`)
+    parts.push('')
+    parts.push(`- **Session ID:** ${s.sessionId}`)
+    parts.push(`- **Source:** ${s.source}`)
+    if (s.models.length > 1) parts.push(`- **Models used:** ${joinList(s.models)}`)
+    parts.push(`- **Duration:** ${s.durationMs}ms`)
+    parts.push(`- **Turns:** ${s.turns} · **Tool calls:** ${s.totalToolCalls} · **Errors:** ${s.errors}`)
+    parts.push(`- **Tokens:** ${s.inputTokens.toLocaleString()} in / ${s.outputTokens.toLocaleString()} out `
+      + `(cache read ${s.cacheReadTokens.toLocaleString()}, cache write ${s.cacheCreateTokens.toLocaleString()}, `
+      + `${(s.cacheHitRate * 100).toFixed(1)}% hit rate)`)
+    parts.push(`- **Outcome:** ${s.outcome}`)
+    if (Object.keys(s.toolCounts).length > 0) {
+      parts.push(`- **Tool counts:** ${joinToolCounts(s.toolCounts)}`)
+    }
+    if (s.loopSignals.length > 0) {
+      parts.push(`- **Loop signals:** ${joinLoopSignals(s.loopSignals)}`)
+    }
+    if (s.filesChanged.length > 0) {
+      parts.push(``, `**Files changed:**`, ``, ...s.filesChanged.map(f => `- \`${mdEscape(f)}\``))
+    }
+    if (s.userRequest) {
+      parts.push(``, `**Prompt:**`, ``, `> ${mdEscape(s.userRequest).replace(/\n/g, '\n> ')}`)
+    }
+    parts.push(``, `---`, ``)
+  }
+
+  return parts.join('\n')
+}
+
+export function serializeExport(sessions: ExportableSession[], format: ExportFormat): string {
+  if (format === 'csv') return toCsv(sessions)
+  if (format === 'markdown') return toMarkdown(sessions)
+  return JSON.stringify(sessions, null, 2)
+}

--- a/src/test/exportFormats.test.ts
+++ b/src/test/exportFormats.test.ts
@@ -1,0 +1,119 @@
+import * as assert from 'assert'
+import { toCsv, toMarkdown, serializeExport, exportFileExtension, type ExportableSession } from '../exportFormats'
+
+function makeSession(overrides: Partial<ExportableSession> = {}): ExportableSession {
+  return {
+    sessionId: 's1',
+    traceId: 't1',
+    source: 'claude_code',
+    model: 'claude-sonnet-4-6',
+    models: ['claude-sonnet-4-6'],
+    startTime: '2026-08-11T10:00:00.000Z',
+    durationMs: 12345,
+    turns: 3,
+    totalToolCalls: 5,
+    inputTokens: 10000,
+    outputTokens: 2000,
+    cacheReadTokens: 500,
+    cacheCreateTokens: 100,
+    cacheHitRate: 0.5,
+    errors: 0,
+    outcome: 'tool_calls',
+    toolCounts: { read_file: 3, edit_file: 2 },
+    filesRead: ['a.ts', 'b.ts'],
+    filesChanged: ['a.ts'],
+    loopSignals: [{ type: 'edit_revert_cycle', severity: 'critical' }],
+    userRequest: 'fix the bug',
+    ...overrides,
+  }
+}
+
+suite('exportFormats', () => {
+  suite('exportFileExtension', () => {
+    test('maps each format to its extension', () => {
+      assert.strictEqual(exportFileExtension('json'), 'json')
+      assert.strictEqual(exportFileExtension('csv'), 'csv')
+      assert.strictEqual(exportFileExtension('markdown'), 'md')
+    })
+  })
+
+  suite('toCsv', () => {
+    test('emits a header row followed by one row per session', () => {
+      const csv = toCsv([makeSession(), makeSession({ sessionId: 's2' })])
+      const lines = csv.trim().split('\r\n')
+      assert.strictEqual(lines.length, 3)
+      assert.ok(lines[0].startsWith('"Session ID","Trace ID"'))
+    })
+
+    test('quotes every field and escapes embedded quotes', () => {
+      const csv = toCsv([makeSession({ userRequest: 'fix the "bug" please' })])
+      assert.ok(csv.includes('"fix the ""bug"" please"'))
+    })
+
+    test('preserves embedded newlines inside a quoted field', () => {
+      const csv = toCsv([makeSession({ userRequest: 'line one\nline two' })])
+      assert.ok(csv.includes('"line one\nline two"'))
+    })
+
+    test('flattens array and object fields with semicolon joins', () => {
+      const csv = toCsv([makeSession({
+        models: ['model-a', 'model-b'],
+        filesChanged: ['x.ts', 'y.ts'],
+        toolCounts: { read: 1, write: 2 },
+        loopSignals: [{ type: 'exact_tool_repeat', severity: 'warning' }, { type: 'edit_revert_cycle', severity: 'critical' }],
+      })])
+      assert.ok(csv.includes('"model-a; model-b"'))
+      assert.ok(csv.includes('"x.ts; y.ts"'))
+      assert.ok(csv.includes('"read:1; write:2"'))
+      assert.ok(csv.includes('"exact_tool_repeat(warning); edit_revert_cycle(critical)"'))
+    })
+
+    test('handles an empty session list (header only)', () => {
+      const csv = toCsv([])
+      assert.strictEqual(csv.trim().split('\r\n').length, 1)
+    })
+  })
+
+  suite('toMarkdown', () => {
+    test('includes a heading per session and the session count', () => {
+      const md = toMarkdown([makeSession(), makeSession({ sessionId: 's2' })])
+      assert.ok(md.includes('2 sessions,'))
+      assert.match(md, /## claude-sonnet-4-6/)
+    })
+
+    test('renders the prompt as a blockquote with wrapped newlines', () => {
+      const md = toMarkdown([makeSession({ userRequest: 'line one\nline two' })])
+      assert.ok(md.includes('> line one\n> line two'))
+    })
+
+    test('omits the prompt section entirely when redacted to an empty string', () => {
+      const md = toMarkdown([makeSession({ userRequest: '' })])
+      assert.ok(!md.includes('**Prompt:**'))
+    })
+
+    test('escapes pipe characters in file paths', () => {
+      const md = toMarkdown([makeSession({ filesChanged: ['weird|file.ts'] })])
+      assert.ok(md.includes('weird\\|file.ts'))
+    })
+  })
+
+  suite('serializeExport', () => {
+    test('json format matches JSON.stringify with 2-space indent', () => {
+      const sessions = [makeSession()]
+      assert.strictEqual(serializeExport(sessions, 'json'), JSON.stringify(sessions, null, 2))
+    })
+
+    test('csv format delegates to toCsv', () => {
+      const sessions = [makeSession()]
+      assert.strictEqual(serializeExport(sessions, 'csv'), toCsv(sessions))
+    })
+
+    test('markdown format delegates to toMarkdown', () => {
+      // toMarkdown embeds the current timestamp, so two independent calls can differ by a few ms —
+      // strip the timestamp before comparing rather than asserting exact string equality.
+      const stripTimestamp = (s: string) => s.replace(/exported \S+/, 'exported <ts>')
+      const sessions = [makeSession()]
+      assert.strictEqual(stripTimestamp(serializeExport(sessions, 'markdown')), stripTimestamp(toMarkdown(sessions)))
+    })
+  })
+})

--- a/standalone/server.ts
+++ b/standalone/server.ts
@@ -730,6 +730,89 @@ function getHtml(): string {
       _toastTimer = setTimeout(function() { el.classList.remove('visible'); }, 3000);
     }
 
+    // CSV/Markdown export helpers — mirrors src/exportFormats.ts. Kept as hand-written vanilla JS
+    // (not compiled from TS) because this whole block is embedded directly into the served HTML's
+    // inline <script>, matching the rest of this file's acquireVsCodeApi polyfill.
+    function csvCell(value) {
+      return '"' + String(value).replace(/"/g, '""') + '"';
+    }
+    function joinList(items) {
+      return (items || []).join('; ');
+    }
+    function joinToolCounts(counts) {
+      var parts = [];
+      for (var tool in (counts || {})) { parts.push(tool + ':' + counts[tool]); }
+      return parts.join('; ');
+    }
+    function joinLoopSignals(signals) {
+      return (signals || []).map(function(s) { return s.type + '(' + s.severity + ')'; }).join('; ');
+    }
+    var CSV_HEADERS = [
+      'Session ID', 'Trace ID', 'Source', 'Model', 'Models', 'Start Time', 'Duration (ms)', 'Turns',
+      'Tool Calls', 'Input Tokens', 'Output Tokens', 'Cache Read Tokens', 'Cache Create Tokens',
+      'Cache Hit Rate', 'Errors', 'Outcome', 'Tool Counts', 'Files Read', 'Files Changed',
+      'Loop Signals', 'User Request'
+    ];
+    function toCsv(sessions) {
+      var rows = sessions.map(function(s) {
+        return [
+          s.sessionId, s.traceId, s.source, s.model, joinList(s.models), s.startTime,
+          String(s.durationMs), String(s.turns), String(s.totalToolCalls), String(s.inputTokens),
+          String(s.outputTokens), String(s.cacheReadTokens), String(s.cacheCreateTokens),
+          (s.cacheHitRate || 0).toFixed(4), String(s.errors), s.outcome,
+          joinToolCounts(s.toolCounts), joinList(s.filesRead), joinList(s.filesChanged),
+          joinLoopSignals(s.loopSignals), s.userRequest || ''
+        ];
+      });
+      var allRows = [CSV_HEADERS].concat(rows);
+      return allRows.map(function(row) { return row.map(csvCell).join(','); }).join('\r\n') + '\r\n';
+    }
+    function mdEscape(text) {
+      return String(text).replace(/\|/g, '\\|');
+    }
+    function toMarkdown(sessions) {
+      var parts = ['# AgentLens Session Export', '', sessions.length + ' session' + (sessions.length === 1 ? '' : 's') + ', exported ' + new Date().toISOString(), ''];
+      sessions.forEach(function(s) {
+        parts.push('## ' + (s.model || 'unknown model') + ' — ' + (s.startTime || 'unknown time'));
+        parts.push('');
+        parts.push('- **Session ID:** ' + s.sessionId);
+        parts.push('- **Source:** ' + s.source);
+        if (s.models && s.models.length > 1) parts.push('- **Models used:** ' + joinList(s.models));
+        parts.push('- **Duration:** ' + s.durationMs + 'ms');
+        parts.push('- **Turns:** ' + s.turns + ' · **Tool calls:** ' + s.totalToolCalls + ' · **Errors:** ' + s.errors);
+        parts.push('- **Tokens:** ' + s.inputTokens.toLocaleString() + ' in / ' + s.outputTokens.toLocaleString() + ' out '
+          + '(cache read ' + s.cacheReadTokens.toLocaleString() + ', cache write ' + s.cacheCreateTokens.toLocaleString() + ', '
+          + ((s.cacheHitRate || 0) * 100).toFixed(1) + '% hit rate)');
+        parts.push('- **Outcome:** ' + s.outcome);
+        if (s.toolCounts && Object.keys(s.toolCounts).length > 0) {
+          parts.push('- **Tool counts:** ' + joinToolCounts(s.toolCounts));
+        }
+        if (s.loopSignals && s.loopSignals.length > 0) {
+          parts.push('- **Loop signals:** ' + joinLoopSignals(s.loopSignals));
+        }
+        if (s.filesChanged && s.filesChanged.length > 0) {
+          parts.push('', '**Files changed:**', '');
+          s.filesChanged.forEach(function(f) { parts.push('- \`' + mdEscape(f) + '\`'); });
+        }
+        if (s.userRequest) {
+          parts.push('', '**Prompt:**', '', '> ' + mdEscape(s.userRequest).replace(/\n/g, '\n> '));
+        }
+        parts.push('', '---', '');
+      });
+      return parts.join('\n');
+    }
+    function serializeExport(sessions, format) {
+      if (format === 'csv') return toCsv(sessions);
+      if (format === 'markdown') return toMarkdown(sessions);
+      return JSON.stringify(sessions, null, 2);
+    }
+    function exportMimeType(format) {
+      return format === 'csv' ? 'text/csv' : format === 'markdown' ? 'text/markdown' : 'application/json';
+    }
+    function exportFileExtension(format) {
+      return format === 'csv' ? 'csv' : format === 'markdown' ? 'md' : 'json';
+    }
+
     function getNotifContainer() {
       var el = document.getElementById('sa-notif-container');
       if (!el) {
@@ -878,12 +961,13 @@ function getHtml(): string {
                 userRequest:  redact ? '[redacted]' : (s.userRequest || null),
               };
             });
+            var format = (msg.format === 'csv' || msg.format === 'markdown') ? msg.format : 'json';
             var now = new Date();
             var pad = function(n) { return String(n).padStart(2, '0'); };
             var ts = '' + now.getFullYear() + pad(now.getMonth() + 1) + pad(now.getDate()) +
                      '_' + pad(now.getHours()) + pad(now.getMinutes()) + pad(now.getSeconds());
-            var filename = (redact ? 'export_redacted' : 'export') + '_sessions_' + ts + '.json';
-            var blob = new Blob([JSON.stringify(exportable, null, 2)], { type: 'application/json' });
+            var filename = (redact ? 'export_redacted' : 'export') + '_sessions_' + ts + '.' + exportFileExtension(format);
+            var blob = new Blob([serializeExport(exportable, format)], { type: exportMimeType(format) });
             var url = URL.createObjectURL(blob);
             var a = document.createElement('a');
             a.href = url; a.download = filename; a.click();


### PR DESCRIPTION
## Summary

Richer export formats (`.staged-issues/06-richer-export-formats.md`) — AgentLens's main session
export was JSON only. JSON is great for round-tripping back into AgentLens via Import, but users
who want to drop session data into a spreadsheet or share a readable report had to convert it by
hand.

New `src/exportFormats.ts` generalizes the CSV pattern already used by the Analytics tab's
cost-table export (one row per item, every cell quoted) to the full session export, and adds a
Markdown format (one section per session, prompt as a blockquote) for shareable reports. JSON
stays the default and the only format Import reads back.

Wired into both entry points:
- `src/dashboardPanel.ts`'s `exportSessions` now takes a `format` parameter and picks the file
  extension/serialization accordingly.
- `standalone/server.ts`'s browser-side export handler got hand-written vanilla-JS equivalents of
  the same functions (that whole block is embedded directly in a template-literal-generated
  `<script>` tag, not compiled TS, so it can't import the shared module — matches this file's
  existing duplication of the JSON export logic). Verified byte-for-byte identical output between
  the two implementations against the same sample data.

Caught a real bug while wiring the standalone side: a literal backtick in the embedded Markdown
code-span formatting terminated the *outer* TS template literal early (the whole `getHtml()`
function body is itself one big backtick string) — a silent-until-build class of error that
`tsc --noEmit` doesn't catch, since `standalone/server.ts` has its own `tsconfig.json` that the
root `check-types` script never invokes; only esbuild (part of `pnpm run package`, which CI runs)
actually parses it. Fixed by escaping the backticks; confirmed the fix by syntax-checking and
functionally running the extracted embedded-JS block directly, without starting a server.

`Export.tsx` gets a format `<select>` per card (JSON/CSV/Markdown, defaulting to JSON) alongside
the existing full/redacted choice. Redaction applies identically across all three formats.

## Test plan
- [x] `pnpm run check-types` passes
- [x] `pnpm run lint` — 0 errors (pre-existing unrelated warnings only)
- [x] 13 new `exportFormats.test.ts` tests pass
- [x] Full 201-test suite passes locally — no regressions
- [x] `pnpm run package` (esbuild) succeeds for both the VS Code extension bundle and the
  standalone server bundle — this is what actually caught the backtick bug above
- [x] Verified byte-for-byte identical CSV/Markdown output between `src/exportFormats.ts` and the
  standalone server's embedded-JS equivalent, run against the same sample data outside of any
  server process (no port binding, no config auto-configuration side effects)
- [ ] Not visually verified in a browser — worth a manual look at the Export tab's new format
  selector before merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)