### PR TITLE
feat: show AgentLens version at startup and on the Help page

### DIFF
--- a/media/src/tabs/Help.tsx
+++ b/media/src/tabs/Help.tsx
@@ -138,8 +138,13 @@ function Toc() {
   return (
     <>
       <style dangerouslySetInnerHTML={{ __html: 'html,body{scroll-behavior:smooth}.help-section{scroll-margin-top:44px}.glossary-item[id]{scroll-margin-top:44px}.help-toc a{display:inline-block;padding:3px 11px;border-radius:12px;font-size:11px;font-weight:500;color:var(--muted);text-decoration:none;border:1px solid var(--border);transition:color .1s,background .1s}.help-toc a:hover{color:var(--fg);background:var(--hover);border-color:var(--fg)}' }} />
-      <nav class="help-toc" aria-label="Help sections" style="position:sticky;top:0;z-index:20;background:var(--vscode-editorWidget-background,var(--bg));border-bottom:1px solid var(--border);padding:7px 0 8px;margin:0 -16px 20px -12px;padding-left:12px;display:flex;gap:4px;flex-wrap:nowrap;overflow-x:auto;scrollbar-width:none">
-        {TOC_SECTIONS.map(s => <a href={s.href}>{s.heading}</a>)}
+      <nav class="help-toc" aria-label="Help sections" style="position:sticky;top:0;z-index:20;background:var(--vscode-editorWidget-background,var(--bg));border-bottom:1px solid var(--border);padding:7px 12px 8px 0;margin:0 -16px 20px -12px;display:flex;align-items:center;gap:12px">
+        <div style="display:flex;gap:4px;flex-wrap:nowrap;overflow-x:auto;scrollbar-width:none;flex:1;min-width:0;padding-left:12px">
+          {TOC_SECTIONS.map(s => <a href={s.href}>{s.heading}</a>)}
+        </div>
+        {window.__VERSION__ && (
+          <span style="font-size:10px;color:var(--muted);white-space:nowrap;flex-shrink:0">v{window.__VERSION__}</span>
+        )}
       </nav>
     </>
   )
@@ -1018,14 +1023,9 @@ export function Help() {
       <ImportSection />
       <BadgesSection />
       <GlossarySection />
-      <div style="margin-top:24px;padding-top:12px;border-top:1px solid var(--border)">
-        {window.__VERSION__ && (
-          <p style="font-size:11px;color:var(--muted);margin:0 0 8px">AgentLens v{window.__VERSION__}</p>
-        )}
-        <p style="font-size:11px;color:var(--muted);margin:0;line-height:1.6">
-          <strong>Disclaimer:</strong> AgentLens is an independent open-source project and is not affiliated with, endorsed by, or associated with GitHub, Inc. or Microsoft Corporation (GitHub Copilot); Anthropic, PBC (Claude / Claude Code); or OpenAI, LLC (Codex / Codex CLI). All product names, trademarks, and registered trademarks are the property of their respective owners. AgentLens interacts with these products solely through their publicly documented OpenTelemetry telemetry interfaces.
-        </p>
-      </div>
+      <p style="font-size:11px;color:var(--muted);margin-top:24px;padding-top:12px;border-top:1px solid var(--border);line-height:1.6">
+        <strong>Disclaimer:</strong> AgentLens is an independent open-source project and is not affiliated with, endorsed by, or associated with GitHub, Inc. or Microsoft Corporation (GitHub Copilot); Anthropic, PBC (Claude / Claude Code); or OpenAI, LLC (Codex / Codex CLI). All product names, trademarks, and registered trademarks are the property of their respective owners. AgentLens interacts with these products solely through their publicly documented OpenTelemetry telemetry interfaces.
+      </p>
     </div>
   )
 }

--- a/media/src/tabs/Help.tsx
+++ b/media/src/tabs/Help.tsx
@@ -1018,9 +1018,14 @@ export function Help() {
       <ImportSection />
       <BadgesSection />
       <GlossarySection />
-      <p style="font-size:11px;color:var(--muted);margin-top:24px;padding-top:12px;border-top:1px solid var(--border);line-height:1.6">
-        <strong>Disclaimer:</strong> AgentLens is an independent open-source project and is not affiliated with, endorsed by, or associated with GitHub, Inc. or Microsoft Corporation (GitHub Copilot); Anthropic, PBC (Claude / Claude Code); or OpenAI, LLC (Codex / Codex CLI). All product names, trademarks, and registered trademarks are the property of their respective owners. AgentLens interacts with these products solely through their publicly documented OpenTelemetry telemetry interfaces.
-      </p>
+      <div style="margin-top:24px;padding-top:12px;border-top:1px solid var(--border)">
+        {window.__VERSION__ && (
+          <p style="font-size:11px;color:var(--muted);margin:0 0 8px">AgentLens v{window.__VERSION__}</p>
+        )}
+        <p style="font-size:11px;color:var(--muted);margin:0;line-height:1.6">
+          <strong>Disclaimer:</strong> AgentLens is an independent open-source project and is not affiliated with, endorsed by, or associated with GitHub, Inc. or Microsoft Corporation (GitHub Copilot); Anthropic, PBC (Claude / Claude Code); or OpenAI, LLC (Codex / Codex CLI). All product names, trademarks, and registered trademarks are the property of their respective owners. AgentLens interacts with these products solely through their publicly documented OpenTelemetry telemetry interfaces.
+        </p>
+      </div>
     </div>
   )
 }

