### PR TITLE
docs: establish a runbooks concept for recurring AI-assisted maintenance tasks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,3 +2,7 @@
 
 Before any task: call get_recent_sessions (recent work + cost) and get_workspace_patterns (hot files, recurring issues).
 Only use find_relevant_context if your task closely matches past prompts by keyword — skip it for novel tasks.
+
+## Recurring maintenance tasks
+
+Check `runbooks/README.md` for periodic maintenance tasks (e.g. refreshing model pricing) that may be relevant or due.

--- a/runbooks/README.md
+++ b/runbooks/README.md
@@ -1,0 +1,23 @@
+# Runbooks
+
+Recurring maintenance tasks in this repo — the kind that come up periodically, get done the same
+way each time, and are easy to forget about between runs. This file is an index, not the
+instructions themselves; each task's actual procedure lives in its own doc, linked below.
+
+These are agent- or human-initiated on demand (e.g. "is pricing stale?"), not scheduled or
+automated — there's no cron job or CI check that triggers them.
+
+## Tasks
+
+| Task | Trigger | Instructions |
+| --- | --- | --- |
+| Refresh model pricing | A vendor changes rates, adds/retires a model, or you notice cost estimates look off | [`PRICING_SOURCES.md`](../PRICING_SOURCES.md) |
+
+## Adding a new runbook
+
+1. Write the task's step-by-step procedure as a standalone doc. If it's tightly coupled to an
+   existing root-level doc (like pricing is to `PRICING_SOURCES.md`), extend that doc instead of
+   creating a new one. Otherwise, add a new file in this directory.
+2. Include: what triggers the task, the exact steps in order, and how to verify the change
+   (which tests/lint/build commands to run before considering it done).
+3. Add a row to the table above.


### PR DESCRIPTION
## Summary
`PRICING_SOURCES.md` has effectively been a maintenance runbook since it was written (it ends with a numbered "how to refresh this file" procedure, and has already been run at least twice per its own commit history), but nothing pointed an agent at it — it only got found if a human named the file explicitly.

- Adds `runbooks/README.md` as an index of recurring tasks (currently just the one: pricing refresh, linking to `PRICING_SOURCES.md` in place rather than moving it, since it's referenced by exact filename from 5 other files) plus a "how to add a new runbook" section so the pattern is self-documenting.
- `CLAUDE.md` — the file every AI session in this repo reads automatically — now points at it, so it's discoverable without prior knowledge.

See `.staged-issues/08-recurring-ai-runbooks.md` (gitignored, not part of this diff) for the fuller rationale.

No code changes — documentation only.

## Test plan
- [x] `pnpm run lint` / `pnpm run check-types` — clean
- Docs-only change; not exercised by the unit test suite or CI's build step.