### PR TITLE
feat: implement per-model long-context surcharge tiers

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -897,7 +897,7 @@ flowchart TD
 
 `contextWindowTokens` (stored in `src/pricing.ts`) enables the `Projection` calculation: given current session token usage and burn rate, estimate time to context exhaustion and final cost.
 
-Pricing data covers: OpenAI (GPT-4.1 through GPT-5.6), Anthropic (Claude Haiku 3.5/4.5, Sonnet 4.x/5, Opus 4.x/5, Fable 5), Google (Gemini 2.5–3.6), Codex, and fine-tuned models. Refreshed per the runbook in `PRICING_SOURCES.md`. Last updated: 2026-08-07.
+Pricing data covers: OpenAI (GPT-4.1 through GPT-5.6), Anthropic (Claude Haiku 3.5/4.5, Sonnet 4.x/5, Opus 4.x/5, Fable 5), Google (Gemini 2.5–3.6), Codex, third-party Copilot-marketplace models (Grok, Kimi, MAI-Code), OpenCode Zen free models, and fine-tuned models. Some models also carry a per-model tiered "long context" surcharge above a token-per-call threshold — see `PRICING_SOURCES.md`. Refreshed per the runbook in `PRICING_SOURCES.md`. Last updated: 2026-08-12.
 
 ---
 

--- a/PRICING_SOURCES.md
+++ b/PRICING_SOURCES.md
@@ -14,7 +14,14 @@ and revert independently if a source turns out to have been misread.
 1. Fetch each source URL below and compare against the rate tables here.
 2. Update `RATES` in both `src/pricing.ts` and `media/src/pricing.ts` to match. See
    "Notes for maintainers" at the bottom for lookup/normalization details.
-3. Bump `PRICING_LAST_UPDATED` in `media/src/pricing.ts` and the "verified" dates below.
+3. Bump every date that records when pricing was last verified — there's more than one, and it's
+   easy to miss one:
+   - `PRICING_LAST_UPDATED` in `media/src/pricing.ts`
+   - The `PRICING_LAST_UPDATED: <date>` comment at the top of `src/pricing.ts`
+   - Every per-section "verified `<date>`" source line below, for whichever sections you actually
+     re-checked
+   - `ARCHITECTURE.md`'s "Cost Calculation" section — it has its own "Last updated: `<date>`" line
+     independent of the two constants above (found missed once already; check it every time)
 4. Run `tsc --noEmit` (both configs), `eslint src media/src`, and `mocha` to confirm nothing broke.
 5. If a rate or model can't be confirmed from a source, add it to that section's "Known gaps"
    instead of guessing.
@@ -35,6 +42,11 @@ Copilot has three billing models depending on plan type and date.
 
 - Per-model token rates: `inputPerMTok`, `cacheReadPerMTok`, `cacheWritePerMTok`, `outputPerMTok` (USD per 1M tokens)
 - List of included models (effectively $0 — look for models with no token rate listed)
