### PR TITLE
fix: clarify git outcome banner wording to say "git" explicitly

### DIFF
--- a/src/gitOutcome.ts
+++ b/src/gitOutcome.ts
@@ -108,10 +108,10 @@ function summarize(overall: FileOutcome, files: Record<string, FileOutcome>): st
   const total = Object.keys(files).length
   const count = Object.values(files).filter(v => v === overall).length
   switch (overall) {
-    case 'reverted':   return `${count}/${total} file(s) reverted to their pre-session state`
-    case 'abandoned':  return `${count}/${total} file(s) still uncommitted since the session`
-    case 'productive': return `${total} file(s) committed after the session`
-    default:           return `Could not determine the outcome for ${count}/${total} file(s)`
+    case 'reverted':   return `${count}/${total} file(s) reverted to their pre-session state, per git history`
+    case 'abandoned':  return `${count}/${total} file(s) changed but not yet committed to git`
+    case 'productive': return `${total} file(s) committed to git after the session`
+    default:           return `Could not determine git status for ${count}/${total} file(s)`
   }
 }
 


### PR DESCRIPTION
## Summary
The git-outcome banner's summary text was ambiguous, e.g. **"Could not determine the outcome for 8/8 file(s)"** — never says "git" anywhere in the ambiguous case, and only implies it via "committed"/"reverted"/"uncommitted" in the other three. AgentLens already has an unrelated **"Outcome"** glossary concept (how a session concluded — text vs. tool response), so a bare "the outcome" reads as ambiguous to someone who hasn't already connected this specific banner to git.

All four cases now say "git" directly:
- `"N/M file(s) reverted to their pre-session state, per git history"`
- `"N/M file(s) changed but not yet committed to git"`
- `"M file(s) committed to git after the session"`
- `"Could not determine git status for N/M file(s)"`

No test asserted on the exact `reason` string content (only on the `overall`/`files` classification), so nothing else needed updating.

## Test plan
- [x] Verified the exact wording change against the ambiguous case: `"Could not determine git status for 8/8 file(s)"`
- [x] All 8 existing `gitOutcome` unit tests pass unchanged
- [x] Full 230-test suite passes
- [x] `pnpm run lint` / `pnpm run check-types` — clean