### PR TITLE
feat: add auth token and Host-header validation to the standalone servers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,6 @@ ENV OTLP_PORT=4318 \
 EXPOSE 4318 3000
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s \
-  CMD wget -qO- http://localhost:3000/ || exit 1
+  CMD wget -qO- http://localhost:3000/health || exit 1
 
 CMD ["node", "standalone/server.js"]

--- a/src/httpSecurity.ts
+++ b/src/httpSecurity.ts
@@ -1,0 +1,78 @@
+/**
+ * Shared HTTP hardening for the three standalone servers (UI, OTLP, MCP) — see
+ * .staged-issues/01-enterprise-readiness.md phase 1. Two independent defenses:
+ *
+ *   - Host-header validation: rejects requests whose Host header isn't a loopback alias or
+ *     the configured bindHost, which defeats DNS-rebinding (an attacker page that gets a
+ *     hostname to resolve to 127.0.0.1 still sends its own hostname as the Host header, not
+ *     "localhost" — the browser doesn't rewrite it).
+ *   - Bearer-token auth: a token generated at first run (`ensureAuthToken` in serviceConfig.ts),
+ *     checked via `Authorization: Bearer`, a `?token=` query param, or an `agentlens_token`
+ *     cookie. Enforced everywhere on the UI server (the CLI hands the token to the browser when
+ *     it opens the dashboard); on OTLP/MCP it only activates once BIND_HOST is non-loopback,
+ *     so today's default loopback setup and existing agent auto-configuration keep working
+ *     unauthenticated exactly as before.
+ */
+
+import * as crypto from 'crypto'
+import type { IncomingMessage } from 'http'
+
+const LOOPBACK_HOSTNAMES = new Set(['localhost', '127.0.0.1', '::1'])
+
+export function isLoopbackHost(host: string): boolean {
+  return LOOPBACK_HOSTNAMES.has(host)
+}
+
+function hostnameOf(hostHeader: string): string {
+  if (hostHeader.startsWith('[')) {
+    const end = hostHeader.indexOf(']')
+    return end === -1 ? hostHeader : hostHeader.slice(1, end)
+  }
+  const idx = hostHeader.lastIndexOf(':')
+  return idx === -1 ? hostHeader : hostHeader.slice(0, idx)
+}
+
+export function isAllowedHostHeader(hostHeader: string | undefined, bindHost: string): boolean {
+  if (!hostHeader) return false
+  const hostname = hostnameOf(hostHeader)
+  return isLoopbackHost(hostname) || hostname === bindHost
+}
+
+export const AUTH_COOKIE_NAME = 'agentlens_token'
+
+export function authCookieHeader(token: string): string {
+  return `${AUTH_COOKIE_NAME}=${token}; Path=/; HttpOnly; SameSite=Lax; Max-Age=31536000`
+}
+
+export function extractCookieToken(req: Pick<IncomingMessage, 'headers'>): string | null {
+  const cookie = req.headers['cookie']
+  if (typeof cookie !== 'string') return null
+  const match = new RegExp(`(?:^|;\\s*)${AUTH_COOKIE_NAME}=([^;]+)`).exec(cookie)
+  return match ? decodeURIComponent(match[1]) : null
+}
+
+export function extractToken(req: Pick<IncomingMessage, 'headers' | 'url'>): string | null {
+  const auth = req.headers['authorization']
+  if (typeof auth === 'string' && auth.startsWith('Bearer ')) return auth.slice(7)
+  try {
+    const url = new URL(req.url ?? '/', 'http://localhost')
+    const qToken = url.searchParams.get('token')
+    if (qToken) return qToken
+  } catch { /* malformed URL — fall through to cookie */ }
+  return extractCookieToken(req)
+}
+
+function timingSafeStringEqual(a: string, b: string): boolean {
+  const bufA = Buffer.from(a)
+  const bufB = Buffer.from(b)
+  if (bufA.length !== bufB.length) return false
+  return crypto.timingSafeEqual(bufA, bufB)
+}
+
+/** `expectedToken === ''` means auth isn't configured yet (shouldn't happen once
+ *  `ensureAuthToken` has run) — fail open rather than lock everyone out. */
+export function isAuthorized(req: Pick<IncomingMessage, 'headers' | 'url'>, expectedToken: string): boolean {
+  if (!expectedToken) return true
+  const provided = extractToken(req)
+  return provided !== null && timingSafeStringEqual(provided, expectedToken)
+}

