### PR TITLE
fix: cap sidebar token averages to the last 5 sessions

### DIFF
--- a/src/sidebarPanel.ts
+++ b/src/sidebarPanel.ts
@@ -3,6 +3,20 @@ import { SessionRepository } from './sessionRepository'
 import { nanoToMs } from './summarizers/helpers'
 import { Span } from './types'
 import { calcTokenCostUsd } from './pricing'
+import { SessionSummaryCard } from './summarizers/summarizerTypes'
+
+// Only the most recent N sessions feed the average — averaging over full history let one
+// unusually long session skew the bar-scaling average for everyone after it, especially
+// early on when the total session count is small.
+const AVG_WINDOW = 5
+
+export function tokenAverages(all: SessionSummaryCard[]): { avgInputTokens: number; avgOutputTokens: number } {
+  const recent = all.slice(0, AVG_WINDOW)
+  return {
+    avgInputTokens: recent.length > 0 ? recent.reduce((s, x) => s + x.inputTokens, 0) / recent.length : 1,
+    avgOutputTokens: recent.length > 0 ? recent.reduce((s, x) => s + x.outputTokens, 0) / recent.length : 1,
+  }
+}
 
 export class SidebarPanel implements vscode.WebviewViewProvider {
   private view?: vscode.WebviewView
@@ -91,10 +105,7 @@ export class SidebarPanel implements vscode.WebviewViewProvider {
     const latest = all.length > 0 ? all[0] : null
 
     // Per-type averages for independent bar scaling
-    const avgInputTokens = all.length > 0
-      ? all.reduce((s, x) => s + x.inputTokens, 0) / all.length : 1
-    const avgOutputTokens = all.length > 0
-      ? all.reduce((s, x) => s + x.outputTokens, 0) / all.length : 1
+    const { avgInputTokens, avgOutputTokens } = tokenAverages(all)
 
     // Burn rate for the current session — use latest if the session is active
     const burnRateResult = activity.isActive && latest
@@ -227,8 +238,7 @@ export class SidebarPanel implements vscode.WebviewViewProvider {
       costPerHour: burnRateResult.burnRate.costPerHour,
     } : null
 
-    const avgInputTokens = all.length > 0 ? all.reduce((s, x) => s + x.inputTokens, 0) / all.length : 1
-    const avgOutputTokens = all.length > 0 ? all.reduce((s, x) => s + x.outputTokens, 0) / all.length : 1
+    const { avgInputTokens, avgOutputTokens } = tokenAverages(all)
 
     const initData = JSON.stringify({
       lastActivityMs: activity.lastMs,

--- a/src/test/sidebarPanel.test.ts
+++ b/src/test/sidebarPanel.test.ts
@@ -1,0 +1,77 @@
+import * as assert from 'assert'
+import { tokenAverages } from '../sidebarPanel'
+import { SessionSummaryCard } from '../summarizers/summarizerTypes'
+
+function makeSession(overrides: Partial<SessionSummaryCard> = {}): SessionSummaryCard {
+  return {
+    sessionId: 'sess-1',
+    traceId: 'trace-1',
+    source: 'claude_code',
+    dataSource: 'otel',
+    workspace: '',
+    userRequest: 'fix the bug',
+    model: 'claude-3-5-sonnet',
+    turns: 3,
+    inputTokens: 5000,
+    outputTokens: 800,
+    cacheReadTokens: 0,
+    cacheCreateTokens: 0,
+    cacheHitRate: 0,
+    durationMs: 12000,
+    startTime: new Date().toISOString(),
+    filesRead: [],
+    filesSearched: [],
+    filesChanged: [],
+    filesWritten: [],
+    toolCounts: {},
+    totalToolCalls: 5,
+    totalLlmCalls: 3,
+    errors: 0,
+    outcome: 'unknown',
+    timeline: [],
+    backgroundSpans: [],
+    loopSignals: [],
+    ...overrides,
+  }
+}
+
+suite('sidebarPanel', () => {
+  suite('tokenAverages', () => {
+    test('returns 1 for both averages when there are no sessions', () => {
+      assert.deepStrictEqual(tokenAverages([]), { avgInputTokens: 1, avgOutputTokens: 1 })
+    })
+
+    test('averages across all sessions when there are 5 or fewer', () => {
+      const sessions = [
+        makeSession({ inputTokens: 1000, outputTokens: 100 }),
+        makeSession({ inputTokens: 2000, outputTokens: 200 }),
+      ]
+      assert.deepStrictEqual(tokenAverages(sessions), { avgInputTokens: 1500, avgOutputTokens: 150 })
+    })
+
+    test('ignores sessions past the most recent 5, so one old outlier session cannot skew the average forever', () => {
+      // Sessions are assumed most-recent-first (index 0 = latest), matching listSessions() ordering.
+      const sessions = [
+        makeSession({ inputTokens: 1000, outputTokens: 100 }),
+        makeSession({ inputTokens: 1000, outputTokens: 100 }),
+        makeSession({ inputTokens: 1000, outputTokens: 100 }),
+        makeSession({ inputTokens: 1000, outputTokens: 100 }),
+        makeSession({ inputTokens: 1000, outputTokens: 100 }),
+        // Outside the 5-session window — a huge outlier here must not affect the average.
+        makeSession({ inputTokens: 1_000_000, outputTokens: 100_000 }),
+      ]
+      assert.deepStrictEqual(tokenAverages(sessions), { avgInputTokens: 1000, avgOutputTokens: 100 })
+    })
+
+    test('a recent outlier still pulls the average, but only across the 5-session window', () => {
+      const sessions = [
+        makeSession({ inputTokens: 500_000, outputTokens: 50_000 }),
+        makeSession({ inputTokens: 1000, outputTokens: 100 }),
+        makeSession({ inputTokens: 1000, outputTokens: 100 }),
+        makeSession({ inputTokens: 1000, outputTokens: 100 }),
+        makeSession({ inputTokens: 1000, outputTokens: 100 }),
+      ]
+      assert.deepStrictEqual(tokenAverages(sessions), { avgInputTokens: 100_800, avgOutputTokens: 10_080 })
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- The Live · Current Session Activity bar-scaling averages (`avgInputTokens`/`avgOutputTokens`) were computed over a session's entire history — with few total sessions, one unusually long session could dominate the average and throw off the bar scaling for everything else
- Caps the averaging window to the 5 most recent sessions via a shared `tokenAverages()` helper (previously duplicated identically in `refresh()` and `getHtml()`)

## Test plan
- [x] `pnpm run check-types`
- [x] Full mocha suite passing, including 4 new `sidebarPanel.test.ts` cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)