### PR TITLE
fix: agentlens service install looped forever installing itself via npx

### DIFF
--- a/src/serviceConfig.ts
+++ b/src/serviceConfig.ts
@@ -103,6 +103,30 @@ export function isRunningFromNpx(userAgent: string | undefined, scriptPath: stri
   return /[\\/]_npx[\\/]/.test(scriptPath) || /[\\/]\.npm[\\/]_npx[\\/]/.test(scriptPath)
 }
 
+// ── npx-bootstrap re-exec guard ──────────────────────────────────────────────
+//
+// `child_process.execFileSync` inherits the parent's environment by default. Without this,
+// re-invoking `agentlens service install` after the global-install bootstrap would still carry
+// the original npm_config_user_agent (containing "npx/...") into the child — isRunningFromNpx
+// would see that stale value and bootstrap again, forever, even though the child is by then
+// correctly running from the global install. childEnvForReexec strips it (so the child's own
+// npx check gets an honest read) and stamps a marker; shouldBlockRepeatedBootstrap checks that
+// marker so any *other* undiscovered path to the same failure mode fails loudly instead of
+// looping.
+
+export const REEXEC_GUARD_ENV = 'AGENTLENS_SERVICE_BOOTSTRAPPED'
+
+export function shouldBlockRepeatedBootstrap(env: NodeJS.ProcessEnv): boolean {
+  return env[REEXEC_GUARD_ENV] === '1'
+}
+
+export function childEnvForReexec(parentEnv: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  const env = { ...parentEnv }
+  delete env.npm_config_user_agent
+  env[REEXEC_GUARD_ENV] = '1'
+  return env
+}
+
 // ── Service-definition generators (pure string builders) ────────────────────
 
 export interface ServiceProgram {

--- a/src/test/serviceConfig.test.ts
+++ b/src/test/serviceConfig.test.ts
@@ -5,6 +5,7 @@ import * as path from 'path'
 import {
   defaultServiceConfig, serviceConfigPath, readServiceConfig, writeServiceConfig,
   serviceLogPath, parseServiceInstallFlags, isRunningFromNpx,
+  childEnvForReexec, shouldBlockRepeatedBootstrap, REEXEC_GUARD_ENV,
   generateLaunchdPlist, generateSystemdUnit, generateWindowsWrapperScript,
   launchdLabel, SYSTEMD_UNIT_NAME, WINDOWS_TASK_NAME,
   type ServiceProgram,
@@ -112,6 +113,39 @@ suite('serviceConfig', () => {
 
     test('returns false for a normal global-install path and user-agent', () => {
       assert.strictEqual(isRunningFromNpx('npm/10.0.0 node/v24', '/usr/local/lib/node_modules/agentlens-dashboard/standalone/cli.js'), false)
+    })
+  })
+
+  suite('childEnvForReexec / shouldBlockRepeatedBootstrap', () => {
+    test('strips npm_config_user_agent so a re-exec\'d child does not see itself as still running via npx', () => {
+      const parentEnv = { PATH: '/usr/bin', npm_config_user_agent: 'npm/10.0.0 node/v24 npx/10.0.0' }
+      const childEnv = childEnvForReexec(parentEnv)
+      assert.strictEqual(childEnv.npm_config_user_agent, undefined)
+      assert.strictEqual(childEnv.PATH, '/usr/bin')
+    })
+
+    test('stamps the re-exec guard marker', () => {
+      const childEnv = childEnvForReexec({})
+      assert.strictEqual(childEnv[REEXEC_GUARD_ENV], '1')
+    })
+
+    test('shouldBlockRepeatedBootstrap is false without the marker', () => {
+      assert.strictEqual(shouldBlockRepeatedBootstrap({}), false)
+    })
+
+    test('shouldBlockRepeatedBootstrap is true once childEnvForReexec has stamped the marker', () => {
+      const childEnv = childEnvForReexec({ npm_config_user_agent: 'npm/10.0.0 npx/10.0.0' })
+      assert.strictEqual(shouldBlockRepeatedBootstrap(childEnv), true)
+    })
+
+    test('regression: without stripping, a naive re-exec would loop forever detecting npx again', () => {
+      // This is the exact bug: execFileSync inherits the parent env by default, so re-invoking
+      // `agentlens service install` without childEnvForReexec would carry the stale npx user-agent
+      // straight through, and isRunningFromNpx would trigger another bootstrap indefinitely.
+      const parentEnv = { npm_config_user_agent: 'npm/10.0.0 node/v24 npx/10.0.0' }
+      assert.strictEqual(isRunningFromNpx(parentEnv.npm_config_user_agent, '/usr/local/bin/agentlens'), true)
+      const fixedChildEnv = childEnvForReexec(parentEnv)
+      assert.strictEqual(isRunningFromNpx(fixedChildEnv.npm_config_user_agent, '/usr/local/bin/agentlens'), false)
     })
   })
 

--- a/standalone/service/index.ts
+++ b/standalone/service/index.ts
@@ -3,6 +3,7 @@ import * as os from 'os'
 import { execFileSync, spawn } from 'child_process'
 import {
   parseServiceInstallFlags, isRunningFromNpx, writeServiceConfig, readServiceConfig,
+  shouldBlockRepeatedBootstrap, childEnvForReexec,
   type ServiceConfig, type ServiceProgram,
 } from '../../src/serviceConfig'
 import * as macos from './macos'
@@ -61,12 +62,22 @@ terminal, or a reboot.`)
  *  install for the user (visibly, not silently — this touches global npm state) and then
  *  re-invokes itself as the now-globally-linked `agentlens` command. */
 function bootstrapGlobalInstall(remainingArgs: string[]): number {
+  if (shouldBlockRepeatedBootstrap(process.env)) {
+    console.error(
+      '[AgentLens] Still detected as running via npx after installing globally and re-invoking ' +
+      '`agentlens` — that shouldn\'t happen and looks like a bug rather than a real npx run. ' +
+      'Try running `npm install -g agentlens-dashboard` yourself, then `agentlens service install` directly.'
+    )
+    return 1
+  }
   console.log('[AgentLens] Running via npx — installing agentlens-dashboard globally first, ' +
     'so the background service has a stable command to launch on every start:')
   console.log('  npm install -g agentlens-dashboard')
   execFileSync('npm', ['install', '-g', 'agentlens-dashboard'], { stdio: 'inherit' })
   console.log('[AgentLens] Global install complete. Continuing with service install...')
-  execFileSync('agentlens', ['service', 'install', ...remainingArgs], { stdio: 'inherit' })
+  execFileSync('agentlens', ['service', 'install', ...remainingArgs], {
+    stdio: 'inherit', env: childEnvForReexec(process.env),
+  })
   return 0
 }
 


### PR DESCRIPTION
## Summary
- User-reported: `npx agentlens-dashboard service install` looped forever, reinstalling the package globally every ~1s until manually interrupted, instead of installing once and continuing.
- Root cause: `execFileSync` inherits the parent's environment by default, so the re-exec'd `agentlens service install` child still carried the original `npm_config_user_agent` (containing `npx/...`) from the npx invocation — even though it was by then running the real globally-installed binary, `isRunningFromNpx()` saw that stale env var and bootstrapped again, forever.
- Fix: strip `npm_config_user_agent` from the re-exec'd child's environment (`childEnvForReexec`) so its own npx check gets an honest read, and add a hard recursion guard (`shouldBlockRepeatedBootstrap`, stamped via an `AGENTLENS_SERVICE_BOOTSTRAPPED` env marker) so any other undiscovered path to the same failure mode fails loudly instead of looping.

This bug is live in the just-published v0.12.0 — worth a patch release once merged.

## Test plan
- [x] 5 new regression tests in `src/test/serviceConfig.test.ts`, including one asserting the exact before/after behavior of the bug
- [x] Verified end-to-end with a fake `npm`/`agentlens` stub on `PATH` simulating the real npx flow (bootstraps exactly once, child sees a clean env)
- [x] Separately confirmed the guard trips instead of looping when forced
- [x] Full suite passing (272/272), typecheck (root + `standalone/tsconfig.json`) and lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)