### PR TITLE
docs: update Help tab, walkthrough, and README for recent features + tab structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,7 +440,7 @@ Override the default database location with the `OPENCODE_DATA_DIR` environment 
 
 - **Files Changed** — The Files tab tracks every file created or modified by the agent, organized by session with inline before/after diffs
 - **Multi-session Comparison** — The Analytics tab shows per-agent breakdown cards with side-by-side token totals, cache rates, TTFT, and top tools for Copilot, Claude, and Codex
-- **Automated Prompts** — The Automation tab lets you configure threshold-based automations (Loop Breaker, Turn Limit Wrap-up, Context Dump) that trigger a correction prompt when a session crosses a limit — delivered as a VS Code notification or written to a file for agent consumption
+- **Automated Prompts** — The gear-icon Settings panel's Automation section lets you configure threshold-based automations (Loop Breaker, Turn Limit Wrap-up, Context Dump) that trigger a correction prompt when a session crosses a limit — delivered as a VS Code notification or written to a file for agent consumption
 
 ## AI Usage Disclosure
 

--- a/media/src/tabs/Help.tsx
+++ b/media/src/tabs/Help.tsx
@@ -415,7 +415,7 @@ function SessionsSection() {
           <div class="glossary-item" style="flex-direction:column;gap:4px">
             <dt class="glossary-term">Files</dt>
             <dd class="glossary-def" style="display:block">
-              Every file created or modified during the session, grouped by path. Click any file to open a diff in the editor. The badge shows the number of unique files touched.
+              Every file created or modified during the session, grouped by path. Click any file to open a diff in the editor. The badge shows the number of unique files touched. A one-shot/retry-rate line summarizes edit passes per file (e.g. "80% one-shot (4/5 files, avg 1.2 edit passes/file)") — hidden when fewer than 2 files were edited. A git outcome banner (VS Code extension only) compares each changed file's content against git history to classify it <strong>Committed</strong> (changed since the session and now in a commit), <strong>Reverted</strong> (back to its pre-session content), <strong>Uncommitted</strong> (changed but still sitting in the working tree), or <strong>Unknown</strong> (outcome can't be determined) — computed on demand when the row is expanded, with a matching badge per file.
             </dd>
           </div>
         </div>
