### PR TITLE
fix: recover Copilot tool spans orphaned by a broken parent-span link

### DIFF
--- a/src/spanSummarizer.ts
+++ b/src/spanSummarizer.ts
@@ -134,7 +134,7 @@ export function summarizeSpans(spans: Span[]) {
   }
 
   const allSorted = [
-    ...buildCopilotSessions(invokeAgentSpans, childrenOf),
+    ...buildCopilotSessions(invokeAgentSpans, childrenOf, spansByTraceId),
     ...buildClaudeSessions(claudeInteractionSpans, spansByTraceId),
     ...buildCodexSessions(spans),
   ].sort((a, b) => timestampToMs(a.startTime) - timestampToMs(b.startTime))

--- a/src/summarizers/copilot.ts
+++ b/src/summarizers/copilot.ts
@@ -8,10 +8,35 @@ import {
 
 export function buildCopilotSessions(
   invokeAgentSpans: Span[],
-  childrenOf: Record<string, Span[]>
+  childrenOf: Record<string, Span[]>,
+  spansByTraceId: Record<string, Span[]> = {}
 ): SessionSummaryCard[] {
+  // How many invoke_agent spans share each traceId — used below to guard the orphan fallback,
+  // since attributing orphaned children by traceId alone would be ambiguous if a trace ever
+  // legitimately contains more than one Copilot session.
+  const invokeAgentCountByTrace = new Map<string, number>()
+  for (const a of invokeAgentSpans) {
+    if (!a.traceId) { continue }
+    invokeAgentCountByTrace.set(a.traceId, (invokeAgentCountByTrace.get(a.traceId) ?? 0) + 1)
+  }
+
   return invokeAgentSpans.map(agent => {
-    const children = collectDescendants(agent.spanId, childrenOf)
+    let children = collectDescendants(agent.spanId, childrenOf)
+
+    // Some real Copilot sessions report a normal invoke_agent span (correct turns/tokens/prompt)
+    // but its chat/execute_tool children carry a parentSpanId that never resolves back to it —
+    // collectDescendants then finds nothing, so tools/files/timeline all read empty even though
+    // the session clearly did work. This mirrors a parent-linking gap already known to affect
+    // in-progress Copilot sessions (see the orphan-parent synthesis in spanSummarizer.ts) — this
+    // is the completed-session sibling of that same class of bug. Fall back to every same-trace
+    // span that looks like a Copilot child, but only when the strict parent chain found nothing
+    // and the trace unambiguously belongs to this one session.
+    if (children.length === 0 && agent.traceId && invokeAgentCountByTrace.get(agent.traceId) === 1) {
+      children = (spansByTraceId[agent.traceId] ?? [])
+        .filter(s => s.spanId !== agent.spanId && (s.name.startsWith('chat') || s.name.startsWith('execute_tool')))
+    }
+
+    children = children
       .slice()
       .sort((a, b) => nanoToMs(a.startTime) - nanoToMs(b.startTime))
 

--- a/src/test/spanSummarizer.test.ts
+++ b/src/test/spanSummarizer.test.ts
@@ -282,6 +282,45 @@ suite('SpanSummarizer', () => {
       assert.strictEqual(copilot?.totalToolCalls, 1)
       assert.ok(copilot?.filesChanged.includes('src/components/SignupForm.tsx'))
     })
+
+    test('recovers Copilot tool spans whose parentSpanId never resolves to the session, via traceId', () => {
+      const agent = makeAgentSpan({ traceId: 'copilot-orphaned', spanId: 'agent-root-2', userRequest: 'fix the readme' })
+      // parentSpanId points at a span that doesn't exist anywhere in this payload — a real-world
+      // gap between how Copilot assigns parent IDs and where the root invoke_agent span actually
+      // ends up, distinct from the already-handled in-progress case (spanSummarizer.ts:91-134).
+      const tool = makeChildSpan('some-parent-id-that-was-never-captured', {
+        traceId: 'copilot-orphaned',
+        name: 'execute_tool/replace_string_in_file',
+        attributes: [
+          makeAttr('gen_ai.tool.name', 'replace_string_in_file'),
+          makeAttr('gen_ai.tool.call.arguments', JSON.stringify({ filePath: 'README.md' })),
+        ],
+      })
+
+      const result = summarizeSpans([agent, tool])
+      const copilot = result.sessions.find(s => s.source === 'copilot')
+      assert.ok(copilot)
+      assert.strictEqual(copilot?.totalToolCalls, 1)
+      assert.ok(copilot?.filesChanged.includes('README.md'))
+    })
+
+    test('does not guess which session owns orphaned spans when a trace has more than one Copilot session', () => {
+      const agentA = makeAgentSpan({ traceId: 'copilot-ambiguous', spanId: 'agent-a', userRequest: 'first request' })
+      const agentB = makeAgentSpan({ traceId: 'copilot-ambiguous', spanId: 'agent-b', userRequest: 'second request' })
+      const tool = makeChildSpan('missing-parent', {
+        traceId: 'copilot-ambiguous',
+        name: 'execute_tool/replace_string_in_file',
+        attributes: [
+          makeAttr('gen_ai.tool.name', 'replace_string_in_file'),
+          makeAttr('gen_ai.tool.call.arguments', JSON.stringify({ filePath: 'README.md' })),
+        ],
+      })
+
+      const result = summarizeSpans([agentA, agentB, tool])
+      const sessions = result.sessions.filter(s => s.source === 'copilot')
+      assert.strictEqual(sessions.length, 2)
+      assert.ok(sessions.every(s => s.totalToolCalls === 0))
+    })
   })
 
   suite('edge cases', () => {


### PR DESCRIPTION
## Summary
- Copilot sessions with a broken `parentSpanId` chain (parent-linking gap in telemetry) showed a blank Tools/Files tab even though the session clearly ran tools/edited files
- Adds a same-`traceId` fallback: when the strict descendant walk finds zero children for an `invoke_agent` span, and it's the only such span in that trace, fall back to any `chat`/`execute_tool` spans sharing the trace

Documented in `.staged-issues/2026-08-18-copilot-tools-files-always-blank.md` — flagged there as a well-evidenced fix, not 100% independently confirmed without a real Copilot OTEL capture from an affected session.

## Test plan
- [x] `pnpm run check-types`
- [x] Full mocha suite passing (238/238)

🤖 Generated with [Claude Code](https://claude.com/claude-code)