### PR TITLE
fix: standalone dashboard fails to load — escaped-string bugs in embedded export JS

### DIFF
--- a/standalone/server.ts
+++ b/standalone/server.ts
@@ -765,10 +765,10 @@ function getHtml(): string {
         ];
       });
       var allRows = [CSV_HEADERS].concat(rows);
-      return allRows.map(function(row) { return row.map(csvCell).join(','); }).join('\r\n') + '\r\n';
+      return allRows.map(function(row) { return row.map(csvCell).join(','); }).join('\\r\\n') + '\\r\\n';
     }
     function mdEscape(text) {
-      return String(text).replace(/\|/g, '\\|');
+      return String(text).replace(/\\|/g, '\\\\|');
     }
     function toMarkdown(sessions) {
       var parts = ['# AgentLens Session Export', '', sessions.length + ' session' + (sessions.length === 1 ? '' : 's') + ', exported ' + new Date().toISOString(), ''];
@@ -795,11 +795,11 @@ function getHtml(): string {
           s.filesChanged.forEach(function(f) { parts.push('- \`' + mdEscape(f) + '\`'); });
         }
         if (s.userRequest) {
-          parts.push('', '**Prompt:**', '', '> ' + mdEscape(s.userRequest).replace(/\n/g, '\n> '));
+          parts.push('', '**Prompt:**', '', '> ' + mdEscape(s.userRequest).replace(/\\n/g, '\\n> '));
         }
         parts.push('', '---', '');
       });
-      return parts.join('\n');
+      return parts.join('\\n');
     }
     function serializeExport(sessions, format) {
       if (format === 'csv') return toCsv(sessions);


### PR DESCRIPTION
## Summary
Fixes a total standalone-mode breakage: `npm run local` (and `npx agentlens-dashboard`) immediately threw `TypeError: window.acquireVsCodeApi is not a function` in the browser and the dashboard never loaded.

Root cause: `standalone/server.ts`'s entire HTML response — including its inline `<script>` — is one big TypeScript template literal. The CSV/Markdown export helpers added in #178 wrote `\r\n`, `\n`, and `\|` as single-escaped sequences, not accounting for the fact that the *outer* template literal consumes one layer of backslash-escaping before the text ever reaches the browser. The outer literal collapsed those into raw control characters and dropped backslashes, so the browser received:
- Actual embedded newline bytes inside single-quoted JS string literals (a hard syntax error), and
- In `mdEscape`, a regex that degenraded to `/|/g` — a zero-width empty-alternation matching every string position, inserting `|` between every character.

The syntax error aborted the whole inline `<script>` block before execution ever reached the `window.acquireVsCodeApi` polyfill defined later in the same block — that's why the reported error pointed at `acquireVsCodeApi`, even though the real problem was upstream of it.

Fix: double the backslashes on all three sites so each escape sequence survives the outer template literal intact.

No equivalent bug exists in `src/exportFormats.ts` (the canonical TS module the VS Code extension uses) — this is isolated to `standalone/server.ts`'s hand-written duplicate, which (per `ARCHITECTURE.md`'s Build Pipeline section) isn't covered by the root `check-types` script — only `esbuild`/`pnpm run package` parses it, and neither catches semantically-valid-but-wrong escaping like this.

## Test plan
- [x] Extracted the actual served HTML's inline `<script>` and syntax-checked it with `node --check` — now passes (previously failed with `SyntaxError: Invalid or unexpected token`)
- [x] Ran the extracted `toCsv`/`toMarkdown` functions against sample data with a newline and a pipe character in it — output now byte-for-byte correct (real `\r\n` row separators, real `\n` line joins, literal `|` correctly escaped to `\|` in Markdown)
- [x] `pnpm run lint` — clean
- [x] `pnpm run check-types` — clean (also spot-checked `tsc --noEmit -p standalone/tsconfig.json`; its one pre-existing unused-var warning is unrelated to this change)
- [x] Full unit suite (218/218) via `node standalone/server.js` after a fresh `node esbuild.js` build, confirmed the dashboard loads without the JS error