### PR TITLE
feat: add a Pricing page with the full rate table and sources

### DIFF
--- a/PRICING_SOURCES.md
+++ b/PRICING_SOURCES.md
@@ -14,16 +14,24 @@ and revert independently if a source turns out to have been misread.
 1. Fetch each source URL below and compare against the rate tables here.
 2. Update `RATES` in both `src/pricing.ts` and `media/src/pricing.ts` to match. See
    "Notes for maintainers" at the bottom for lookup/normalization details.
-3. Bump every date that records when pricing was last verified — there's more than one, and it's
+3. If you added, removed, or renamed a model key in `RATES`, update `PRICING_SECTIONS` in
+   `media/src/pricing.ts` to match — it's the vendor grouping + source citations the in-app Pricing
+   page (`$` icon in the header, `media/src/tabs/Pricing.tsx`) renders. A model left out doesn't go
+   missing — the page has an "Uncategorized" fallback for exactly this — but it should still land in
+   the right vendor group rather than sit there as a nudge to finish the job. If a source URL in a
+   section changed, update `PRICING_SECTIONS[].sources` too.
+4. Bump every date that records when pricing was last verified — there's more than one, and it's
    easy to miss one:
    - `PRICING_LAST_UPDATED` in `media/src/pricing.ts`
    - The `PRICING_LAST_UPDATED: <date>` comment at the top of `src/pricing.ts`
    - Every per-section "verified `<date>`" source line below, for whichever sections you actually
      re-checked
+   - The matching `PRICING_SECTIONS[].verified` date(s) in `media/src/pricing.ts` — these mirror the
+     sections below and drive the "verified `<date>`" text shown on the in-app Pricing page itself
    - `ARCHITECTURE.md`'s "Cost Calculation" section — it has its own "Last updated: `<date>`" line
      independent of the two constants above (found missed once already; check it every time)
-4. Run `tsc --noEmit` (both configs), `eslint src media/src`, and `mocha` to confirm nothing broke.
-5. If a rate or model can't be confirmed from a source, add it to that section's "Known gaps"
+5. Run `tsc --noEmit` (both configs), `eslint src media/src`, and `mocha` to confirm nothing broke.
+6. If a rate or model can't be confirmed from a source, add it to that section's "Known gaps"
    instead of guessing.
 
 ---

--- a/media/src/App.tsx
+++ b/media/src/App.tsx
@@ -21,6 +21,7 @@ import { Alerts, computeAlertCount, getTriggeredAlerts, checkAlerts, type Trigge
 import { Export } from './tabs/Export'
 import { Import } from './tabs/Import'
 import { Help } from './tabs/Help'
+import { Pricing } from './tabs/Pricing'
 import { Patterns } from './tabs/Patterns'
 import { Automation, checkAutomations } from './tabs/Automation'
 import { instructionFiles, appliedSuggestions, dismissedIds } from './tabs/Instructions'
@@ -51,6 +52,7 @@ function ActivePanel() {
     case 'export':    return <Export />
     case 'import':    return <Import />
     case 'help':      return <Help />
+    case 'pricing':   return <Pricing />
     default:          return null
   }
 }
@@ -158,6 +160,16 @@ function IconHelp() {
   )
 }
 