@@ -519,7 +519,7 @@ function AnalyticsSection() {
         <div class="glossary">
           <div class="glossary-item" style="flex-direction:column;gap:4px">
             <dt class="glossary-term">Agent Breakdown</dt>
-            <dd class="glossary-def" style="display:block">One card per agent showing total input tokens, output tokens, cache hit rate, estimated cost, and top tools used — all scoped to the active time range and source filter.</dd>
+            <dd class="glossary-def" style="display:block">One card per agent showing total input tokens, output tokens, cache hit rate, estimated cost, One-shot rate, and top tools used — all scoped to the active time range and source filter. One-shot rate is the file-level percentage of edited files that got it right on the first pass, aggregated across all of the agent's sessions; hidden when fewer than 2 files were edited (not enough data for a meaningful rate).</dd>
           </div>
           <div class="glossary-item" style="flex-direction:column;gap:4px">
             <dt class="glossary-term">Estimated Cost</dt>
@@ -672,8 +672,12 @@ function SettingsSection() {
         <p>The gear icon opens a slide-in settings panel containing two collapsible sections: <strong>Alerts</strong> and <strong>Automation</strong>. Close it with the × button or by pressing Escape.</p>
 
         <h4 id="help-alerts" style={subHeadStyle}>Alerts</h4>
-        <p style="font-size:12px;color:var(--muted);margin:0 0 12px">Configure thresholds for six signals. When a live session crosses a threshold the bell badge increments and the alert appears in the status card. Two alerts use shared token-count thresholds; the other four use per-agent profiles so you can tune Claude Code, Copilot, and Codex independently.</p>
+        <p style="font-size:12px;color:var(--muted);margin:0 0 12px">Configure thresholds for seven signals. When a live session crosses a threshold the bell badge increments and the alert appears in the status card. Five alerts use per-agent profiles so you can tune Claude Code, Copilot, and Codex independently; the daily cost threshold is a single global dollar figure across all agents.</p>
         <div class="glossary">
+          <div class="glossary-item" style="flex-direction:column;gap:2px">
+            <dt class="glossary-term">Daily Cost Threshold <span style="font-size:10px;font-weight:400;color:var(--muted)">(warning)</span></dt>
+            <dd class="glossary-def" style="display:block">Fires when today's total estimated cost across all agents (UTC day) crosses the configured dollar threshold. Disabled by default. Default threshold: $20/day.</dd>
+          </div>
           <div class="glossary-item" style="flex-direction:column;gap:2px">
             <dt class="glossary-term">Context Window Filling Up <span style="font-size:10px;font-weight:400;color:var(--muted)">(warning)</span></dt>
             <dd class="glossary-def" style="display:block">Fires when peak input tokens for a session reaches the per-agent threshold. Defaults: Claude Code 170K, Copilot 108K, Codex 340K. Adjust per agent or raise the shared baseline.</dd>

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
           {
             "id": "agentlens.openDashboard",
             "title": "Open the Full Dashboard",
-            "description": "The sidebar shows a live summary. Open the full 16-tab dashboard in an editor panel for traces, diffs, alerts, cost estimation, export, and more.\n\n[Open Dashboard](command:agentLens.openDashboard)",
+            "description": "The sidebar shows a live summary. Open the full dashboard in an editor panel for traces, diffs, alerts, cost estimation, export, and more.\n\n[Open Dashboard](command:agentLens.openDashboard)",
             "media": {
               "markdown": "walkthrough/dashboard.md"
             },

--- a/walkthrough/dashboard.md
+++ b/walkthrough/dashboard.md
@@ -1,15 +1,19 @@
-The sidebar gives you a compact live view. For the full experience, open the **editor panel dashboard** — a 6-tab interface you can open alongside your code.
+The sidebar gives you a compact live view. For the full experience, open the **editor panel dashboard** — a 5-tab interface, plus a Help icon and a gear-icon Settings panel, that you can open alongside your code.
 
 ## Dashboard tabs
 
 | Tab | What it shows |
 | --- | --- |
-| **Sessions** | Session list as a sortable table — timestamp, prompt, model, tokens, duration, and estimated cost per row. Sort by Cost, Duration, or Tokens using the pills in the filter bar. Click any row to expand in-place and drill into five sub-tabs: Overview (stat tiles, burn rate, and Insights), Trace (LLM and tool call waterfall), Flow (turn-to-tool graph), Tools (donut chart), and Files (modified files with inline diffs) |
-| **Analytics** | Aggregate charts across all sessions: per-agent breakdown (token totals, cache rates, top tools), Estimated Cost (bar chart + daily total line, day-grouped cost table, model breakdown), Token Usage Per Session, and Context Growth |
+| **Sessions** | Session list as a sortable table — timestamp, prompt, model, tokens, duration, and estimated cost per row. Sort by Cost, Duration, or Tokens using the pills in the filter bar. Click any row to expand in-place and drill into five sub-tabs: Overview (stat tiles, burn rate, and Insights), Trace (LLM and tool call waterfall), Flow (turn-to-tool graph), Tools (donut chart), and Files (modified files with inline diffs, a one-shot/retry-rate summary, and a git-outcome banner showing whether each file's changes were committed, reverted, or left uncommitted) |
+| **Analytics** | Aggregate charts across all sessions: per-agent breakdown (token totals, cache rates, one-shot rate, top tools), Estimated Cost (bar chart + daily total line, day-grouped cost table, model breakdown), Token Usage Per Session, and Context Growth |
 | **Advisor** | Project-scoped suggestions for improving your agent instruction file — detects hot files the agent rediscovers each session, behavioral loop patterns, high turn counts, and open-ended prompt habits. Each suggestion includes ready-to-copy instruction text and an inquiry prompt to paste directly into your agent. Also includes an efficiency scatter plot and hot files table. Select a project from the workspace filter for tailored suggestions. |
-| **Alerts** | Configurable threshold notifications per agent — turns, errors, active session time, and identical tool repeats |
-| **Automation** | Automated prompts triggered when session thresholds are crossed — Loop Breaker, Turn Limit Wrap-up, and Context Dump |
-| **Export** | Export all recorded sessions as JSON — full (includes prompt text) or redacted — from the full SQLite session history |
+| **Export** | Export recorded sessions — full (includes prompt text) or redacted — as JSON, CSV, or Markdown, from the full SQLite session history |
+| **Import** | Preview and import sessions from a previously exported AgentLens JSON file |
 | **Help** | Overview, setup instructions, agent OTEL data shapes, Insights reference, loop signal documentation, and glossary |
+
+Two icons in the top-right of the tab bar handle alerting and configuration without cluttering the tabs themselves:
+
+- **Bell icon** — shows a badge when an alert threshold is currently triggered; click it for a status card with severity and detail per alert.
+- **Gear icon** — opens a slide-in Settings panel with two collapsible sections: **Alerts** (configurable thresholds — context window size, turn count, error spike, active session time, cache utilization, identical tool repeats, and daily cost across all agents) and **Automation** (automated prompts triggered when thresholds are crossed — Loop Breaker, Turn Limit Wrap-up, and Context Dump). Also holds the OTEL/log ingestion toggles.
 
 Use the **agent filter** and **session limit** controls at the top to focus on what matters.

--- a/walkthrough/loops.md
+++ b/walkthrough/loops.md
@@ -10,4 +10,4 @@ The **Sessions** tab continuously scans your sessions for five failure patterns.
 
 Each detected signal shows the evidence and concrete examples (tool names, file paths, error messages). Use the **⧉** button to copy the recommended prompt to your clipboard, then paste it into your agent session. Use **Ignore** to dismiss a signal that represents intentional behavior.
 
-Check the **Alerts** tab to configure proactive notifications when sessions exceed thresholds for context window usage, turn count, error rate, or tool repetition.
+Open the gear-icon **Settings** panel's Alerts section to configure proactive notifications when sessions exceed thresholds for context window usage, turn count, error rate, tool repetition, cache utilization, or daily cost.


### PR DESCRIPTION
## Summary
- Updates `media/src/tabs/Help.tsx`'s Settings section (7 alert signals now, with a new Daily Cost Threshold entry), Analytics section (Agent Breakdown cards now include a One-shot rate tile), and Sessions section (Files sub-tab now has a one-shot/retry-rate summary line and a git-outcome banner). The Export section was already current from #178.
- Rewrites `walkthrough/dashboard.md`'s tab table: was claiming "6-tab interface" while listing 7 rows and missing Import entirely. Now accurately describes 5 tabs (Sessions, Analytics, Advisor, Export, Import) + Help icon + gear-icon Settings panel (Alerts/Automation aren't tabs — verified against `media/src/App.tsx`'s `TABS` array and `ConfigPanel`).
- Fixes `package.json`'s walkthrough step, which called it a "16-tab dashboard" (also wrong) — drops the specific count so it can't drift again; the linked `dashboard.md` has the accurate breakdown.
- Fixes `walkthrough/loops.md` and `README.md`, which referred to an "Alerts tab" / "Automation tab" that doesn't exist (they're in the gear-icon Settings panel).

No code changes — documentation only.

## Test plan
- [x] `pnpm run lint` — clean (0 errors, pre-existing warnings only)
- [x] `tsc --noEmit -p media/tsconfig.json` — clean
- Docs-only change; not exercised by the unit test suite or CI's build step.