### PR TITLE
docs: say "built with Claude" instead of "Claude Opus"

### DIFF
--- a/README.md
+++ b/README.md
@@ -452,7 +452,7 @@ Override the default database location with the `OPENCODE_DATA_DIR` environment 
 
 ## AI Usage Disclosure
 
-AgentLens was built primarily with [Claude Opus](https://www.anthropic.com/claude). Thank you to Anthropic for building tools that make projects like this possible.
+AgentLens was built primarily with [Claude](https://www.anthropic.com/claude). Thank you to Anthropic for building tools that make projects like this possible.
 
 ## License
 


### PR DESCRIPTION
## Summary
- README's "built with" line named a specific Claude model (Opus), which goes stale as models change — generalized to "built with Claude"

🤖 Generated with [Claude Code](https://claude.com/claude-code)