+- Per-model "long context" surcharge tiers for some models — 2x input/cache-read/cache-write, 1.5x
+  output above a per-model token-per-call threshold (272K for GPT-5.4/5.5/5.6-Sol/5.6-Terra, 200K
+  for GPT-5.6-Luna/Gemini 3.1 Pro/Grok 4.5). Modeled in `RATES` via `longContextThresholdTokens` +
+  the `*AboveThresholdPerMTok` fields (`src/pricing.ts` only — `media/src/pricing.ts`'s
+  session-level estimate stays flat-rate, see that file's own comment for why).
 
 **Formula:**
 
@@ -101,18 +113,6 @@ sessions; don't expect to re-verify them.
   pricing page at the same rate ($2.00/$0.50/$8.00) that Codex CLI uses directly (see the Codex
   section below), so `RATES` is left unchanged. Copilot apparently just doesn't currently offer it
   as a selectable model; that's a different thing from the rate being wrong.
-- **Long-context surcharge tier** (GPT-5.4, GPT-5.5, GPT-5.6 family, and — newly discovered this
-  refresh — Gemini 3.1 Pro and Grok 4.5 too): confirmed to exist — Copilot's pricing page lists a
-  distinct "Long context" row for each, consistently at 2x the default input/cache-read/cache-write
-  rate and 1.5x the default output rate. **Token thresholds are now confirmed** (previously
-  thought unconfirmed): 272K for GPT-5.4, GPT-5.5, GPT-5.6 Sol, GPT-5.6 Terra; 200K for GPT-5.6
-  Luna, Gemini 3.1 Pro, and Grok 4.5 — read directly off the pricing page's per-model "≤272K" /
-  "≤200K" default-tier labels. Still **not implemented** in `RATES` (holds only the default-tier
-  rate) — confirming the threshold removes the "wrong guess" risk that blocked this before, but
-  wiring up per-model tiered surcharge logic (mirroring the existing `claude-sonnet-4`
-  `inputAbove200kPerMTok`-style fields, generalized to a per-model threshold rather than the
-  hardcoded 200K `tieredCost()` currently assumes) is real feature work, not a rate-table edit —
-  see `.staged-issues/` for a follow-up if this is worth doing.
 - `gpt-5.1-codex`, `gpt-5.1-codex-mini`, `gpt-5.1-codex-max`: not independently re-confirmed in the
   2026-08-07 refresh — absent from the general API pricing page (only base `gpt-5.1` was listed,
   and it turned out to have been repriced down to $1.25/$10.00 from $1.75/$14.00). Left unchanged
@@ -298,10 +298,6 @@ Model name available on `codex.user_prompt`, `codex.turn_ttft`, and `codex.tool_
 
 **Known gaps:**
 
-- Long-context surcharges: `gpt-5.4`, `gpt-5.5`, and the whole `gpt-5.6` family have a long-context
-  tier — see the Copilot section's Known gaps above for the now-confirmed thresholds (272K for
-  most, 200K for Luna). Still not implemented in `RATES` — this is real feature work (per-model
-  tiered thresholds), not a rate-table edit.
 - `gpt-5.3-codex-spark`: research preview with no published rates.
 - Reasoning tokens (`codex.usage.reasoning_output_tokens`): included in `gen_ai.usage.output_tokens` and billed at the standard output rate per available data; verify against the official rate card once it's fetchable (see Sources above).
 - Which GPT-5.6 variant (Sol/Terra/Luna) is the actual default model invoked by plain `codex` CLI runs (as opposed to an explicit model flag) is not confirmed by public docs.

--- a/src/pricing.ts
+++ b/src/pricing.ts
@@ -8,11 +8,15 @@ export interface ModelRates {
   cacheWritePerMTok: number
   outputPerMTok: number
   contextWindowTokens: number   // max context window for Projection estimates; 0 = unknown
-  // Optional tiered rates for the >200K tokens-per-call surcharge. When absent, flat rates apply.
-  inputAbove200kPerMTok?: number
-  outputAbove200kPerMTok?: number
-  cacheReadAbove200kPerMTok?: number
-  cacheWriteAbove200kPerMTok?: number
+  // Optional tiered "long context" surcharge, applied per API call above longContextThresholdTokens.
+  // When absent, flat rates apply regardless of call size. Threshold is per-model (confirmed values
+  // vary — 200K for some models, 272K for others — see PRICING_SOURCES.md); defaults to 200K if the
+  // above-threshold rates are set but the threshold itself isn't (kept for claude-sonnet-4 parity).
+  longContextThresholdTokens?: number
+  inputAboveThresholdPerMTok?: number
+  outputAboveThresholdPerMTok?: number
+  cacheReadAboveThresholdPerMTok?: number
+  cacheWriteAboveThresholdPerMTok?: number
 }
 
 const RATES: Record<string, ModelRates> = {
@@ -37,23 +41,38 @@ const RATES: Record<string, ModelRates> = {
   'gpt-5.2':            { inputPerMTok: 1.75,  cacheReadPerMTok: 0.175,  cacheWritePerMTok: 0, outputPerMTok: 14.00, contextWindowTokens: 256_000 },
   'gpt-5.2-codex':      { inputPerMTok: 1.75,  cacheReadPerMTok: 0.175,  cacheWritePerMTok: 0, outputPerMTok: 14.00, contextWindowTokens: 256_000 },
   'gpt-5.3-codex':      { inputPerMTok: 1.75,  cacheReadPerMTok: 0.175,  cacheWritePerMTok: 0, outputPerMTok: 14.00, contextWindowTokens: 256_000 },
-  'gpt-5.4':            { inputPerMTok: 2.50,  cacheReadPerMTok: 0.25,   cacheWritePerMTok: 0, outputPerMTok: 15.00, contextWindowTokens: 272_000 },
+  // gpt-5.4: long-context surcharge above 272K tokens/call confirmed 2026-08-12 (2x input/cache-read, 1.5x output).
+  'gpt-5.4':            { inputPerMTok: 2.50,  cacheReadPerMTok: 0.25,   cacheWritePerMTok: 0, outputPerMTok: 15.00, contextWindowTokens: 272_000,
+                          longContextThresholdTokens: 272_000,
+                          inputAboveThresholdPerMTok: 5.00, cacheReadAboveThresholdPerMTok: 0.50, outputAboveThresholdPerMTok: 22.50 },
   'gpt-5.4-mini':       { inputPerMTok: 0.75,  cacheReadPerMTok: 0.075,  cacheWritePerMTok: 0, outputPerMTok: 4.50,  contextWindowTokens: 200_000 },
   'gpt-5.4-nano':       { inputPerMTok: 0.20,  cacheReadPerMTok: 0.02,   cacheWritePerMTok: 0, outputPerMTok: 1.25,  contextWindowTokens: 128_000 },
-  'gpt-5.5':            { inputPerMTok: 5.00,  cacheReadPerMTok: 0.50,   cacheWritePerMTok: 0, outputPerMTok: 30.00, contextWindowTokens: 256_000 },
+  // gpt-5.5: long-context surcharge above 272K tokens/call confirmed 2026-08-12 (2x input/cache-read, 1.5x output).
+  'gpt-5.5':            { inputPerMTok: 5.00,  cacheReadPerMTok: 0.50,   cacheWritePerMTok: 0, outputPerMTok: 30.00, contextWindowTokens: 256_000,
+                          longContextThresholdTokens: 272_000,
+                          inputAboveThresholdPerMTok: 10.00, cacheReadAboveThresholdPerMTok: 1.00, outputAboveThresholdPerMTok: 45.00 },
   // gpt-5.6 family: Luna (small/fast), Terra (mid), Sol (flagship). Corrected 2026-08-07 — Luna and Terra were
   // repriced down (Luna $1.00→$0.20 input, Terra $2.50→$2.00 input), and the whole family gained real cache-write
   // pricing (1.25x input, confirmed across the Copilot docs, OpenAI's pricing page, and the Codex credits page).
-  // A "long context" surcharge tier also exists above an unconfirmed token threshold (~2x input/cache, ~1.5x
-  // output per Copilot's docs) — not implemented; see PRICING_SOURCES.md Known gaps.
-  'gpt-5.6-luna':       { inputPerMTok: 0.20,  cacheReadPerMTok: 0.02,   cacheWritePerMTok: 0.25, outputPerMTok: 1.20,  contextWindowTokens: 256_000 },
-  'gpt-5.6-terra':      { inputPerMTok: 2.00,  cacheReadPerMTok: 0.20,   cacheWritePerMTok: 2.50, outputPerMTok: 12.00, contextWindowTokens: 256_000 },
-  'gpt-5.6-sol':        { inputPerMTok: 5.00,  cacheReadPerMTok: 0.50,   cacheWritePerMTok: 6.25, outputPerMTok: 30.00, contextWindowTokens: 256_000 },
+  // Long-context surcharge tiers confirmed 2026-08-12 (2x input/cache-read/cache-write, 1.5x output) — Luna's
+  // threshold (200K) is lower than Sol/Terra's (272K), per Copilot's pricing page default-tier labels.
+  'gpt-5.6-luna':       { inputPerMTok: 0.20,  cacheReadPerMTok: 0.02,   cacheWritePerMTok: 0.25, outputPerMTok: 1.20,  contextWindowTokens: 256_000,
+                          longContextThresholdTokens: 200_000,
+                          inputAboveThresholdPerMTok: 0.40, cacheReadAboveThresholdPerMTok: 0.04, cacheWriteAboveThresholdPerMTok: 0.50, outputAboveThresholdPerMTok: 1.80 },
+  'gpt-5.6-terra':      { inputPerMTok: 2.00,  cacheReadPerMTok: 0.20,   cacheWritePerMTok: 2.50, outputPerMTok: 12.00, contextWindowTokens: 256_000,
+                          longContextThresholdTokens: 272_000,
+                          inputAboveThresholdPerMTok: 4.00, cacheReadAboveThresholdPerMTok: 0.40, cacheWriteAboveThresholdPerMTok: 5.00, outputAboveThresholdPerMTok: 18.00 },
+  'gpt-5.6-sol':        { inputPerMTok: 5.00,  cacheReadPerMTok: 0.50,   cacheWritePerMTok: 6.25, outputPerMTok: 30.00, contextWindowTokens: 256_000,
+                          longContextThresholdTokens: 272_000,
+                          inputAboveThresholdPerMTok: 10.00, cacheReadAboveThresholdPerMTok: 1.00, cacheWriteAboveThresholdPerMTok: 12.50, outputAboveThresholdPerMTok: 45.00 },
   // ── Copilot marketplace third-party models ──────────────────────────────────
   // These four were already present in media/src/pricing.ts (browser-side) but missing here — a real sync gap
   // that made cost_usd store as 0 (not ~$?) for any Copilot session using them, silently under-reporting rather
   // than flagging as unknown. Added 2026-08-12 to restore parity; rates confirmed against the Copilot pricing page.
-  'grok-4.5':           { inputPerMTok: 2.00,  cacheReadPerMTok: 0.50,   cacheWritePerMTok: 0, outputPerMTok: 6.00,  contextWindowTokens: 0 },
+  // grok-4.5: long-context surcharge above 200K tokens/call confirmed 2026-08-12 (2x input/cache-read, 1.5x output).
+  'grok-4.5':           { inputPerMTok: 2.00,  cacheReadPerMTok: 0.50,   cacheWritePerMTok: 0, outputPerMTok: 6.00,  contextWindowTokens: 0,
+                          longContextThresholdTokens: 200_000,
+                          inputAboveThresholdPerMTok: 4.00, cacheReadAboveThresholdPerMTok: 1.00, outputAboveThresholdPerMTok: 12.00 },
   'kimi-k3':            { inputPerMTok: 3.00,  cacheReadPerMTok: 0.30,   cacheWritePerMTok: 0, outputPerMTok: 15.00, contextWindowTokens: 0 },
   'kimi-k2.7-code':     { inputPerMTok: 0.95,  cacheReadPerMTok: 0.19,   cacheWritePerMTok: 0, outputPerMTok: 4.00,  contextWindowTokens: 0 },
   'mai-code-1-flash':   { inputPerMTok: 0.75,  cacheReadPerMTok: 0.075,  cacheWritePerMTok: 0, outputPerMTok: 4.50,  contextWindowTokens: 0 },
@@ -68,7 +87,8 @@ const RATES: Record<string, ModelRates> = {
   'claude-haiku-3-5':   { inputPerMTok:  0.80, cacheReadPerMTok: 0.08,  cacheWritePerMTok:  1.00, outputPerMTok:  4.00, contextWindowTokens: 200_000 },
   'claude-haiku-4-5':   { inputPerMTok:  1.00, cacheReadPerMTok: 0.10,  cacheWritePerMTok:  1.25, outputPerMTok:  5.00, contextWindowTokens: 200_000 },
   'claude-sonnet-4':    { inputPerMTok:  3.00, cacheReadPerMTok: 0.30,  cacheWritePerMTok:  3.75, outputPerMTok: 15.00, contextWindowTokens: 1_000_000,
-                          inputAbove200kPerMTok: 6.00, outputAbove200kPerMTok: 22.50, cacheReadAbove200kPerMTok: 0.60, cacheWriteAbove200kPerMTok: 7.50 },
+                          longContextThresholdTokens: 200_000,
+                          inputAboveThresholdPerMTok: 6.00, outputAboveThresholdPerMTok: 22.50, cacheReadAboveThresholdPerMTok: 0.60, cacheWriteAboveThresholdPerMTok: 7.50 },
   'claude-sonnet-4-5':  { inputPerMTok:  3.00, cacheReadPerMTok: 0.30,  cacheWritePerMTok:  3.75, outputPerMTok: 15.00, contextWindowTokens: 1_000_000 },
   'claude-sonnet-4-6':  { inputPerMTok:  3.00, cacheReadPerMTok: 0.30,  cacheWritePerMTok:  3.75, outputPerMTok: 15.00, contextWindowTokens: 1_000_000 },
   // claude-sonnet-5: launched at introductory pricing ($2/$0.20/$2.50/$10) with a scheduled increase to
@@ -96,7 +116,10 @@ const RATES: Record<string, ModelRates> = {
   'gemini-2.5-pro':  { inputPerMTok: 1.25, cacheReadPerMTok: 0.125, cacheWritePerMTok: 0, outputPerMTok: 10.00, contextWindowTokens: 1_000_000 },
   'gemini-3-flash':  { inputPerMTok: 0.50, cacheReadPerMTok: 0.05,  cacheWritePerMTok: 0, outputPerMTok:  3.00, contextWindowTokens: 1_000_000 },
   'gemini-3-pro':    { inputPerMTok: 2.00, cacheReadPerMTok: 0.20,  cacheWritePerMTok: 0, outputPerMTok: 12.00, contextWindowTokens: 1_000_000 },
-  'gemini-3.1-pro':  { inputPerMTok: 2.00, cacheReadPerMTok: 0.20,  cacheWritePerMTok: 0, outputPerMTok: 12.00, contextWindowTokens: 1_000_000 },
+  // gemini-3.1-pro: long-context surcharge above 200K tokens/call confirmed 2026-08-12 (2x input/cache-read, 1.5x output).
+  'gemini-3.1-pro':  { inputPerMTok: 2.00, cacheReadPerMTok: 0.20,  cacheWritePerMTok: 0, outputPerMTok: 12.00, contextWindowTokens: 1_000_000,
+                       longContextThresholdTokens: 200_000,
+                       inputAboveThresholdPerMTok: 4.00, cacheReadAboveThresholdPerMTok: 0.40, outputAboveThresholdPerMTok: 18.00 },
   'gemini-3.5-flash':{ inputPerMTok: 1.50, cacheReadPerMTok: 0.15,  cacheWritePerMTok: 0, outputPerMTok:  9.00, contextWindowTokens: 1_000_000 },
   // gemini-3.6-flash: added 2026-08-07, new on the Copilot pricing page.
   'gemini-3.6-flash':{ inputPerMTok: 1.50, cacheReadPerMTok: 0.15,  cacheWritePerMTok: 0, outputPerMTok:  7.50, contextWindowTokens: 1_000_000 },
@@ -138,11 +161,10 @@ export function lookupRates(modelId: string): ModelRates | null {
 }
 
 // Applies two-tier pricing: tokens up to the threshold at baseRate, remainder at aboveRate.
-function tieredCost(tokens: number, baseRatePerMTok: number, aboveRatePerMTok: number): number {
-  const THRESHOLD = 200_000
-  if (tokens <= THRESHOLD) return (tokens / 1_000_000) * baseRatePerMTok
-  return (THRESHOLD / 1_000_000) * baseRatePerMTok
-       + ((tokens - THRESHOLD) / 1_000_000) * aboveRatePerMTok
+function tieredCost(tokens: number, threshold: number, baseRatePerMTok: number, aboveRatePerMTok: number): number {
+  if (tokens <= threshold) return (tokens / 1_000_000) * baseRatePerMTok
+  return (threshold / 1_000_000) * baseRatePerMTok
+       + ((tokens - threshold) / 1_000_000) * aboveRatePerMTok
 }
 
 export function calcTokenCostUsd(
@@ -154,11 +176,16 @@ export function calcTokenCostUsd(
 ): number {
   const rates = lookupRates(modelId)
   if (!rates) return 0
-  if (rates.inputAbove200kPerMTok !== undefined) {
-    return tieredCost(inputTokens,     rates.inputPerMTok,      rates.inputAbove200kPerMTok)
-         + tieredCost(cacheReadTokens,  rates.cacheReadPerMTok,  rates.cacheReadAbove200kPerMTok!)
-         + tieredCost(cacheWriteTokens, rates.cacheWritePerMTok, rates.cacheWriteAbove200kPerMTok!)
-         + tieredCost(outputTokens,     rates.outputPerMTok,     rates.outputAbove200kPerMTok!)
+  if (rates.inputAboveThresholdPerMTok !== undefined) {
+    // Threshold defaults to 200K if above-threshold rates are set without an explicit threshold
+    // (kept for claude-sonnet-4 parity — every model added since has set this explicitly).
+    // Missing per-category above-threshold rates (e.g. cache write on a model with no cache-write
+    // pricing at all) fall back to that category's flat rate, i.e. no surcharge for that category.
+    const threshold = rates.longContextThresholdTokens ?? 200_000
+    return tieredCost(inputTokens,     threshold, rates.inputPerMTok,      rates.inputAboveThresholdPerMTok)
+         + tieredCost(cacheReadTokens,  threshold, rates.cacheReadPerMTok,  rates.cacheReadAboveThresholdPerMTok ?? rates.cacheReadPerMTok)
+         + tieredCost(cacheWriteTokens, threshold, rates.cacheWritePerMTok, rates.cacheWriteAboveThresholdPerMTok ?? rates.cacheWritePerMTok)
+         + tieredCost(outputTokens,     threshold, rates.outputPerMTok,     rates.outputAboveThresholdPerMTok ?? rates.outputPerMTok)
   }
   return (inputTokens     / 1_000_000) * rates.inputPerMTok
        + (cacheReadTokens / 1_000_000) * rates.cacheReadPerMTok

--- a/src/test/pricing.test.ts
+++ b/src/test/pricing.test.ts
@@ -72,4 +72,38 @@ suite('pricing', () => {
     const expected = (300_000 / 1_000_000) * 3.00
     assert.ok(Math.abs(cost - expected) < 0.0001, `Expected $${expected}, got $${cost}`)
   })
+
+  test('calcTokenCostUsd uses flat rate for gpt-5.4 under its 272K threshold', () => {
+    const cost = calcTokenCostUsd(200_000, 0, 0, 100_000, 'gpt-5.4')
+    const expected = (200_000 / 1_000_000) * 2.50 + (100_000 / 1_000_000) * 15.00
+    assert.ok(Math.abs(cost - expected) < 0.0001, `Expected $${expected}, got $${cost}`)
+  })
+
+  test('calcTokenCostUsd applies the surcharge for gpt-5.4 above its 272K threshold', () => {
+    // 372K input: first 272K at $2.50, next 100K at $5.00 (2x)
+    const cost = calcTokenCostUsd(372_000, 0, 0, 0, 'gpt-5.4')
+    const expected = (272_000 / 1_000_000) * 2.50 + (100_000 / 1_000_000) * 5.00
+    assert.ok(Math.abs(cost - expected) < 0.0001, `Expected $${expected}, got $${cost}`)
+  })
+
+  test('calcTokenCostUsd uses flat rate for gpt-5.6-luna under its 200K threshold', () => {
+    const cost = calcTokenCostUsd(150_000, 0, 0, 0, 'gpt-5.6-luna')
+    const expected = (150_000 / 1_000_000) * 0.20
+    assert.ok(Math.abs(cost - expected) < 0.0001, `Expected $${expected}, got $${cost}`)
+  })
+
+  test('calcTokenCostUsd applies the surcharge for gpt-5.6-luna above its 200K threshold (lower than the rest of the 5.6 family)', () => {
+    // 250K input: first 200K at $0.20, next 50K at $0.40 (2x)
+    const cost = calcTokenCostUsd(250_000, 0, 0, 0, 'gpt-5.6-luna')
+    const expected = (200_000 / 1_000_000) * 0.20 + (50_000 / 1_000_000) * 0.40
+    assert.ok(Math.abs(cost - expected) < 0.0001, `Expected $${expected}, got $${cost}`)
+  })
+
+  test('calcTokenCostUsd applies the surcharge to cache-read tokens for grok-4.5', () => {
+    // grok-4.5 has no cache-write pricing (0), so this also exercises the cacheWrite fallback path.
+    // 300K cache-read: first 200K at $0.50, next 100K at $1.00 (2x)
+    const cost = calcTokenCostUsd(0, 300_000, 50_000, 0, 'grok-4.5')
+    const expectedCacheRead = (200_000 / 1_000_000) * 0.50 + (100_000 / 1_000_000) * 1.00
+    assert.ok(Math.abs(cost - expectedCacheRead) < 0.0001, `Expected $${expectedCacheRead}, got $${cost}`)
+  })
 })


### PR DESCRIPTION
## Summary
Follow-up to the 2026-08-12 pricing refresh (#185), which confirmed the per-model long-context surcharge token thresholds that were previously the blocker on implementing this (`.staged-issues/09-long-context-surcharge-tiers.md`).

- `ModelRates`' tiered-pricing fields (previously `*Above200kPerMTok`, implicitly hardcoded to a 200K threshold, only ever used by `claude-sonnet-4`) are generalized to `*AboveThresholdPerMTok` plus an explicit per-model `longContextThresholdTokens` (defaults to 200K when unset, for `claude-sonnet-4` parity — no behavior change for it).
- `tieredCost()` / `calcTokenCostUsd()` now read the threshold from the rate entry instead of a module-level constant.
- Wires up the 7 models confirmed to have this tier: `gpt-5.4`, `gpt-5.5`, `gpt-5.6-sol`, `gpt-5.6-terra` (272K threshold), and `gpt-5.6-luna`, `gemini-3.1-pro`, `grok-4.5` (200K threshold) — 2x input/cache-read/cache-write, 1.5x output above the threshold, per `PRICING_SOURCES.md`.
- `media/src/pricing.ts` (browser-side session-level estimate) is intentionally left alone, per its own existing comment — it operates on session totals and can't reconstruct per-call token counts, so tiered pricing doesn't apply there regardless of threshold confirmation.

**Also**, per a request to double-check every place a pricing date needs to stay current: found and fixed a stale "Last updated: 2026-08-07" in `ARCHITECTURE.md`'s Cost Calculation section that #185 missed (it wasn't part of the original runbook checklist — there are three separate date locations, not one). `PRICING_SOURCES.md`'s refresh procedure now lists all three explicitly so this doesn't get missed again. Swept the whole repo to confirm no other stale `2026-08-07` pricing-date references remain.

## Test plan
- [x] 5 new unit tests: flat-vs-surcharge on both threshold values (`gpt-5.4` at 272K, `gpt-5.6-luna` at 200K), plus a cache-category fallback case (`grok-4.5`, which has no cache-write pricing at all)
- [x] `claude-sonnet-4`'s existing 4 tiered tests still pass unchanged — confirms no regression
- [x] Full 230-test suite passes
- [x] `pnpm run lint` / `pnpm run check-types` / `node esbuild.js` — all clean