--- a/src/mcpServer.ts
+++ b/src/mcpServer.ts
@@ -27,6 +27,7 @@ import type { SessionSummaryCard, TimelineEntry } from './summarizers/summarizer
 import { generateSuggestions } from './instructionAdvisor'
 import { readAllInstructionContent } from './instructionFiles'
 import { checkAutomationTriggers } from './automationEngine'
+import { isAllowedHostHeader, isAuthorized, isLoopbackHost } from './httpSecurity'
 
 // ── Session accessor ──────────────────────────────────────────────────────────
 
@@ -565,13 +566,24 @@ export function startMcpHttpServer(
   opts: McpServerOptions,
   port: number,
   bindHost = '127.0.0.1',
+  authToken = '',
 ): http.Server {
   const server = createMcpServer(opts)
+  // Only enforced once bindHost is exposed beyond loopback — the default local setup and
+  // existing MCP clients (this repo's own Claude Code / editor integrations) point at
+  // 127.0.0.1 with no way to supply a token, so they must keep working unauthenticated.
+  const requireToken = !isLoopbackHost(bindHost)
   const httpServer = http.createServer((req, res) => {
+    if (!isAllowedHostHeader(req.headers.host, bindHost)) {
+      res.writeHead(403, { 'Content-Type': 'text/plain' }); res.end('Forbidden — invalid Host header'); return
+    }
     res.setHeader('Access-Control-Allow-Origin', '*')
     res.setHeader('Access-Control-Allow-Methods', 'GET, POST, DELETE, OPTIONS')
-    res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Accept, mcp-session-id')
+    res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Accept, mcp-session-id, Authorization')
     if (req.method === 'OPTIONS') { res.writeHead(204); res.end(); return }
+    if (requireToken && !isAuthorized(req, authToken)) {
+      res.writeHead(401, { 'Content-Type': 'text/plain' }); res.end('Unauthorized'); return
+    }
     handleMcpRequest(server, req, res)
   })
   httpServer.on('error', (err: NodeJS.ErrnoException) => {

--- a/src/serviceConfig.ts
+++ b/src/serviceConfig.ts
@@ -9,6 +9,7 @@
 import * as fs from 'fs'
 import * as path from 'path'
 import * as os from 'os'
+import * as crypto from 'crypto'
 
 export interface ServiceConfig {
   uiPort: number
@@ -16,6 +17,10 @@ export interface ServiceConfig {
   mcpPort: number
   bindHost: string
   dataDir: string
+  /** Bearer token guarding the UI/OTLP/MCP servers. Empty until `ensureAuthToken` generates
+   *  and persists one on first run — kept out of `defaultServiceConfig` so that function stays
+   *  pure and deterministic for tests. */
+  authToken: string
 }
 
 // `baseHome` defaults to the real home directory in production; tests pass a temp directory
@@ -32,6 +37,7 @@ export function defaultServiceConfig(baseHome?: string): ServiceConfig {
     mcpPort: 4316,
     bindHost: '127.0.0.1',
     dataDir: defaultDataDir(baseHome),
+    authToken: '',
   }
 }
 
@@ -59,6 +65,23 @@ export function writeServiceConfig(config: ServiceConfig, baseHome?: string): vo
   fs.writeFileSync(configPath, JSON.stringify(config, null, 2) + '\n', 'utf-8')
 }
 
+/** Generates a fresh bearer token for the UI/OTLP/MCP servers. */
+export function generateAuthToken(): string {
+  return crypto.randomBytes(24).toString('hex')
+}
+
+/** Returns `config` unchanged if it already has an auth token; otherwise generates one,
+ *  persists it to disk immediately (so a restart reuses the same token instead of
+ *  invalidating every open browser tab / configured agent), and returns the updated config.
+ *  Called once at server startup — not from `readServiceConfig` itself — so that function can
+ *  stay a pure read with no side effects. */
+export function ensureAuthToken(config: ServiceConfig, baseHome?: string): ServiceConfig {
+  if (config.authToken) return config
+  const withToken = { ...config, authToken: generateAuthToken() }
+  writeServiceConfig(withToken, baseHome)
+  return withToken
+}
+
 export function serviceLogPath(config: ServiceConfig): string {
   return path.join(config.dataDir, 'logs', 'service.log')
 }
@@ -82,7 +105,7 @@ export function parseServiceInstallFlags(args: string[]): ServiceConfig {
     const value = args[i + 1]
     if (value === undefined) { continue }
     i++
-    if (key === 'bindHost' || key === 'dataDir') {
+    if (key === 'bindHost' || key === 'dataDir' || key === 'authToken') {
       config[key] = value
     } else {
       const n = parseInt(value, 10)

--- a/src/test/httpSecurity.test.ts
+++ b/src/test/httpSecurity.test.ts
@@ -1,0 +1,116 @@
+import * as assert from 'assert'
+import {
+  isLoopbackHost, isAllowedHostHeader, isAuthorized, extractToken, extractCookieToken,
+  authCookieHeader, AUTH_COOKIE_NAME,
+} from '../httpSecurity'
+
+function req(opts: { host?: string; authorization?: string; url?: string; cookie?: string }) {
+  const headers: Record<string, string> = {}
+  if (opts.host !== undefined) headers['host'] = opts.host
+  if (opts.authorization !== undefined) headers['authorization'] = opts.authorization
+  if (opts.cookie !== undefined) headers['cookie'] = opts.cookie
+  return { headers, url: opts.url ?? '/' }
+}
+
+suite('httpSecurity', () => {
+  suite('isLoopbackHost', () => {
+    test('recognizes the three loopback aliases', () => {
+      assert.strictEqual(isLoopbackHost('localhost'), true)
+      assert.strictEqual(isLoopbackHost('127.0.0.1'), true)
+      assert.strictEqual(isLoopbackHost('::1'), true)
+    })
+
+    test('rejects a real hostname or 0.0.0.0', () => {
+      assert.strictEqual(isLoopbackHost('0.0.0.0'), false)
+      assert.strictEqual(isLoopbackHost('example.com'), false)
+    })
+  })
+
+  suite('isAllowedHostHeader', () => {
+    test('allows localhost and 127.0.0.1 with a port, regardless of bindHost', () => {
+      assert.strictEqual(isAllowedHostHeader('localhost:3000', '0.0.0.0'), true)
+      assert.strictEqual(isAllowedHostHeader('127.0.0.1:3000', '0.0.0.0'), true)
+    })
+
+    test('allows bracketed IPv6 loopback', () => {
+      assert.strictEqual(isAllowedHostHeader('[::1]:3000', '127.0.0.1'), true)
+    })
+
+    test('allows the configured bindHost itself when it is not loopback', () => {
+      assert.strictEqual(isAllowedHostHeader('agentlens.internal:3000', 'agentlens.internal'), true)
+    })
+
+    test('rejects an attacker-controlled hostname (DNS-rebinding scenario)', () => {
+      // The whole point of Host validation: a page at evil.com that gets its own domain to
+      // resolve to 127.0.0.1 still sends "evil.com" as the Host header, not "localhost" —
+      // the browser does not rewrite it to match the IP it actually connected to.
+      assert.strictEqual(isAllowedHostHeader('evil.com:3000', '127.0.0.1'), false)
+    })
+
+    test('rejects a missing Host header', () => {
+      assert.strictEqual(isAllowedHostHeader(undefined, '127.0.0.1'), false)
+    })
+  })
+
+  suite('extractToken', () => {
+    test('reads an Authorization: Bearer header', () => {
+      assert.strictEqual(extractToken(req({ authorization: 'Bearer abc123' })), 'abc123')
+    })
+
+    test('reads a ?token= query param', () => {
+      assert.strictEqual(extractToken(req({ url: '/?token=xyz789' })), 'xyz789')
+    })
+
+    test('reads the agentlens_token cookie', () => {
+      assert.strictEqual(extractToken(req({ cookie: `${AUTH_COOKIE_NAME}=cookieval` })), 'cookieval')
+    })
+
+    test('prefers the Authorization header over a query token', () => {
+      assert.strictEqual(extractToken(req({ authorization: 'Bearer header-token', url: '/?token=query-token' })), 'header-token')
+    })
+
+    test('returns null when nothing is present', () => {
+      assert.strictEqual(extractToken(req({})), null)
+    })
+
+    test('ignores a malformed Authorization header', () => {
+      assert.strictEqual(extractToken(req({ authorization: 'Basic dXNlcjpwYXNz' })), null)
+    })
+  })
+
+  suite('extractCookieToken', () => {
+    test('extracts the token from among multiple cookies', () => {
+      assert.strictEqual(extractCookieToken(req({ cookie: `foo=bar; ${AUTH_COOKIE_NAME}=thetoken; baz=qux` })), 'thetoken')
+    })
+
+    test('returns null when the cookie is absent', () => {
+      assert.strictEqual(extractCookieToken(req({ cookie: 'foo=bar' })), null)
+    })
+  })
+
+  suite('isAuthorized', () => {
+    test('accepts a matching token from any source', () => {
+      assert.strictEqual(isAuthorized(req({ authorization: 'Bearer secret' }), 'secret'), true)
+      assert.strictEqual(isAuthorized(req({ url: '/?token=secret' }), 'secret'), true)
+      assert.strictEqual(isAuthorized(req({ cookie: `${AUTH_COOKIE_NAME}=secret` }), 'secret'), true)
+    })
+
+    test('rejects a wrong or missing token', () => {
+      assert.strictEqual(isAuthorized(req({ authorization: 'Bearer wrong' }), 'secret'), false)
+      assert.strictEqual(isAuthorized(req({}), 'secret'), false)
+    })
+
+    test('fails open when no token is configured yet', () => {
+      assert.strictEqual(isAuthorized(req({}), ''), true)
+    })
+  })
+
+  suite('authCookieHeader', () => {
+    test('sets the token, HttpOnly, and a long Max-Age', () => {
+      const header = authCookieHeader('mytoken')
+      assert.ok(header.includes(`${AUTH_COOKIE_NAME}=mytoken`))
+      assert.ok(header.includes('HttpOnly'))
+      assert.ok(header.includes('Path=/'))
+    })
+  })
+})

--- a/src/test/serviceConfig.test.ts
+++ b/src/test/serviceConfig.test.ts
@@ -8,6 +8,7 @@ import {
   childEnvForReexec, shouldBlockRepeatedBootstrap, REEXEC_GUARD_ENV,
   generateLaunchdPlist, generateSystemdUnit, generateWindowsWrapperScript,
   launchdLabel, SYSTEMD_UNIT_NAME, WINDOWS_TASK_NAME,
+  generateAuthToken, ensureAuthToken,
   type ServiceProgram,
 } from '../serviceConfig'
 
@@ -57,6 +58,43 @@ suite('serviceConfig', () => {
       fs.mkdirSync(path.dirname(serviceConfigPath(home)), { recursive: true })
       fs.writeFileSync(serviceConfigPath(home), 'not valid json{{{', 'utf-8')
       assert.deepStrictEqual(readServiceConfig(home), defaultServiceConfig(home))
+    })
+  })
+
+  suite('generateAuthToken', () => {
+    test('generates a non-empty, sufficiently long token', () => {
+      const token = generateAuthToken()
+      assert.ok(token.length >= 32)
+    })
+
+    test('generates a different token each call', () => {
+      assert.notStrictEqual(generateAuthToken(), generateAuthToken())
+    })
+  })
+
+  suite('ensureAuthToken', () => {
+    test('generates and persists a token when the config has none', () => {
+      const home = tmpHome()
+      const config = defaultServiceConfig(home)
+      assert.strictEqual(config.authToken, '')
+      const updated = ensureAuthToken(config, home)
+      assert.ok(updated.authToken.length > 0)
+      assert.deepStrictEqual(readServiceConfig(home).authToken, updated.authToken)
+    })
+
+    test('leaves an existing token untouched', () => {
+      const home = tmpHome()
+      const withToken = { ...defaultServiceConfig(home), authToken: 'already-set' }
+      writeServiceConfig(withToken, home)
+      const result = ensureAuthToken(withToken, home)
+      assert.strictEqual(result.authToken, 'already-set')
+    })
+
+    test('a restart reuses the persisted token instead of generating a new one', () => {
+      const home = tmpHome()
+      const first = ensureAuthToken(readServiceConfig(home), home)
+      const second = ensureAuthToken(readServiceConfig(home), home)
+      assert.strictEqual(first.authToken, second.authToken)
     })
   })
 

--- a/standalone/server.ts
+++ b/standalone/server.ts
@@ -24,18 +24,36 @@ import { detectInstructionFiles, appendSuggestion } from '../src/instructionFile
 import type { Span } from '../src/types'
 import type { SessionSummaryCard } from '../src/summarizers/summarizerTypes'
 import { pruneSpans, DEFAULT_MAX_SPANS } from '../src/spanStore'
-import { readServiceConfig } from '../src/serviceConfig'
+import { readServiceConfig, ensureAuthToken } from '../src/serviceConfig'
+import { isAllowedHostHeader, isAuthorized, isLoopbackHost, extractCookieToken, authCookieHeader } from '../src/httpSecurity'
 
 // `agentlens service install` persists its port/host/data-dir choices to
 // ~/.agentlens/config.json (see src/serviceConfig.ts) so a background-service install and an
 // ad-hoc `npx`/`node standalone/server.js` run share one config story. Env vars still win when
-// set, matching this server's behavior before the config file existed.
-const fileConfig = readServiceConfig()
+// set, matching this server's behavior before the config file existed. ensureAuthToken generates
+// and persists a bearer token the first time this runs with none set yet.
+const fileConfig = ensureAuthToken(readServiceConfig())
 
 const OTLP_PORT  = parseInt(process.env.OTLP_PORT  ?? String(fileConfig.otlpPort))
 const UI_PORT    = parseInt(process.env.UI_PORT    ?? String(fileConfig.uiPort))
 const MCP_PORT   = parseInt(process.env.MCP_PORT   ?? String(fileConfig.mcpPort))
 const BIND_HOST  = process.env.BIND_HOST ?? fileConfig.bindHost
+const AUTH_TOKEN = fileConfig.authToken
+
+// Turns the "BIND_HOST=0.0.0.0 ships with zero access control" footgun into a startup error:
+// once bindHost is exposed beyond loopback, a token must actually be in place (it always will
+// be, barring a disk-write failure in ensureAuthToken) before any server is allowed to listen.
+if (!isLoopbackHost(BIND_HOST) && !AUTH_TOKEN) {
+  console.error(`[AgentLens] Refusing to start: BIND_HOST=${BIND_HOST} exposes AgentLens beyond localhost, but no auth token could be generated or persisted (check that the data directory is writable). Fix that, or set BIND_HOST back to 127.0.0.1.`)
+  process.exit(1)
+}
+// OTLP and MCP only require the token once bound beyond loopback, so today's default setup and
+// existing agent auto-configuration keep working unauthenticated exactly as before. The UI
+// server (below) always requires it — the CLI hands the token to the browser on open.
+const REQUIRE_TOKEN_EVERYWHERE = !isLoopbackHost(BIND_HOST)
+if (REQUIRE_TOKEN_EVERYWHERE) {
+  console.log('[AgentLens] BIND_HOST is not loopback — OTLP and MCP now require Authorization: Bearer <token> (or ?token=) too. Configure agents accordingly.')
+}
 const parsedMaxSpans = parseInt(process.env.AGENTLENS_MAX_SPANS ?? '', 10)
 const MAX_SPANS  = Number.isNaN(parsedMaxSpans) ? DEFAULT_MAX_SPANS : parsedMaxSpans
 
@@ -169,7 +187,7 @@ startMcpHttpServer({
     const summary = buildSessionSummary()
     return summary?.sessions ?? []
   },
-}, MCP_PORT, BIND_HOST)
+}, MCP_PORT, BIND_HOST, AUTH_TOKEN)
 
 function runLogScan() {
   const results = logReader.scan()
@@ -1260,7 +1278,27 @@ const MIME: Record<string, string> = {
 // ── UI server ─────────────────────────────────────────────────────────────────
 
 const uiServer = http.createServer((req, res) => {
+  if (!isAllowedHostHeader(req.headers.host, BIND_HOST)) {
+    res.writeHead(403, { 'Content-Type': 'text/plain' }); res.end('Forbidden — invalid Host header'); return
+  }
   const url = (req.url ?? '/').split('?')[0]
+
+  // Unauthenticated liveness probe — `agentlens service status` and the Dockerfile HEALTHCHECK
+  // both poll this and need a plain 200, not a 401.
+  if (url === '/health') {
+    res.writeHead(200, { 'Content-Type': 'application/json' }); res.end(JSON.stringify({ status: 'ok' })); return
+  }
+
+  if (!isAuthorized(req, AUTH_TOKEN)) {
+    res.writeHead(401, { 'Content-Type': 'text/plain' })
+    res.end('Unauthorized — open the dashboard via the URL AgentLens printed at startup (it includes an access token).')
+    return
+  }
+  // First request authenticated via ?token= or an Authorization header rather than an existing
+  // cookie — hand the browser a cookie so every subsequent asset/API/SSE request just works.
+  if (extractCookieToken(req) !== AUTH_TOKEN) {
+    res.setHeader('Set-Cookie', authCookieHeader(AUTH_TOKEN))
+  }
   res.setHeader('Access-Control-Allow-Origin', '*')
 
   if (url === '/events') {
@@ -1505,10 +1543,18 @@ const uiServer = http.createServer((req, res) => {
 // ── OTLP server ───────────────────────────────────────────────────────────────
 
 const otlpServer = http.createServer((req, res) => {
+  if (!isAllowedHostHeader(req.headers.host, BIND_HOST)) {
+    res.writeHead(403, { 'Content-Type': 'text/plain' }); res.end('Forbidden — invalid Host header'); return
+  }
+  // Unauthenticated identify probe (the VS Code extension uses this to detect a standalone
+  // server already running before starting its own collector) — same reasoning as /health above.
   if (req.method === 'GET' && req.url === '/agentlens/standalone') {
     res.writeHead(200, { 'Content-Type': 'application/json' })
     res.end(JSON.stringify({ agentlens: true, kind: 'standalone' }))
     return
+  }
+  if (REQUIRE_TOKEN_EVERYWHERE && !isAuthorized(req, AUTH_TOKEN)) {
+    res.writeHead(401, { 'Content-Type': 'text/plain' }); res.end('Unauthorized'); return
   }
   if (req.method !== 'POST') { res.writeHead(200); res.end(); return }
   const chunks: Buffer[] = []
@@ -1586,11 +1632,14 @@ uiServer.on('error', (err: NodeJS.ErrnoException) => {
 })
 
 uiServer.listen(UI_PORT, BIND_HOST, () => {
-  const url = `http://localhost:${UI_PORT}`
+  const plainUrl = `http://localhost:${UI_PORT}`
+  const url = `${plainUrl}/?token=${AUTH_TOKEN}`
   console.log(`[AgentLens] Dashboard      → ${url}`)
   console.log(`[AgentLens] MCP server     → http://localhost:${MCP_PORT}/mcp`)
 
-  // Auto-open browser
+  // Auto-open browser — includes the access token so the browser gets its auth cookie on
+  // first load; the printed URL above is the fallback if auto-open fails or you're opening on
+  // another device.
   const cmd = process.platform === 'darwin' ? `open "${url}"`
             : process.platform === 'win32'  ? `start "" "${url}"`
             : `xdg-open "${url}"`

--- a/standalone/service/health.ts
+++ b/standalone/service/health.ts
@@ -1,12 +1,13 @@
-/** Same convention as the Dockerfile's HEALTHCHECK (`wget -qO- http://localhost:3000/`) —
- *  any response at all from the UI port means the server is up. Used for `agentlens service
- *  status` across all three platforms instead of parsing launchctl/systemctl/schtasks output,
- *  which is more meaningful ("is AgentLens actually reachable") and avoids three different
- *  fragile text-parsing paths. */
+/** Same convention as the Dockerfile's HEALTHCHECK (`wget -qO- http://localhost:3000/health`) —
+ *  any 200 from the UI port's unauthenticated /health route means the server is up. Used for
+ *  `agentlens service status` across all three platforms instead of parsing
+ *  launchctl/systemctl/schtasks output, which is more meaningful ("is AgentLens actually
+ *  reachable") and avoids three different fragile text-parsing paths. /health (rather than /)
+ *  is required now that / requires the auth token — see src/httpSecurity.ts. */
 export async function probeServiceHealth(uiPort: number, bindHost: string): Promise<boolean> {
   const host = bindHost === '0.0.0.0' ? '127.0.0.1' : bindHost
   try {
-    const res = await fetch(`http://${host}:${uiPort}/`, { signal: AbortSignal.timeout(2000) })
+    const res = await fetch(`http://${host}:${uiPort}/health`, { signal: AbortSignal.timeout(2000) })
     return res.ok
   } catch {
     return false

--- a/standalone/service/index.ts
+++ b/standalone/service/index.ts
@@ -4,7 +4,7 @@ import * as path from 'path'
 import { execFileSync, spawn } from 'child_process'
 import {
   parseServiceInstallFlags, isRunningFromNpx, writeServiceConfig, readServiceConfig,
-  shouldBlockRepeatedBootstrap, childEnvForReexec,
+  shouldBlockRepeatedBootstrap, childEnvForReexec, serviceConfigPath,
   type ServiceConfig, type ServiceProgram,
 } from '../../src/serviceConfig'
 import * as macos from './macos'
@@ -166,7 +166,7 @@ export async function runServiceCli(args: string[]): Promise<number> {
       const config = parseServiceInstallFlags(rest)
       writeServiceConfig(config)
       platformService.install(buildProgram(config))
-      console.log(`[AgentLens] Background service installed and started — dashboard at http://${config.bindHost}:${config.uiPort}`)
+      console.log(`[AgentLens] Background service installed and started. The dashboard now requires an access token — run \`agentlens service status\` once it's up for the URL to open (its first startup generates and persists the token to ${serviceConfigPath()}).`)
       return 0
     }
     case 'uninstall':
@@ -200,8 +200,9 @@ export async function runServiceCli(args: string[]): Promise<number> {
     case 'status': {
       const config = readServiceConfig()
       const running = await platformService.status(config.uiPort, config.bindHost)
+      const dashboardUrl = `http://${config.bindHost}:${config.uiPort}` + (config.authToken ? `/?token=${config.authToken}` : '')
       console.log(running
-        ? `[AgentLens] Running — dashboard reachable at http://${config.bindHost}:${config.uiPort}`
+        ? `[AgentLens] Running — dashboard reachable at ${dashboardUrl}`
         : '[AgentLens] Not reachable. Run `agentlens service logs` to check for errors, or `agentlens service start`.')
       return running ? 0 : 1
     }


### PR DESCRIPTION
## Summary

The three unauthenticated local servers (UI :3000, OTLP :4318, MCP :4316) were reachable by any process or web page on the machine, and `BIND_HOST=0.0.0.0` shipped with zero access control. This closes that gap:

- **Local bearer token**, generated at first run and persisted to `~/.agentlens/config.json` (`ensureAuthToken` in `src/serviceConfig.ts`). The CLI hands it to the browser via `?token=...` on the URL it opens; the UI server sets it as an HttpOnly cookie on first authenticated request so nothing else in the frontend needed to change.
- **Host-header validation on all three servers** (new `src/httpSecurity.ts`) — rejects any request whose Host header isn't a loopback alias or the configured `bindHost`, closing the DNS-rebinding vector.
- **OTLP and MCP require the token too, once `BIND_HOST` is non-loopback** — previously only the UI was ever going to be gated; this closes the actual "0.0.0.0 = wide open" hole, not just the browser tab. Default loopback setup and existing agent auto-configuration keep working unauthenticated exactly as before.
- **Startup refuses to run** if a non-loopback bind somehow has no token in place, turning a silent footgun into a loud error.
- Added an unauthenticated `/health` route and repointed `agentlens service status` and the Dockerfile `HEALTHCHECK` at it, since both used to probe `/`, which now requires the token.

## Test plan

- [x] Smoke-tested Host-header validation, token/cookie flow, and non-loopback token enforcement on OTLP
- [x] Confirmed `/health` stays unauthenticated for liveness checks
- [x] Full test suite passing (297 tests at implementation time)

🤖 Generated with [Claude Code](https://claude.com/claude-code)