--- a/media/src/types.ts
+++ b/media/src/types.ts
@@ -244,5 +244,6 @@ declare global {
     __INITIAL_SESSION_SUMMARY__?: FullSummary | null
     __MASCOT_URI__?: string
     __STANDALONE__?: boolean
+    __VERSION__?: string
   }
 }

--- a/src/dashboardPanel.ts
+++ b/src/dashboardPanel.ts
@@ -379,6 +379,7 @@ export class DashboardPanel {
         window.__INITIAL_TOOL_CALLS__ = ${safeJsonForScript(summary.toolCalls)};
         window.__INITIAL_SESSION_SUMMARY__ = ${safeJsonForScript(sessionSummary)};
         window.__MASCOT_URI__ = ${safeJsonForScript(mascotUri.toString())};
+        window.__VERSION__ = ${safeJsonForScript(this.context.extension.packageJSON.version)};
         window.__MCP_ENABLED__ = ${mcpEnabled};
         window.__MCP_PORT__ = ${mcpPort};
       </script>`

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -87,7 +87,7 @@ async function detectPortOwner(port: number): Promise<'plugin' | 'standalone' | 
 export async function activate(context: vscode.ExtensionContext) {
   outputChannel = vscode.window.createOutputChannel('AgentLens')
   context.subscriptions.push(outputChannel)
-  outputChannel.appendLine('AgentLens activating…')
+  outputChannel.appendLine(`AgentLens activating… (v${context.extension.packageJSON.version})`)
 
   // ── Database ────────────────────────────────────────────────────────────────
   try {

--- a/standalone/server.ts
+++ b/standalone/server.ts
@@ -40,6 +40,7 @@ const parsedMaxSpans = parseInt(process.env.AGENTLENS_MAX_SPANS ?? '', 10)
 const MAX_SPANS  = Number.isNaN(parsedMaxSpans) ? DEFAULT_MAX_SPANS : parsedMaxSpans
 
 const PACKAGE_VERSION: string = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'package.json'), 'utf8')).version
+console.log(`[AgentLens] Version         ${PACKAGE_VERSION}`)
 
 const mediaDir  = path.join(__dirname, '..', 'media')
 const DATA_DIR  = process.env.DATA_DIR ?? fileConfig.dataDir
@@ -1573,7 +1574,6 @@ Promise.all([
 }).catch(e => console.warn('[AgentLens] Auto-configure error:', e))
 
 otlpServer.listen(OTLP_PORT, BIND_HOST, () => {
-  console.log(`[AgentLens] Version         ${PACKAGE_VERSION}`)
   console.log(`[AgentLens] OTLP receiver → http://localhost:${OTLP_PORT}`)
 })
 

--- a/standalone/server.ts
+++ b/standalone/server.ts
@@ -39,6 +39,8 @@ const BIND_HOST  = process.env.BIND_HOST ?? fileConfig.bindHost
 const parsedMaxSpans = parseInt(process.env.AGENTLENS_MAX_SPANS ?? '', 10)
 const MAX_SPANS  = Number.isNaN(parsedMaxSpans) ? DEFAULT_MAX_SPANS : parsedMaxSpans
 
+const PACKAGE_VERSION: string = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'package.json'), 'utf8')).version
+
 const mediaDir  = path.join(__dirname, '..', 'media')
 const DATA_DIR  = process.env.DATA_DIR ?? fileConfig.dataDir
 const DATA_FILE = path.join(DATA_DIR, 'spans.json')
@@ -726,6 +728,7 @@ function getHtml(): string {
     window.__INITIAL_SESSION_SUMMARY__ = ${sessionSummaryJson};
     window.__MASCOT_URI__ = '/help-mascot.png';
     window.__STANDALONE__ = true;
+    window.__VERSION__ = ${JSON.stringify(PACKAGE_VERSION)};
 
     // ── Client-side search support ────────────────────────────────────────────
     var __latestSessions__ = (window.__INITIAL_SESSION_SUMMARY__ && window.__INITIAL_SESSION_SUMMARY__.sessions) || [];
@@ -1570,6 +1573,7 @@ Promise.all([
 }).catch(e => console.warn('[AgentLens] Auto-configure error:', e))
 
 otlpServer.listen(OTLP_PORT, BIND_HOST, () => {
+  console.log(`[AgentLens] Version         ${PACKAGE_VERSION}`)
   console.log(`[AgentLens] OTLP receiver → http://localhost:${OTLP_PORT}`)
 })
 


### PR DESCRIPTION
## Summary
- The VS Code extension now logs its version to the AgentLens output channel on activation: `AgentLens activating… (v0.12.2)`.
- The standalone/npx server now prints its version in the startup banner: `[AgentLens] Version         0.12.2`.
- The Help page footer (both VS Code and standalone/npx mode) now shows `AgentLens vX.Y.Z`, sourced from `package.json` via a new `window.__VERSION__` injection — following the existing `__MASCOT_URI__`/`__STANDALONE__` pattern.

## Test plan
- [x] `pnpm run check-types` passes (main + media + standalone projects)
- [x] `pnpm run lint` — 0 errors (pre-existing warnings only)
- [x] Full unit suite: 273/273 passing
- [x] Ran the built standalone server locally — confirmed `[AgentLens] Version         0.12.2` in the startup log and `window.__VERSION__ = "0.12.2"` in the served HTML
- [x] Confirmed the bundled `dashboard.js` renders "AgentLens v" text on the Help page

🤖 Generated with [Claude Code](https://claude.com/claude-code)