### PR TITLE
fix: parse Codex apply_patch unified-diff arguments for file extraction

### DIFF
--- a/src/summarizers/codex.ts
+++ b/src/summarizers/codex.ts
@@ -150,6 +150,22 @@ export function buildCodexSessions(spans: Span[]): SessionSummaryCard[] {
         if (argsStr) {
           try {
             const args = JSON.parse(argsStr) as Record<string, unknown>
+            // apply_patch is Codex's standard file-editing tool — its edit is a unified-diff-style
+            // patch string (args.input/patch/command), not a filePath/path key, so it needs its
+            // own parse: pull the file path out of each "*** Update/Add/Delete File: <path>" header.
+            if (toolName === 'apply_patch') {
+              const patchContent = String(args.input || args.patch || args.command || args.cmd || '')
+              for (const line of patchContent.split('\n')) {
+                const m = line.match(/^\*\*\*\s+(?:Update File:|Add File:|Delete File:)?\s*(.+)/)
+                if (m) {
+                  const patchFp = m[1].trim()
+                  if (patchFp && patchFp.includes('/')) {
+                    filesChanged.add(patchFp)
+                    foundFilePath = true
+                  }
+                }
+              }
+            }
             const fp = args.filePath || args.file_path || args.path
             if (fp) {
               foundFilePath = true
@@ -157,7 +173,7 @@ export function buildCodexSessions(spans: Span[]): SessionSummaryCard[] {
                 filesRead.add(String(fp).split('/').pop() || String(fp))
               } else if (toolName === 'grep_search' || toolName === 'file_search' || toolName === 'Glob' || toolName === 'Grep') {
                 filesSearched.add(String(args.query || args.pattern || fp))
-              } else {
+              } else if (toolName !== 'apply_patch') {
                 filesChanged.add(String(fp))
               }
             }

--- a/src/test/spanSummarizer.test.ts
+++ b/src/test/spanSummarizer.test.ts
@@ -508,6 +508,41 @@ suite('SpanSummarizer', () => {
       assert.ok((codex?.filesRead || []).includes('fullDashboardPanel.ts'))
     })
 
+    test('extracts file paths from Codex apply_patch unified-diff arguments', () => {
+      const patch = [
+        '*** Begin Patch',
+        '*** Update File: src/summarizers/codex.ts',
+        '@@',
+        '-old line',
+        '+new line',
+        '*** Add File: src/newThing.ts',
+        '+created',
+        '*** End Patch',
+      ].join('\n')
+      const spans: Span[] = [
+        makeSpan({
+          traceId: 'codex-apply-patch-trace',
+          spanId: 'cx-root-3',
+          name: 'codex.user_message',
+          attributes: [makeAttr('user_prompt', 'Fix the summarizer')],
+        }),
+        makeSpan({
+          traceId: 'codex-apply-patch-trace',
+          spanId: 'cx-tool-3',
+          name: 'codex.tool_result',
+          attributes: [
+            makeAttr('tool_name', 'apply_patch'),
+            makeAttr('arguments', JSON.stringify({ input: patch })),
+          ],
+        }),
+      ]
+
+      const result = summarizeSpans(spans)
+      const codex = result.sessions.find(s => s.source === 'codex')
+      assert.ok(codex)
+      assert.deepStrictEqual(codex?.filesChanged.sort(), ['src/newThing.ts', 'src/summarizers/codex.ts'])
+    })
+
     test('shows Codex tool_result output on the summary tool step', () => {
       const spans: Span[] = [
         makeSpan({


### PR DESCRIPTION
## Summary
- Real (non-demo) Codex OTEL sessions showed an empty Files tab despite the session clearly editing files
- `apply_patch` is Codex CLI's standard file-editing tool, and its arguments are a unified-diff patch string (`*** Update File: ...`), not a `filePath`/`path` key — `codex.ts` never parsed that shape, so file paths were silently dropped while tool-call counts stayed correct (making the gap easy to miss)
- Ports the same header-parsing logic `copilot.ts` already had for the equivalent patch format

Part of the investigation in `.staged-issues/2026-08-18-codex-copilot-empty-files.md` — the Codex half is fixed here; the Copilot half (no code gap found, needs more info from the user) is unrelated and not part of this PR.

## Test plan
- [x] `pnpm run check-types`
- [x] Full mocha suite passing (239/239), including a new regression test for apply_patch parsing

🤖 Generated with [Claude Code](https://claude.com/claude-code)