### PR TITLE
docs: surface loop patterns near top of Help, clarify Clear All + Automation/Advisor wording

### DIFF
--- a/media/src/tabs/Help.tsx
+++ b/media/src/tabs/Help.tsx
@@ -581,7 +581,7 @@ function PatternsSection() {
             <dd class="glossary-def" style="display:block">Triggered when a significant share of sessions exceed 1.5× the average turn count, indicating missing upfront context. Works for all agent types including Copilot.</dd>
           </div>
         </div>
-        <p style={mutedP}>Each suggestion card shows a <strong>Recommended addition</strong> — text ready to paste into your instruction file — and an <strong>Ask your agent</strong> prompt you can copy and send directly to your agent to get its own recommendation. Both have Copy buttons.</p>
+        <p style={mutedP}>Each suggestion card shows a <strong>Recommended addition</strong> — text ready to paste into your instruction file — and an <strong>Ask your agent</strong> prompt you can copy and send directly to your agent to get its own recommendation. Both have Copy buttons. <strong>AgentLens never edits your instruction file itself</strong> — nothing here writes to disk; every suggestion is copy-and-paste only, applied by you (or by the agent, if you paste the "Ask your agent" prompt into it).</p>
 
         <h4 style={subHeadStyle}>Efficiency Map</h4>
         <p style={mutedP}>A scatter plot where each dot is one session. Right = more expensive. Up = more LLM calls. Color = cache hit rate (green ≥60%, orange 20–60%, red &lt;20%). Click a dot to navigate to that session. The table below shows the top 10 sessions sorted by the active column — click any column header to re-sort.</p>
@@ -716,15 +716,19 @@ function SettingsSection() {
         </div>
 
         <h4 id="help-automation" style={subHeadStyle}>Automation</h4>
-        <p style="font-size:12px;color:var(--muted);margin:0 0 12px">Automations send a prompt to the agent automatically when a session crosses a threshold — without you having to intervene manually. Each automation can be enabled per-agent with independent thresholds for Claude Code, Copilot, and Codex. In the VS Code extension, automations surface as a notification with a copyable prompt. In standalone (npx) mode they appear as an in-page notification.</p>
+        <p style="font-size:12px;color:var(--muted);margin:0 0 12px">Automations watch live sessions and fire a correction prompt when a session crosses a threshold — but AgentLens never sends that prompt to the agent process itself, and there's no live channel (MCP included) that pushes it in automatically. Delivery is one of two things, per automation, controlled by its <strong>Write prompts file</strong> toggle in Settings: by default, a notification appears (VS Code warning notification, or an in-page notification in standalone/npx mode) with a <strong>Copy Prompt</strong> button — you copy it and paste it into the agent yourself. With <strong>Write prompts file</strong> enabled instead, AgentLens appends the prompt to <code style={codeStyle}>agentlens-prompts-&#123;agent&#125;.md</code> in the workspace root rather than showing a notification; nothing reads that file back to the agent automatically — it only helps if you (or an instruction you've added to CLAUDE.md/AGENTS.md) has the agent check it. Each automation can be enabled per-agent with independent thresholds for Claude Code, Copilot, and Codex.</p>
         <div class="glossary">
           <div class="glossary-item" style="flex-direction:column;gap:4px">
-            <dt class="glossary-term">Context Dump</dt>
+            <dt class="glossary-term">Context Compaction</dt>
             <dd class="glossary-def" style="display:block">Fires when a session's peak input tokens reaches the configured threshold. Sends a prompt asking the agent to summarize its context and compact before continuing. Helps avoid context-window overflows and keeps token cost in check. Default: 140K tokens.</dd>
           </div>
           <div class="glossary-item" style="flex-direction:column;gap:4px">
             <dt class="glossary-term">Loop Breaker</dt>
             <dd class="glossary-def" style="display:block">Fires when the same tool with identical arguments repeats beyond the threshold without a file change between repeats. Sends a prompt instructing the agent to stop and choose a different approach. A hard-stop backstop fires at 8 repeats regardless of configuration. Default: 3 repeats.</dd>
+          </div>
+          <div class="glossary-item" style="flex-direction:column;gap:4px">
+            <dt class="glossary-term">Error Cascade Stop</dt>
+            <dd class="glossary-def" style="display:block">Fires when a session hits its agent-specific consecutive-error streak. Sends a prompt instructing the agent to stop, diagnose the root cause, and change strategy before trying again. A hard-stop backstop fires at 8 consecutive errors regardless of configuration. Default: 3 consecutive errors.</dd>
           </div>
           <div class="glossary-item" style="flex-direction:column;gap:4px">
             <dt class="glossary-term">Turn Limit Wrap-up</dt>

--- a/media/src/tabs/Help.tsx
+++ b/media/src/tabs/Help.tsx
@@ -177,6 +177,14 @@ function OverviewSection() {
       <h3 class="help-heading">{HELP_SECTIONS.overview.heading}</h3>
       <div class="help-overview-body">
         <p><strong>AgentLens</strong> is a local observability tool that makes AI <a href="#gl-agent">agent</a> sessions more transparent — see what's happening inside each run. Available as a VS Code-family IDE extension (VS Code, Cursor, Windsurf, VSCodium, Trae, Kiro), a local web app (npx), or Docker, with no data leaving your machine. It captures <a href="#gl-otlp">OpenTelemetry</a> <a href="#gl-trace">traces</a> from GitHub Copilot, Claude Code, and Codex, and also reads <strong>local session files and databases</strong> written automatically by each agent as a zero-config fallback — including OpenCode's local SQLite database — so history loads even without OTEL configured. Both sources feed one unified dashboard and surface efficiency metrics, session cost estimates, human-readable summaries, and actionable insights in real time.</p>
+        <p style="font-size:13px;margin:10px 0 4px"><strong>AgentLens detects five loop / malfunction patterns</strong> — each with a ready-to-paste correction prompt (see <a href="#help-loops">Loop Detection</a> below for details):</p>
+        <ul style="margin:0 0 0 18px;padding:0;font-size:13px;color:var(--muted);line-height:1.75">
+          <li><a href="#help-tool-deadlock">Tool Call Deadlock</a> — the same tool call repeated 5+ times</li>
+          <li><a href="#help-state-spiral">State Corruption Spiral</a> — a file edited then reverted, oscillating</li>
+          <li><a href="#help-hallucination">Hallucination Amplification Loop</a> — the same error recurring 3+ times</li>
+          <li><a href="#help-runaway-steps">Ambiguous Success / Escalating Scope</a> — runaway step count, no stopping condition</li>
+          <li><a href="#help-context-accumulation">Infinite Loop — Context Accumulation</a> — input tokens growing while output collapses</li>
+        </ul>
       </div>
     </div>
   )
@@ -723,6 +731,9 @@ function SettingsSection() {
             <dd class="glossary-def" style="display:block">Fires when a session reaches the agent-specific turn threshold. Sends a prompt asking the agent to summarize progress, merge check-in details, and work toward a clean stopping point before hitting the model's hard turn limit. Default: 120 turns.</dd>
           </div>
         </div>
+
+        <h4 id="help-clear-all" style={subHeadStyle}>Clear All Data</h4>
+        <p style="font-size:12px;color:var(--muted);margin:0 0 12px">This button only deletes what AgentLens itself has stored — its local database/cache of parsed sessions. It does <strong>not</strong> touch the source files it read those sessions from: OTEL-captured sessions are removed permanently, but log-sourced sessions (Claude Code, Codex, Copilot JSONL logs, OpenCode's SQLite database) are re-read from those local log files and will reappear on the next scan. AgentLens currently has no feature to delete the underlying log files themselves — if you want those gone too, remove or rotate them yourself outside AgentLens (e.g. in <code style={codeStyle}>~/.claude/</code>, <code style={codeStyle}>~/.codex/</code>, <code style={codeStyle}>~/.copilot/</code>).</p>
       </div>
     </div>
   )

--- a/media/src/tabs/Help.tsx
+++ b/media/src/tabs/Help.tsx
@@ -797,6 +797,10 @@ Only use find_relevant_context if your task closely matches past prompts by keyw
             <dt class="glossary-term"><code style={codeStyle}>get_efficiency_report</code></dt>
             <dd class="glossary-def" style="display:block">Trend analysis over the last N days (default 30): cost trend (increasing/stable/decreasing), average cost and turns, error rate, agent/model ranking by cost efficiency, and most frequent loop signals with their occurrence rate.</dd>
           </div>
+          <div class="glossary-item" style="flex-direction:column;gap:2px">
+            <dt class="glossary-term"><code style={codeStyle}>get_instruction_suggestions</code></dt>
+            <dd class="glossary-def" style="display:block">Returns pending Advisor suggestions for improving the agent instruction file (CLAUDE.md, AGENTS.md, etc.) for the specified workspace — the same ready-to-paste text shown in the Advisor tab's Instructions File section. Use at the start of a session to check for improvements before beginning work. Requires <code style={codeStyle}>workspace</code> (absolute path) — cross-workspace suggestions aren't meaningful.</dd>
+          </div>
         </div>
 
         <h4 style={subHeadStyle}>Example prompts</h4>
@@ -811,7 +815,11 @@ to see what files similar sessions touched and what they typically cost.
 
 # To check efficiency trends over time:
 Use agentlens get_efficiency_report to see if sessions are getting more or
-less expensive, and which loop signals keep recurring.`}</pre>
+less expensive, and which loop signals keep recurring.
+
+# Before starting work — check for open Advisor suggestions:
+Use agentlens get_instruction_suggestions with workspace="/absolute/path/to/project"
+to see pending instruction-file suggestions before beginning work.`}</pre>
 
       </div>
     </div>

--- a/media/src/tabs/Settings.tsx
+++ b/media/src/tabs/Settings.tsx
@@ -7,11 +7,13 @@ function sendConfig(key: string, value: boolean) {
   }
 }
 
+const CLEAR_ALL_CONFIRM_TEXT = 'Clear all AgentLens data? OTEL session data is deleted permanently. AgentLens log cache is cleared and will be rebuilt from your local agent log files (the log files themselves are not deleted).'
+
 export function sendConfirmClear() {
   if (vscode) {
     vscode.postMessage({ type: 'confirmClear' })
   } else {
-    if (!confirm('Clear all AgentLens session data? This cannot be undone.')) return
+    if (!confirm(CLEAR_ALL_CONFIRM_TEXT)) return
     fetch('/action', { method: 'POST', body: JSON.stringify({ type: 'clearAll' }),
       headers: { 'Content-Type': 'application/json' } })
   }


### PR DESCRIPTION
## Summary
- Lists the five named loop/malfunction patterns as a bulleted quick-reference in Help Overview
- Documents Clear All Data's actual scope (spares log files) and adds the missing `get_instruction_suggestions` MCP tool doc
- Clarifies Advisor is copy-paste-only and fixes inaccuracies in the Automation section

## Test plan
- [x] Manual review of rendered Help tab content
- [x] `pnpm run check-types`

🤖 Generated with [Claude Code](https://claude.com/claude-code)