### PR TITLE
fix: Codex git add/commit/etc. shell commands weren't counted as file changes

### DIFF
--- a/src/summarizers/codex.ts
+++ b/src/summarizers/codex.ts
@@ -17,7 +17,12 @@ const SHELL_WRITE_SIGNS = [
   /\btee\b/,
   /\bsed\b.*(^|\s)-i\b/,     // sed -i: in-place edit (plain `sed` without -i only prints to stdout)
   /\b(mv|cp|rm|rmdir|mkdir|touch|chmod|ln)\b/,
-  /\bgit\s+apply\b/,
+  // git subcommands that finalize a file's state as part of the agent's work — `git add`/`commit`
+  // don't rewrite the file's bytes themselves, but from a "what did this session touch" view they're
+  // exactly how an edited file gets wrapped up, and are frequently the ONLY shell evidence of a file
+  // touched by a tool call whose own arguments didn't carry a usable file path (e.g. a failed/atypical
+  // apply_patch parse). Without these, "git add foo.ts && git commit" reads as a no-op.
+  /\bgit\s+(apply|add|commit|rm|mv|restore|checkout|cherry-pick|revert|merge|rebase|stash)\b/,
   /\bpatch\b/,
   /--write\b|--fix\b/,       // prettier --write, eslint --fix, etc.
 ]

--- a/src/test/spanSummarizer.test.ts
+++ b/src/test/spanSummarizer.test.ts
@@ -614,6 +614,36 @@ suite('SpanSummarizer', () => {
       assert.deepStrictEqual(codex?.filesChanged, ['src/status.txt'])
     })
 
+    test('treats "git add && git commit" as a file change, not a read', () => {
+      // Regression: git add/commit don't rewrite the file's bytes, but they're exactly how an
+      // agent finalizes an already-edited file, and are frequently the only shell evidence of a
+      // touched file when the tool call that actually wrote it didn't parse cleanly. Real-world
+      // command captured from a user report of files wrongly showing up as reads.
+      const spans: Span[] = [
+        makeSpan({
+          traceId: 'codex-shell-git-commit-trace',
+          name: 'codex.user_message',
+          attributes: [makeAttr('user_prompt', 'Commit the fix')],
+        }),
+        makeSpan({
+          traceId: 'codex-shell-git-commit-trace',
+          name: 'codex.tool_result',
+          attributes: [
+            makeAttr('tool_name', 'exec_command'),
+            makeAttr('arguments', JSON.stringify({
+              cmd: 'git add src/foo.ts && git commit --amend --no-edit && git status --short',
+            })),
+          ],
+        }),
+      ]
+
+      const result = summarizeSpans(spans)
+      const codex = result.sessions.find(s => s.source === 'codex')
+      assert.ok(codex)
+      assert.deepStrictEqual(codex?.filesChanged, ['src/foo.ts'])
+      assert.deepStrictEqual(codex?.filesRead, [])
+    })
+
     test('shows Codex tool_result output on the summary tool step', () => {
       const spans: Span[] = [
         makeSpan({


### PR DESCRIPTION
## Summary
- Fixes a regression from the v0.12.0 shell-command read-vs-write classification fix (#205): `git add`/`commit`/`rm`/`mv`/`restore`/`checkout`/`cherry-pick`/`revert`/`merge`/`rebase`/`stash` weren't recognized as write signals, so finalizing an edit via `git add <file> && git commit` was misclassified as a mere "read" instead of a "changed" file.
- Adds these git subcommands to the write-signal list alongside the existing `git apply`.
- New regression test reproduces the exact real-world command shape from a user-reported session.

## Test plan
- [x] 273/273 tests passing (`npm test` via mocha programmatic API)
- [x] New regression test in `src/test/spanSummarizer.test.ts` covers `git add && git commit --amend --no-edit && git status --short`

🤖 Generated with [Claude Code](https://claude.com/claude-code)