### PR TITLE
fix: don't count files mentioned in read-only Codex shell commands as changed

### DIFF
--- a/src/summarizers/codex.ts
+++ b/src/summarizers/codex.ts
@@ -7,6 +7,25 @@ import {
   summarizeToolResult, normalizeUserRequest, rankModelsByWeight,
 } from './helpers'
 
+// A shell command mentioning a file path doesn't mean the file was changed — `cat foo.ts`,
+// `rg pattern foo.ts`, and `git diff foo.ts` are all reads. Only treat the command as a write
+// when it contains one of these unambiguous write signals; otherwise the mentioned files are
+// reads, not changes (this was previously always treated as a change, which is why sessions
+// that only ran read-only shell commands could show files as modified).
+const SHELL_WRITE_SIGNS = [
+  />{1,2}(?!=)/,             // output redirection: > or >> (not >=)
+  /\btee\b/,
+  /\bsed\b.*(^|\s)-i\b/,     // sed -i: in-place edit (plain `sed` without -i only prints to stdout)
+  /\b(mv|cp|rm|rmdir|mkdir|touch|chmod|ln)\b/,
+  /\bgit\s+apply\b/,
+  /\bpatch\b/,
+  /--write\b|--fix\b/,       // prettier --write, eslint --fix, etc.
+]
+
+function shellCommandWritesFiles(cmd: string): boolean {
+  return SHELL_WRITE_SIGNS.some(re => re.test(cmd))
+}
+
 export function buildCodexSessions(spans: Span[]): SessionSummaryCard[] {
   const toMs = (s: Span) => nanoToMs(s.startTime) || s.receivedAt || 0
   const codexBySession = groupCodexSpansBySession(spans)
@@ -188,13 +207,15 @@ export function buildCodexSessions(spans: Span[]): SessionSummaryCard[] {
           const cmd = cmdFromArgs
             || getFirstAttr(child, ['cmd', 'command', 'codex.tool.cmd', 'codex.tool.command', 'shell_command'])
           if (cmd) {
+            const isWrite = shellCommandWritesFiles(cmd)
             // Match absolute paths, ./relative paths, AND bare relative paths (e.g. src/file.ts)
             const fileRe = /(?:^|[\s'"<>`|])([./~]?(?:[\w.-]+\/)+[\w.-]+\.(?:ts|tsx|js|jsx|mjs|cjs|py|go|rs|rb|java|kt|swift|cpp|c|h|cs|php|html|css|scss|json|yaml|yml|toml|md|txt|sh|env))\b/g
             let m: RegExpExecArray | null
             while ((m = fileRe.exec(cmd)) !== null) {
               const p = m[1].replace(/['"]/g, '')
               if (p.length > 2 && !p.includes('*')) {
-                filesChanged.add(p)
+                if (isWrite) { filesChanged.add(p) }
+                else { filesRead.add(p.split('/').pop() || p) }
               }
             }
           }

--- a/src/test/spanSummarizer.test.ts
+++ b/src/test/spanSummarizer.test.ts
@@ -543,6 +543,77 @@ suite('SpanSummarizer', () => {
       assert.deepStrictEqual(codex?.filesChanged.sort(), ['src/newThing.ts', 'src/summarizers/codex.ts'])
     })
 
+    test('treats a read-only shell command as a file read, not a change', () => {
+      const spans: Span[] = [
+        makeSpan({
+          traceId: 'codex-shell-read-trace',
+          name: 'codex.user_message',
+          attributes: [makeAttr('user_prompt', 'Where is dispose() defined?')],
+        }),
+        makeSpan({
+          traceId: 'codex-shell-read-trace',
+          name: 'codex.tool_result',
+          attributes: [
+            makeAttr('tool_name', 'exec_command'),
+            makeAttr('arguments', JSON.stringify({ cmd: 'rg -n "dispose\\(\\)" src/foo.ts' })),
+          ],
+        }),
+      ]
+
+      const result = summarizeSpans(spans)
+      const codex = result.sessions.find(s => s.source === 'codex')
+      assert.ok(codex)
+      assert.deepStrictEqual(codex?.filesChanged, [])
+      assert.ok(codex?.filesRead.includes('foo.ts'))
+    })
+
+    test('treats a shell command with an explicit write signal as a file change', () => {
+      const spans: Span[] = [
+        makeSpan({
+          traceId: 'codex-shell-write-trace',
+          name: 'codex.user_message',
+          attributes: [makeAttr('user_prompt', 'Fix the typo in-place')],
+        }),
+        makeSpan({
+          traceId: 'codex-shell-write-trace',
+          name: 'codex.tool_result',
+          attributes: [
+            makeAttr('tool_name', 'exec_command'),
+            makeAttr('arguments', JSON.stringify({ cmd: "sed -i 's/teh/the/' src/foo.ts" })),
+          ],
+        }),
+      ]
+
+      const result = summarizeSpans(spans)
+      const codex = result.sessions.find(s => s.source === 'codex')
+      assert.ok(codex)
+      assert.deepStrictEqual(codex?.filesChanged, ['src/foo.ts'])
+      assert.deepStrictEqual(codex?.filesRead, [])
+    })
+
+    test('treats output redirection into a file as a change', () => {
+      const spans: Span[] = [
+        makeSpan({
+          traceId: 'codex-shell-redirect-trace',
+          name: 'codex.user_message',
+          attributes: [makeAttr('user_prompt', 'Write the log to a file')],
+        }),
+        makeSpan({
+          traceId: 'codex-shell-redirect-trace',
+          name: 'codex.tool_result',
+          attributes: [
+            makeAttr('tool_name', 'exec_command'),
+            makeAttr('arguments', JSON.stringify({ cmd: 'echo "done" > src/status.txt' })),
+          ],
+        }),
+      ]
+
+      const result = summarizeSpans(spans)
+      const codex = result.sessions.find(s => s.source === 'codex')
+      assert.ok(codex)
+      assert.deepStrictEqual(codex?.filesChanged, ['src/status.txt'])
+    })
+
     test('shows Codex tool_result output on the summary tool step', () => {
       const spans: Span[] = [
         makeSpan({


### PR DESCRIPTION
## Summary
- Codex's file-extraction fallback (used for its shell/`exec_command` tool when a call has no `filePath`/`file_path`/`path` argument) pulled every file-looking path out of the raw shell command string and unconditionally added it to `filesChanged` — so a read-only command like `rg pattern foo.ts` or `cat foo.ts` made the Files tab show the file as modified (M) even though nothing was written
- Now only treats the command as a write when it contains an unambiguous write signal (output redirection, `sed -i`, `tee`, `mv`/`cp`/`rm`/`mkdir`/`touch`/`chmod`/`ln`, `git apply`, `patch`, `--write`/`--fix`); otherwise the mentioned files are treated as reads

## Test plan
- [x] `pnpm run check-types`
- [x] Full mocha suite passing, including 3 new regression tests in `spanSummarizer.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)