+function IconDollar() {
+  return (
+    <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="display:block">
+      <circle cx="12" cy="12" r="10" />
+      <path d="M16 8h-6a2 2 0 1 0 0 4h4a2 2 0 1 1 0 4H8" />
+      <path d="M12 6v12" />
+    </svg>
+  )
+}
+
 function AlertStatusCard({ alerts }: { alerts: TriggeredAlert[] }) {
   useEffect(() => {
     function onKey(e: KeyboardEvent) { if (e.key === 'Escape') bellOpen.value = false }
@@ -240,6 +252,17 @@ function HelpButton() {
       title="Help"
       onClick={() => { activeTab.value = 'help' }}
     ><IconHelp /></button>
+  )
+}
+
+function PricingButton() {
+  const isActive = normalizeTabId(activeTab.value) === 'pricing'
+  return (
+    <button
+      class={'icon-btn' + (isActive ? ' active' : '')}
+      title="Pricing — full rate table AgentLens uses to estimate cost"
+      onClick={() => { activeTab.value = 'pricing' }}
+    ><IconDollar /></button>
   )
 }
 
@@ -395,7 +418,7 @@ export function App() {
   }, [])
 
   const tab = normalizeTabId(activeTab.value)
-  const showFilterBars = tab !== 'help'
+  const showFilterBars = tab !== 'help' && tab !== 'pricing'
 
   return (
     <>
@@ -419,6 +442,7 @@ export function App() {
         <div style="margin-left:auto;display:flex;align-items:center;border-left:1px solid var(--border);padding-left:2px">
           <BellButton />
           <GearButton />
+          <PricingButton />
           <HelpButton />
         </div>
       </div>

--- a/media/src/pricing.ts
+++ b/media/src/pricing.ts
@@ -27,7 +27,7 @@ export interface ModelRates {
 }
 
 // Keyed by normalized model ID (lowercase, no date suffix).
-const RATES: Record<string, ModelRates> = {
+export const RATES: Record<string, ModelRates> = {
   // ── OpenAI ─────────────────────────────────────────────────────────────────────────────────────
   //                                                                     token rates ──────────────────────────────────── │ pre-Jun1  │ annual post-Jun1
   // gpt-4.1: re-listed on the pricing page as of 2026-08-07 at real rates (previously assumed delisted/$0 —
@@ -145,6 +145,86 @@ const RATES: Record<string, ModelRates> = {
   'nemotron-3-ultra-free':       { inputPerMTok: 0, cacheReadPerMTok: 0, cacheWritePerMTok: 0, outputPerMTok: 0, multiplier: 0, multiplierAnnualPostJun1: 0 },
   'nemotron-3.5-lightning-free': { inputPerMTok: 0, cacheReadPerMTok: 0, cacheWritePerMTok: 0, outputPerMTok: 0, multiplier: 0, multiplierAnnualPostJun1: 0 },
 }
+
+// ── UI display grouping ──────────────────────────────────────────────────────────
+// Purely presentational metadata for the Pricing page (tabs/Pricing.tsx) — groups
+// RATES entries by vendor (mirroring the section comments above), with the sources
+// each group was last checked against. Doesn't affect cost calculation at all;
+// PRICING_SOURCES.md's refresh runbook covers keeping this in sync alongside RATES.
+export interface PricingSection {
+  label: string
+  verified: string  // YYYY-MM-DD
+  sources: { label: string; url: string }[]
+  modelKeys: string[]
+}
+
+export const PRICING_SECTIONS: PricingSection[] = [
+  {
+    label: 'OpenAI (GPT / Codex family)',
+    verified: '2026-08-12',
+    sources: [
+      { label: 'Copilot model pricing', url: 'https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing' },
+      { label: 'OpenAI API pricing', url: 'https://developers.openai.com/api/docs/pricing' },
+      { label: 'Codex CLI pricing', url: 'https://learn.chatgpt.com/docs/pricing' },
+    ],
+    modelKeys: [
+      'gpt-4.1', 'gpt-4.1-mini', 'gpt-5-mini', 'gpt-5 mini', 'gpt-4o', 'gpt-4o-mini',
+      'gpt-5.1', 'gpt-5.1-codex', 'gpt-5.1-codex-mini', 'gpt-5.1-codex-max',
+      'gpt-5.2', 'gpt-5.2-codex', 'gpt-5.3-codex', 'gpt-5.4', 'gpt-5.4-mini', 'gpt-5.4-nano',
+      'gpt-5.5', 'gpt-5.6-luna', 'gpt-5.6-terra', 'gpt-5.6-sol', 'codex-mini-latest',
+    ],
+  },
+  {
+    label: 'Anthropic (Claude)',
+    verified: '2026-08-12',
+    sources: [
+      { label: 'Anthropic API pricing', url: 'https://platform.claude.com/docs/en/about-claude/pricing' },
+      { label: 'Copilot model pricing', url: 'https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing' },
+    ],
+    modelKeys: [
+      'claude-opus-4', 'claude-opus-4-1', 'claude-haiku-3-5', 'claude-haiku-4-5',
+      'claude-sonnet-4', 'claude-sonnet-4-5', 'claude-sonnet-4-6', 'claude-sonnet-5',
+      'claude-opus-4-5', 'claude-opus-4-6', 'claude-opus-4-7', 'claude-opus-4-8', 'claude-opus-5',
+      'claude-opus-4-6-fast', 'claude-opus-4-7-fast', 'claude-opus-4-8-fast', 'claude-opus-5-fast',
+      'claude-fable-5', 'claude-mythos-5',
+    ],
+  },
+  {
+    label: 'Google (Gemini)',
+    verified: '2026-08-12',
+    sources: [
+      { label: 'Copilot model pricing', url: 'https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing' },
+    ],
+    modelKeys: ['gemini-2.5-pro', 'gemini-3-flash', 'gemini-3-pro', 'gemini-3.1-pro', 'gemini-3.5-flash', 'gemini-3.6-flash'],
+  },
+  {
+    label: 'Fine-tuned & other Copilot-marketplace models',
+    verified: '2026-08-12',
+    sources: [
+      { label: 'Copilot model pricing', url: 'https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing' },
+    ],
+    modelKeys: ['raptor-mini', 'goldeneye', 'mai-code-1-flash', 'mai-code-1.1-flash', 'kimi-k2.7-code', 'grok-4.5', 'kimi-k3'],
+  },
+  {
+    label: 'OpenCode Zen (free evaluation models)',
+    verified: '2026-08-12',
+    sources: [
+      { label: 'OpenCode Zen docs', url: 'https://opencode.ai/docs/zen/' },
+    ],
+    modelKeys: [
+      'big-pickle', 'deepseek-v4-flash-free', 'mimo-v2.5-free', 'hy3-free',
+      'laguna-s-2.1-free', 'ling-3.0-tiny-free', 'nemotron-3-ultra-free', 'nemotron-3.5-lightning-free',
+    ],
+  },
+]
+
+// Copilot's request-based billing (multiplier / multiplierAnnualPostJun1 fields) applies across
+// every model above regardless of vendor, so its sources are shown once, globally, rather than
+// repeated per section.
+export const REQUEST_BILLING_SOURCES = [
+  { label: 'Annual-plan multipliers (post-Jun 1, 2026)', url: 'https://docs.github.com/en/copilot/reference/copilot-billing/model-multipliers-for-annual-plans' },
+  { label: 'Legacy request multipliers (pre-Jun 1, 2026, historical)', url: 'https://docs.github.com/en/copilot/concepts/billing/copilot-requests' },
+]
 
 function normalizeModelId(modelId: string): string {
   return modelId

--- a/media/src/tabs/Pricing.tsx
+++ b/media/src/tabs/Pricing.tsx
@@ -1,0 +1,133 @@
+import { PRICING_LAST_UPDATED, RATES, PRICING_SECTIONS, REQUEST_BILLING_SOURCES, type ModelRates } from '../pricing'
+
+// Table styling matches the established convention duplicated per-component across
+// the codebase (see Help.tsx's CostSection, Cost.tsx) rather than a shared import.
+const tblStyle = 'width:100%;border-collapse:collapse;font-size:12px;margin-bottom:8px'
+const thStyle = 'text-align:left;padding:5px 10px 5px 0;border-bottom:2px solid var(--border);color:var(--muted);font-size:11px;text-transform:uppercase;font-weight:600;white-space:nowrap'
+const tdStyle = 'padding:5px 10px 5px 0;border-bottom:1px solid var(--border);vertical-align:top'
+const tdBold  = tdStyle + ';font-weight:600;color:var(--fg);white-space:nowrap;font-family:var(--vscode-editor-font-family,monospace)'
+const tdNum   = tdStyle + ';white-space:nowrap;font-variant-numeric:tabular-nums'
+
+// Rate tables use fixed 2-decimal formatting (matching PRICING_SOURCES.md's own
+// tables) rather than fmtUsd's variable-precision cost-total formatting, which reads
+// oddly for small per-token rates (e.g. "$0.020" instead of "$0.02").
+function fmtRate(v: number): string {
+  return v === 0 ? '—' : '$' + v.toFixed(2)
+}
+
+function fmtMult(v: number): string {
+  if (v === 0) return '—'
+  const s = v % 1 === 0 ? v.toFixed(0) : v.toString()
+  return s + '×'
+}
+
+function SourceLinks({ sources }: { sources: { label: string; url: string }[] }) {
+  return (
+    <span style="font-size:11px;color:var(--muted)">
+      {sources.map((s, i) => (
+        <span key={s.url}>
+          {i > 0 && ' · '}
+          <a href={s.url} target="_blank" rel="noopener noreferrer" style="color:inherit;text-decoration:underline;text-underline-offset:2px">{s.label}</a>
+        </span>
+      ))}
+    </span>
+  )
+}
+
+function RatesTable({ modelKeys }: { modelKeys: string[] }) {
+  const hasTier = (r: ModelRates) => r.inputAbove200kPerMTok !== undefined
+  const anyTiered = modelKeys.some(k => RATES[k] && hasTier(RATES[k]))
+
+  return (
+    <>
+      <table style={tblStyle}>
+        <thead>
+          <tr>
+            <th style={thStyle}>Model</th>
+            <th style={thStyle}>Input</th>
+            <th style={thStyle}>Cache Read</th>
+            <th style={thStyle}>Cache Write</th>
+            <th style={thStyle}>Output</th>
+            <th style={thStyle}>Request ×</th>
+            <th style={thStyle}>Annual ×</th>
+          </tr>
+        </thead>
+        <tbody>
+          {modelKeys.map(key => {
+            const r = RATES[key]
+            if (!r) return null
+            return (
+              <tr key={key}>
+                <td style={tdBold}>{key}{hasTier(r) ? <sup style="margin-left:2px;color:var(--muted)">†</sup> : null}</td>
+                <td style={tdNum}>{fmtRate(r.inputPerMTok)}</td>
+                <td style={tdNum}>{fmtRate(r.cacheReadPerMTok)}</td>
+                <td style={tdNum}>{fmtRate(r.cacheWritePerMTok)}</td>
+                <td style={tdNum}>{fmtRate(r.outputPerMTok)}</td>
+                <td style={tdNum}>{fmtMult(r.multiplier)}</td>
+                <td style={tdNum}>{fmtMult(r.multiplierAnnualPostJun1)}</td>
+              </tr>
+            )
+          })}
+        </tbody>
+      </table>
+      {anyTiered && (
+        <div style="font-size:10px;color:var(--muted);margin:-4px 0 12px">
+          † Tiered — a higher rate applies above 200K tokens in a single call. Not broken out in this table; see <code>PRICING_SOURCES.md</code> for the full tier.
+        </div>
+      )}
+    </>
+  )
+}
+
+export function Pricing() {
+  const assignedKeys = new Set(PRICING_SECTIONS.flatMap(s => s.modelKeys))
+  const unassignedKeys = Object.keys(RATES).filter(k => !assignedKeys.has(k))
+
+  return (
+    <div id="pricing-content" style="padding:16px;max-width:960px">
+      <div style="font-size:11px;background:var(--hover);border:1px solid var(--border);border-left:3px solid var(--warning,#ffb74d);border-radius:4px;padding:8px 10px;margin-bottom:20px;line-height:1.6;color:var(--muted);display:flex;justify-content:space-between;align-items:center;gap:12px;flex-wrap:wrap">
+        <span><strong style="color:var(--fg)">Estimates only</strong> — this is the exact rate table AgentLens uses to estimate cost, nothing hidden or approximated for display. Actual billing may differ; see each vendor's own invoice.</span>
+        <span style="white-space:nowrap">Rates last updated: {PRICING_LAST_UPDATED}</span>
+      </div>
+
+      <p style="font-size:12px;color:var(--muted);line-height:1.6;margin:0 0 8px">
+        All USD rates are per 1M tokens. <strong style="color:var(--fg)">Request ×</strong> and <strong style="color:var(--fg)">Annual ×</strong> are Copilot's
+        per-request multipliers (× $0.04/request) — pre- and post-June 1 2026 respectively — for
+        plans on request-based billing rather than token-based AI Credits; <code>—</code> means
+        included/free under that billing mode. Sources for those two columns specifically:{' '}
+        <SourceLinks sources={REQUEST_BILLING_SOURCES} />.
+      </p>
+
+      {PRICING_SECTIONS.map(section => (
+        <div key={section.label} style="margin-top:24px">
+          <div style="display:flex;align-items:baseline;justify-content:space-between;flex-wrap:wrap;gap:8px;margin-bottom:6px">
+            <h3 style="font-size:13px;margin:0;color:var(--fg)">{section.label}</h3>
+            <span style="font-size:10px;color:var(--muted)">verified {section.verified} · <SourceLinks sources={section.sources} /></span>
+          </div>
+          <RatesTable modelKeys={section.modelKeys} />
+        </div>
+      ))}
+
+      {unassignedKeys.length > 0 && (
+        <div style="margin-top:24px">
+          <div style="display:flex;align-items:baseline;justify-content:space-between;flex-wrap:wrap;gap:8px;margin-bottom:6px">
+            <h3 style="font-size:13px;margin:0;color:var(--fg)">Uncategorized</h3>
+            <span style="font-size:10px;color:var(--muted)">
+              Added to <code>RATES</code> but not yet assigned to a section above — nothing is hidden, this just needs sorting into a vendor group.
+            </span>
+          </div>
+          <RatesTable modelKeys={unassignedKeys} />
+        </div>
+      )}
+
+      <div style="margin-top:24px;padding-top:16px;border-top:1px solid var(--vscode-panel-border);font-size:11px;color:var(--muted);line-height:1.7">
+        Full sourcing detail, known gaps, and per-model notes:{' '}
+        <a
+          href="https://github.com/RogerReed/agentlens/blob/main/PRICING_SOURCES.md"
+          target="_blank" rel="noopener noreferrer"
+          style="color:inherit;text-decoration:underline;text-underline-offset:2px"
+        >PRICING_SOURCES.md</a>.
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- New `$` icon in the header, next to Help, opens a **Pricing** page showing the exact rate table AgentLens uses to estimate cost — every model, grouped by vendor (OpenAI, Anthropic, Google, fine-tuned/third-party Copilot-marketplace models, OpenCode Zen).
- Each vendor group shows its own **"verified `<date>`"** and source links as footnotes, plus a global note on where the Copilot request-billing multiplier columns come from.
- An **"Uncategorized" fallback section** guarantees a model added to `RATES` can never silently go missing from the page, even if a future pricing refresh forgets to sort it into a vendor group.
- `RATES` in `media/src/pricing.ts` is now exported (was module-private) so the page renders it directly — no duplicated rate values anywhere. The new `PRICING_SECTIONS` array is purely grouping/citation metadata.
- Updates `PRICING_SOURCES.md`'s refresh runbook to keep `PRICING_SECTIONS` (model assignments, source links, per-section verified dates) in sync whenever `RATES` changes.

## Test plan
- [x] `tsc --noEmit` (both configs) clean
- [x] `eslint src media/src` — 0 errors (pre-existing warnings elsewhere, none introduced)
- [x] Full 181-test mocha suite passing
- [x] Cross-checked programmatically: all 61 `RATES` keys assigned to exactly one `PRICING_SECTIONS` entry — none missing, none duplicated
- [x] Live-verified in a real browser (rebuilt the standalone bundle, drove it with Playwright): `$` icon renders and opens the page, all 5 sections render with 61 total table rows, no console errors, switching back to Sessions correctly restores the filter bars (no tab-routing regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)