### PR TITLE
feat: add `agentlens service update` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,8 +317,13 @@ agentlens service logs        # print the service's log file
 agentlens service logs --follow
 agentlens service stop        # stop it
 agentlens service start       # start it again
+agentlens service update      # upgrade to the latest version and restart on it
 agentlens service uninstall   # remove it (your data in ~/.agentlens is untouched)
 ```
+
+> **Installing the background service does not make it auto-update.** It keeps running whatever
+> version was installed until you run `agentlens service update` yourself — that pulls the latest
+> `agentlens-dashboard` from npm and restarts the service on it.
 
 `service install` uses whichever OS-native mechanism fits your platform, all installed per-user
 with no admin/root privileges required:
@@ -339,8 +344,6 @@ agentlens service install --ui-port 3001 --otlp-port 4319 --data-dir ~/agentlens
 Since `npx` always runs from a temporary cache with no stable path to launch from, running
 `service install` under `npx` installs `agentlens-dashboard` globally first (equivalent to
 `npm install -g agentlens-dashboard`) so the service definition has something fixed to point at.
-That also means the service runs whatever version was installed at that point — update it later
-with `npm install -g agentlens-dashboard@latest` followed by `agentlens service restart`.
 
 ### Docker (OTEL only)
 

--- a/media/src/tabs/Help.tsx
+++ b/media/src/tabs/Help.tsx
@@ -366,7 +366,7 @@ trace_exporter = { otlp-http = { endpoint = "http://localhost:4318", protocol = 
         all per-user, no admin/root privileges needed. Once installed, it starts automatically at login
         (and immediately on install) and restarts itself if it crashes.
       </p>
-      <p style="font-size:12px;color:var(--muted);margin:0">
+      <p style="font-size:12px;color:var(--muted);margin:0 0 8px">
         <code style={codeStyle}>agentlens service status</code> checks whether it's running,{' '}
         <code style={codeStyle}>logs</code> (or <code style={codeStyle}>logs --follow</code>) shows its
         output, <code style={codeStyle}>stop</code>/<code style={codeStyle}>start</code>/<code style={codeStyle}>restart</code> control
@@ -374,6 +374,12 @@ trace_exporter = { otlp-http = { endpoint = "http://localhost:4318", protocol = 
         <code style={codeStyle}>~/.agentlens</code> is untouched either way. See{' '}
         <a href="https://github.com/RogerReed/agentlens#background-service-macos--windows--linux" target="_blank" rel="noreferrer">the README</a> for
         the full command reference and custom port/data-dir options.
+      </p>
+      <p style="font-size:12px;color:var(--muted);margin:0;background:var(--panel-bg);border-radius:3px;padding:8px 10px">
+        <strong style="color:var(--fg)">The background service does not auto-update.</strong> It keeps
+        running whatever version was installed until you run{' '}
+        <code style={codeStyle}>agentlens service update</code>, which installs the latest{' '}
+        <code style={codeStyle}>agentlens-dashboard</code> from npm and restarts the service on it.
       </p>
     </div>
   ) : null

--- a/standalone/service/index.ts
+++ b/standalone/service/index.ts
@@ -49,6 +49,10 @@ Commands:
   start             Start the installed service.
   stop              Stop the installed service.
   restart           Restart the installed service.
+  update            Install the latest agentlens-dashboard from npm and restart
+                    the service on it. This is how you upgrade — installing a
+                    background service does NOT auto-update; it keeps running
+                    whatever version was installed until you run this.
   status            Check whether the service is running and reachable.
   logs [--follow]   Print (or tail) the service's log file.
 
@@ -66,6 +70,20 @@ terminal, or a reboot.`)
 function resolveGlobalCliPath(): string {
   const globalRoot = execFileSync('npm', ['root', '-g'], { encoding: 'utf-8' }).trim()
   return path.join(globalRoot, 'agentlens-dashboard', 'standalone', 'cli.js')
+}
+
+/** Reads the version of the globally-installed package straight off disk — used to report what
+ *  `service update` actually changed, since `npm install -g` prints its own noisy log rather than
+ *  a clean before/after. */
+function readGlobalVersion(): string | undefined {
+  try {
+    const globalRoot = execFileSync('npm', ['root', '-g'], { encoding: 'utf-8' }).trim()
+    const pkgPath = path.join(globalRoot, 'agentlens-dashboard', 'package.json')
+    if (!fs.existsSync(pkgPath)) return undefined
+    return JSON.parse(fs.readFileSync(pkgPath, 'utf-8')).version
+  } catch {
+    return undefined
+  }
 }
 
 /** npx runs from an ephemeral cache with no stable path a service definition can point
@@ -164,6 +182,21 @@ export async function runServiceCli(args: string[]): Promise<number> {
     case 'restart':
       platformService.restart()
       return 0
+    case 'update': {
+      const before = readGlobalVersion()
+      console.log('[AgentLens] Updating agentlens-dashboard to the latest version:')
+      console.log('  npm install -g agentlens-dashboard@latest')
+      execFileSync('npm', ['install', '-g', 'agentlens-dashboard@latest'], { stdio: 'inherit' })
+      const after = readGlobalVersion()
+      if (before && after && before === after) {
+        console.log(`[AgentLens] Already up to date (v${after}) — no restart needed.`)
+        return 0
+      }
+      console.log(`[AgentLens] Updated${before ? ` v${before} →` : ''} v${after ?? '(unknown)'}. Restarting the background service...`)
+      platformService.restart()
+      console.log('[AgentLens] Background service restarted on the new version.')
+      return 0
+    }
     case 'status': {
       const config = readServiceConfig()
       const running = await platformService.status(config.uiPort, config.bindHost)


### PR DESCRIPTION
## Summary
- The background service installed via `agentlens service install` never auto-updates — it keeps running whatever version was installed until someone manually updates it. That was previously documented only as a single sentence buried inside an unrelated README paragraph about npx bootstrapping, wasn't mentioned in the CLI's own `--help` text, and wasn't in the in-app Help page at all.
- Adds `agentlens service update` — runs `npm install -g agentlens-dashboard@latest`, then restarts the service, reporting the before/after version (or "already up to date" if nothing changed).
- Surfaces this clearly in three places: the CLI's `service --help` usage text, a dedicated callout in the README's Background Service section (plus adding it to the command list), and the standalone-mode Help page's Setup section.

## Test plan
- [x] `pnpm run check-types` passes (main + media + standalone projects)
- [x] `pnpm run lint` — 0 errors (pre-existing warnings only)
- [x] Full unit suite: 273/273 passing
- [x] `node standalone/cli.js service --help` — confirmed `update` appears with clear wording
- [x] Did not execute the real `npm install -g agentlens-dashboard@latest` against the live registry (would mutate global npm state) — verified `readGlobalVersion()` degrades gracefully (returns `undefined`) when nothing is installed globally, matching existing `restart` behavior when the service isn't installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)