### PR TITLE
fix: tighten accuracy of the 5 loop/malfunction detectors

### DIFF
--- a/src/dashboardPanel.ts
+++ b/src/dashboardPanel.ts
@@ -7,6 +7,7 @@ import { computeBaseline } from './instructionEffectiveness'
 import { autoConfigureCopilot, autoConfigureClaudeCode, autoConfigureCodex } from './autoConfig'
 import { serializeExport, exportFileExtension, type ExportFormat } from './exportFormats'
 import { classifySessionOutcome, type GitOutcome } from './gitOutcome'
+import { temperLoopSignalSeverity } from './loopDetector'
 
 function isExportFormat(value: unknown): value is ExportFormat {
   return value === 'json' || value === 'csv' || value === 'markdown'
@@ -281,13 +282,19 @@ export class DashboardPanel {
   }
 
   private async sendGitOutcome(sessionId: string, workspace: string, filesChanged: string[], startTime: string, endTime: string): Promise<void> {
+    let outcome: GitOutcome | null
     if (this.gitOutcomeCache.has(sessionId)) {
-      this.panel.webview.postMessage({ type: 'gitOutcome', sessionId, outcome: this.gitOutcomeCache.get(sessionId) })
-      return
+      outcome = this.gitOutcomeCache.get(sessionId) ?? null
+    } else {
+      outcome = await classifySessionOutcome(workspace, filesChanged, startTime, endTime)
+      this.gitOutcomeCache.set(sessionId, outcome)
     }
-    const outcome = await classifySessionOutcome(workspace, filesChanged, startTime, endTime)
-    this.gitOutcomeCache.set(sessionId, outcome)
-    this.panel.webview.postMessage({ type: 'gitOutcome', sessionId, outcome })
+    // Re-temper this session's already-computed loop signals now that its outcome is known — see
+    // temperLoopSignalSeverity's docstring for why this happens here rather than in the eager
+    // per-card computation everywhere else.
+    const card = this.repo.listSessions().find(s => s.sessionId === sessionId) ?? null
+    const temperedLoopSignals = card ? temperLoopSignalSeverity(card.loopSignals ?? [], outcome) : null
+    this.panel.webview.postMessage({ type: 'gitOutcome', sessionId, outcome, temperedLoopSignals })
   }
 
   private async exportSessions(redact: boolean, ids: Set<string> | null = null, format: ExportFormat = 'json'): Promise<void> {

--- a/src/loopDetector.ts
+++ b/src/loopDetector.ts
@@ -3,7 +3,7 @@
  *
  * Detects 5 signal types that indicate an agent is stuck in a loop or spiraling:
  *
- *   1. exact_tool_repeat  — identical tool call (by label) executed 3+ times
+ *   1. exact_tool_repeat  — identical tool call (by label) executed 3+ times with no edit in between
  *   2. edit_revert_cycle  — a file was edited then reverted to a prior state
  *   3. error_recurrence   — the same error message appearing 3+ times
  *   4. runaway_steps      — too many steps relative to inferred task complexity
@@ -14,6 +14,7 @@
 
 import { LoopSignal, LoopSignalType } from './types'
 import { SessionSummaryCard } from './spanSummarizer'
+import type { GitOutcome } from './gitOutcome'
 
 // ── Pattern taxonomy names ───────────────────────────────────────────────────
 
@@ -67,6 +68,26 @@ export function detectLoopSignals(session: SessionSummaryCard): LoopSignal[] {
   return signals
 }
 
+/**
+ * Tempers already-computed signal severity using a session's eventual git outcome, when known.
+ * None of the 5 detectors above check whether a session ultimately succeeded — a session that
+ * tripped a critical signal mid-session and then recovered gets the same alarm level as one that
+ * never did. Deliberately conservative: only ever downgrades (a confirmed-productive outcome softens
+ * a critical signal to a warning), never upgrades — a clean signal list on a session with a bad
+ * outcome isn't evidence this function should invent one.
+ *
+ * Not wired into the eager per-session-card computation in spanSummarizer.ts/extension.ts.
+ * `GitOutcome` is deliberately computed on demand (see gitOutcome.ts) because it shells out to git
+ * per session — running it eagerly for every session on a dashboard load would reintroduce exactly
+ * the cost that lazy computation exists to avoid. Call this instead wherever a `GitOutcome` is
+ * already being computed on demand (session detail view) to get outcome-aware severity there
+ * specifically, without changing how signals are computed for the session list.
+ */
+export function temperLoopSignalSeverity(signals: LoopSignal[], outcome: GitOutcome | null): LoopSignal[] {
+  if (!outcome || outcome.overall !== 'productive') { return signals }
+  return signals.map(s => s.severity === 'critical' ? { ...s, severity: 'warning' as const } : s)
+}
+
 // ── Detector 1: Exact tool repeat ────────────────────────────────────────────
 
 /**
@@ -74,18 +95,29 @@ export function detectLoopSignals(session: SessionSummaryCard): LoopSignal[] {
  * arguments (e.g. "read_file types.ts L1-50"), so an identical label means
  * the agent is making the exact same call again.
  *
- * Thresholds: 3+ occurrences → warning, 5+ → critical.
+ * A streak only counts toward the threshold if nothing changed between repeats — any file edit
+ * anywhere in the session resets every label's streak, since that's forward progress, not
+ * redundancy. Without this, re-running a verification command (tests, lint) after each fix looks
+ * identical to an agent re-issuing the same call because it isn't retaining results.
+ *
+ * Thresholds: 3+ occurrences in a row with no intervening edit → warning, 5+ → critical.
  */
 export function detectExactToolRepeat(session: SessionSummaryCard, signals: LoopSignal[]): void {
-  const counts: Record<string, number> = {}
+  const streaks: Record<string, number> = {}
+  const maxStreaks: Record<string, number> = {}
+
   for (const entry of session.timeline) {
+    if (entry.editDetails && entry.editDetails.length > 0) {
+      for (const key of Object.keys(streaks)) { streaks[key] = 0 }
+    }
     if (entry.type !== 'tool') { continue }
     const key = (entry.label || '').trim()
     if (!key) { continue }
-    counts[key] = (counts[key] || 0) + 1
+    streaks[key] = (streaks[key] || 0) + 1
+    maxStreaks[key] = Math.max(maxStreaks[key] || 0, streaks[key])
   }
 
-  const repeated = Object.entries(counts)
+  const repeated = Object.entries(maxStreaks)
     .filter(([, n]) => n >= 3)
     .sort((a, b) => b[1] - a[1])
 
@@ -95,7 +127,7 @@ export function detectExactToolRepeat(session: SessionSummaryCard, signals: Loop
   signals.push({
     type: 'exact_tool_repeat',
     severity: topCount >= 5 ? 'critical' : 'warning',
-    evidence: `${repeated.length} tool call(s) executed identically 3+ times`,
+    evidence: `${repeated.length} tool call(s) executed identically 3+ times with no edit in between`,
     count: topCount,
     examples: repeated.slice(0, 3).map(([label, n]) => `"${label.slice(0, 60)}" ×${n}`),
     patternName: PATTERN_NAMES.exact_tool_repeat,
@@ -147,34 +179,36 @@ export function getFileEditCounts(session: SessionSummaryCard): Record<string, A
  * Detects when a file is edited (A→B) and later reverted to its prior state
  * (B→A). Checks every pair of edits on the same file for exact string reversal.
  *
- * Always critical when detected — there is no legitimate reason for an agent to
- * undo its own edit unless it is oscillating.
+ * Critical only if at least one reverted file's revert was still its *final* edit when the session
+ * ended — a revert followed by further edits to that file means the agent reconsidered and moved on,
+ * not that it's still stuck. Downgraded to a warning otherwise: the pattern happened, but the
+ * session recovered from it.
  */
 export function detectEditRevertCycle(session: SessionSummaryCard, signals: LoopSignal[]): void {
   const fileEdits = getFileEditCounts(session)
 
   const revertedFiles: string[] = []
+  let anyStillReverted = false
 
   for (const [file, edits] of Object.entries(fileEdits)) {
     if (edits.length < 2) { continue }
-    let reverted = false
     outer:
     for (let j = 1; j < edits.length; j++) {
       for (let i = 0; i < j; i++) {
         if (edits[j].old === edits[i].new && edits[j].new === edits[i].old) {
-          reverted = true
+          revertedFiles.push(file)
+          if (j === edits.length - 1) { anyStillReverted = true }
           break outer
         }
       }
     }
-    if (reverted) { revertedFiles.push(file) }
   }
 
   if (revertedFiles.length === 0) { return }
 
   signals.push({
     type: 'edit_revert_cycle',
-    severity: 'critical',
+    severity: anyStillReverted ? 'critical' : 'warning',
     evidence: `${revertedFiles.length} file(s) were edited then reverted to a prior state`,
     count: revertedFiles.length,
     examples: revertedFiles.slice(0, 3).map(f => f.split('/').pop() || f),
@@ -186,32 +220,51 @@ export function detectEditRevertCycle(session: SessionSummaryCard, signals: Loop
 // ── Detector 3: Error recurrence ─────────────────────────────────────────────
 
 /**
- * Groups error timeline entries by errorMessage content. Falls back to tool
- * label when errorMessage is absent.
+ * Strips the specific patterns that make an otherwise-identical error message look unique each
+ * time it recurs — a temp-file path, an ISO timestamp, a long hex id/hash. Deliberately does NOT
+ * touch plain short numbers (line numbers, counts, error codes): those usually distinguish
+ * genuinely different errors, and stripping them would trade one false-positive-merge problem
+ * ("line 42" and "line 43" treated as the same error) for another.
+ */
+const DYNAMIC_TOKEN_PATTERN = /\/tmp\/\S+|\b\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:\.\d+)?Z?\b|\b[0-9a-f]{8,}\b/gi
+
+function normalizeErrorMessage(msg: string): string {
+  return msg.replace(DYNAMIC_TOKEN_PATTERN, '<var>')
+}
+
+/**
+ * Groups error timeline entries by normalized errorMessage content. Falls back to tool label when
+ * errorMessage is absent — but a label-fallback grouping can merge unrelated errors that happen to
+ * share a tool (three different Bash failures, say), so it's inherently less certain than a real
+ * errorMessage match and is capped below critical regardless of count.
  *
- * Thresholds: 3+ occurrences → warning, 5+ → critical.
+ * Thresholds: 3+ occurrences → warning, 5+ (with a real errorMessage match) → critical.
  */
 export function detectErrorRecurrence(session: SessionSummaryCard, signals: LoopSignal[]): void {
-  const counts: Record<string, number> = {}
+  const groups: Record<string, { count: number; example: string; fromFallback: boolean }> = {}
   for (const entry of session.timeline) {
     if (!entry.isError) { continue }
-    const key = ((entry.errorMessage || entry.label || 'unknown error').trim()).slice(0, 200)
-    counts[key] = (counts[key] || 0) + 1
+    const raw = (entry.errorMessage || entry.label || 'unknown error').trim()
+    const fromFallback = !entry.errorMessage
+    const key = normalizeErrorMessage(raw).slice(0, 200)
+    if (!groups[key]) { groups[key] = { count: 0, example: raw.slice(0, 200), fromFallback } }
+    groups[key].count++
+    if (fromFallback) { groups[key].fromFallback = true }
   }
 
-  const recurring = Object.entries(counts)
-    .filter(([, n]) => n >= 3)
-    .sort((a, b) => b[1] - a[1])
+  const recurring = Object.entries(groups)
+    .filter(([, g]) => g.count >= 3)
+    .sort((a, b) => b[1].count - a[1].count)
 
   if (recurring.length === 0) { return }
 
-  const topCount = recurring[0][1]
+  const top = recurring[0][1]
   signals.push({
     type: 'error_recurrence',
-    severity: topCount >= 5 ? 'critical' : 'warning',
+    severity: top.count >= 5 && !top.fromFallback ? 'critical' : 'warning',
     evidence: `${recurring.length} error(s) recurring 3+ times`,
-    count: recurring.reduce((s, [, n]) => s + n, 0),
-    examples: recurring.slice(0, 3).map(([msg, n]) => `"${msg.slice(0, 60)}" ×${n}`),
+    count: recurring.reduce((s, [, g]) => s + g.count, 0),
+    examples: recurring.slice(0, 3).map(([, g]) => `"${g.example.slice(0, 60)}" ×${g.count}`),
     patternName: PATTERN_NAMES.error_recurrence,
     action: LOOP_SIGNAL_ACTIONS.error_recurrence,
   })
@@ -222,6 +275,10 @@ export function detectErrorRecurrence(session: SessionSummaryCard, signals: Loop
 const COMPLEX_KEYWORDS = [
   'implement', 'refactor', 'build', 'design', 'migrate', 'convert',
   'rewrite', 'integrate', 'architect', 'scaffold', 'rework',
+  // Debugging/investigation tasks are often exploration-heavy without touching many files (many
+  // iterations against one stubborn file), so the files-touched behavioral override below doesn't
+  // reliably catch them — they need to be recognized from the prompt text too.
+  'debug', 'investigate', 'diagnose', 'root cause', 'flaky', 'intermittent',
 ]
 const SIMPLE_KEYWORDS = [
   'fix typo', 'rename', 'delete', 'move file', 'add comment',
@@ -301,6 +358,15 @@ export function detectRunawaySteps(session: SessionSummaryCard, signals: LoopSig
  *
  * Triggers when input grew >15k tokens AND output ratio collapsed to <30% of
  * its starting value (a 70% drop is a strong signal of a stuck agent).
+ *
+ * A windowed/median baseline (first 2-3 calls instead of literally the first) was tried here to
+ * guard against a single atypical opening exchange skewing the comparison, but the existing test
+ * suite caught it doing more harm than good: in a genuine runaway, the 2nd/3rd calls are often
+ * already mid-decline, so blending them into the baseline drags it down and suppresses detection
+ * exactly when it should fire (see `existing-detection-accuracy.md`'s open question about needing
+ * real session data — this is exactly the kind of threshold change that needs it before shipping).
+ * Reverted to the literal first-call baseline rather than ship a change proven worse by the tests
+ * already in place.
  */
 export function detectTokenRunaway(session: SessionSummaryCard, signals: LoopSignal[]): void {
   const llmCalls = session.timeline.filter(

--- a/src/test/loopDetector.test.ts
+++ b/src/test/loopDetector.test.ts
@@ -8,10 +8,12 @@ import {
   detectTokenRunaway,
   inferTaskComplexity,
   getFileEditCounts,
+  temperLoopSignalSeverity,
   LOOP_SIGNAL_ACTIONS,
 } from '../loopDetector'
 import { SessionSummaryCard, TimelineEntry } from '../spanSummarizer'
 import { LoopSignal } from '../types'
+import type { GitOutcome } from '../gitOutcome'
 
 // ── Factories ────────────────────────────────────────────────────────────────
 
@@ -124,6 +126,11 @@ suite('inferTaskComplexity', () => {
     assert.strictEqual(inferTaskComplexity('build a helper for parsing JSON'), 'medium')
   })
 
+  test('debug/investigate keywords count as complex even without many files touched', () => {
+    const result = inferTaskComplexity('investigate why checkout occasionally fails and find the root cause')
+    assert.strictEqual(result, 'complex')
+  })
+
   test('very short request with no keywords → simple', () => {
     assert.strictEqual(inferTaskComplexity('hi'), 'simple')
   })
@@ -188,6 +195,36 @@ suite('detectExactToolRepeat', () => {
         makeLlm(1000, 200),
         makeLlm(1200, 210),
         makeLlm(1400, 220),
+      ],
+    })
+    detectExactToolRepeat(session, signals)
+    assert.strictEqual(signals.length, 0)
+  })
+
+  test('resets the streak when a file is edited between repeats', () => {
+    const signals: LoopSignal[] = []
+    const session = makeSession({
+      timeline: [
+        makeTool('run_tests'),
+        makeEdit('src/a.ts', 'x', 'y'),
+        makeTool('run_tests'),
+        makeEdit('src/a.ts', 'y', 'z'),
+        makeTool('run_tests'),
+      ],
+    })
+    detectExactToolRepeat(session, signals)
+    assert.strictEqual(signals.length, 0)
+  })
+
+  test('does not sum partial streaks across an edit boundary', () => {
+    const signals: LoopSignal[] = []
+    const session = makeSession({
+      timeline: [
+        makeTool('run_tests'),
+        makeTool('run_tests'),
+        makeEdit('src/a.ts', 'x', 'y'),
+        makeTool('run_tests'),
+        makeTool('run_tests'),
       ],
     })
     detectExactToolRepeat(session, signals)
@@ -294,6 +331,39 @@ suite('detectEditRevertCycle', () => {
     })
     detectEditRevertCycle(session, signals)
     assert.strictEqual(signals.length, 0)
+  })
+
+  test('downgrades to warning when the file is edited again after the revert', () => {
+    const signals: LoopSignal[] = []
+    const session = makeSession({
+      timeline: [
+        makeEdit('src/app.ts', 'const x = 1', 'const x = 2'),
+        makeEdit('src/app.ts', 'const x = 2', 'const x = 1'), // reverts the first edit
+        makeEdit('src/app.ts', 'const x = 1', 'const x = 3'), // agent moved on afterward
+      ],
+    })
+    detectEditRevertCycle(session, signals)
+    assert.strictEqual(signals.length, 1)
+    assert.strictEqual(signals[0].severity, 'warning')
+  })
+
+  test('stays critical overall if at least one reverted file never recovered, even if another did', () => {
+    const signals: LoopSignal[] = []
+    const session = makeSession({
+      timeline: [
+        // a.ts recovers after its revert
+        makeEdit('a.ts', 'x', 'y'),
+        makeEdit('a.ts', 'y', 'x'),
+        makeEdit('a.ts', 'x', 'z'),
+        // b.ts stays reverted — this is still the last edit to b.ts
+        makeEdit('b.ts', '1', '2'),
+        makeEdit('b.ts', '2', '1'),
+      ],
+    })
+    detectEditRevertCycle(session, signals)
+    assert.strictEqual(signals.length, 1)
+    assert.strictEqual(signals[0].severity, 'critical')
+    assert.strictEqual(signals[0].count, 2)
   })
 })
 
@@ -413,6 +483,50 @@ suite('detectErrorRecurrence', () => {
     detectErrorRecurrence(session, signals)
     assert.strictEqual(signals.length, 1)
     assert.ok(signals[0].examples[0].includes('bash'))
+  })
+
+  test('label-fallback grouping is capped at warning even with 5+ occurrences', () => {
+    const signals: LoopSignal[] = []
+    const session = makeSession({
+      // isError with no errorMessage falls back to the tool label for grouping
+      timeline: [
+        makeTool('run_build', true),
+        makeTool('run_build', true),
+        makeTool('run_build', true),
+        makeTool('run_build', true),
+        makeTool('run_build', true),
+      ],
+    })
+    detectErrorRecurrence(session, signals)
+    assert.strictEqual(signals.length, 1)
+    assert.strictEqual(signals[0].severity, 'warning')
+  })
+
+  test('normalizes tmp paths and timestamps so the same underlying error still groups', () => {
+    const signals: LoopSignal[] = []
+    const session = makeSession({
+      timeline: [
+        makeErrorTool('bash', 'ENOENT: /tmp/agentlens-abc123/build.log not found at 2026-01-01T10:00:00.000Z'),
+        makeErrorTool('bash', 'ENOENT: /tmp/agentlens-xyz789/build.log not found at 2026-01-01T10:05:12.500Z'),
+        makeErrorTool('bash', 'ENOENT: /tmp/agentlens-qqq111/build.log not found at 2026-01-01T10:11:47.100Z'),
+      ],
+    })
+    detectErrorRecurrence(session, signals)
+    assert.strictEqual(signals.length, 1)
+    assert.strictEqual(signals[0].count, 3)
+  })
+
+  test('does not merge different line numbers into the same error', () => {
+    const signals: LoopSignal[] = []
+    const session = makeSession({
+      timeline: [
+        makeErrorTool('bash', 'SyntaxError at line 42'),
+        makeErrorTool('bash', 'SyntaxError at line 43'),
+        makeErrorTool('bash', 'SyntaxError at line 44'),
+      ],
+    })
+    detectErrorRecurrence(session, signals)
+    assert.strictEqual(signals.length, 0)
   })
 
   test('ignores non-error entries', () => {
@@ -689,5 +803,46 @@ suite('LOOP_SIGNAL_ACTIONS', () => {
       assert.ok(LOOP_SIGNAL_ACTIONS[t], `missing action for ${t}`)
       assert.ok(LOOP_SIGNAL_ACTIONS[t].length > 20, `action too short for ${t}`)
     }
+  })
+})
+
+// ── temperLoopSignalSeverity ─────────────────────────────────────────────────
+
+suite('temperLoopSignalSeverity', () => {
+  const criticalSignal: LoopSignal = {
+    type: 'exact_tool_repeat', severity: 'critical', evidence: 'e', count: 5, examples: [], patternName: 'p', action: 'a',
+  }
+  const warningSignal: LoopSignal = { ...criticalSignal, severity: 'warning' }
+
+  function outcome(overall: GitOutcome['overall']): GitOutcome {
+    return { overall, files: {}, reason: 'test' }
+  }
+
+  test('downgrades critical to warning when outcome is productive', () => {
+    const result = temperLoopSignalSeverity([criticalSignal], outcome('productive'))
+    assert.strictEqual(result[0].severity, 'warning')
+  })
+
+  test('leaves warnings alone when outcome is productive', () => {
+    const result = temperLoopSignalSeverity([warningSignal], outcome('productive'))
+    assert.strictEqual(result[0].severity, 'warning')
+  })
+
+  test('leaves signals unchanged when outcome is null', () => {
+    const result = temperLoopSignalSeverity([criticalSignal], null)
+    assert.strictEqual(result[0].severity, 'critical')
+  })
+
+  test('leaves signals unchanged for reverted/abandoned/ambiguous outcomes', () => {
+    for (const overall of ['reverted', 'abandoned', 'ambiguous'] as const) {
+      const result = temperLoopSignalSeverity([criticalSignal], outcome(overall))
+      assert.strictEqual(result[0].severity, 'critical')
+    }
+  })
+
+  test('does not mutate the original signal objects', () => {
+    const result = temperLoopSignalSeverity([criticalSignal], outcome('productive'))
+    assert.strictEqual(criticalSignal.severity, 'critical')
+    assert.notStrictEqual(result[0], criticalSignal)
   })
 })

--- a/standalone/server.ts
+++ b/standalone/server.ts
@@ -19,6 +19,7 @@ import { startMcpHttpServer } from '../src/mcpServer'
 import { LogReader, type OpenCodeSqlFactory } from '../src/logReader'
 import { computeOneShotStats } from '../src/oneShotRate'
 import { classifySessionOutcome, type GitOutcome } from '../src/gitOutcome'
+import { temperLoopSignalSeverity } from '../src/loopDetector'
 import { generateSuggestions } from '../src/instructionAdvisor'
 import { detectInstructionFiles, appendSuggestion } from '../src/instructionFiles'
 import type { Span } from '../src/types'
@@ -1474,8 +1475,13 @@ const uiServer = http.createServer((req, res) => {
           )
           gitOutcomeCache.set(sessionId, outcome)
         }
+        // Re-temper this session's already-computed loop signals now that its outcome is known —
+        // see temperLoopSignalSeverity's docstring for why this happens here (on demand, alongside
+        // the outcome it needs) rather than in the eager per-card computation everywhere else.
+        const card = buildSessionSummary()?.sessions.find(s => s.sessionId === sessionId) ?? null
+        const temperedLoopSignals = card ? temperLoopSignalSeverity(card.loopSignals ?? [], outcome) : null
         res.writeHead(200, { 'Content-Type': 'application/json' })
-        res.end(JSON.stringify({ sessionId, outcome }))
+        res.end(JSON.stringify({ sessionId, outcome, temperedLoopSignals }))
       } catch (e) {
         console.warn('[AgentLens] Malformed /api/git-outcome body:', e)
         res.writeHead(400); res.end()


### PR DESCRIPTION
## Summary

Read through `loopDetector.ts`'s actual implementation and pressure-tested each of the existing 5 signals for false-positive/false-negative scenarios. Found one structural gap affecting all five, plus a concrete failure mode in each detector.

- **`exact_tool_repeat`**: a repeated tool-call streak now resets whenever a file is edited in between, so re-running a verification command (tests, lint) after each fix no longer looks identical to a stuck agent re-issuing the same call for no reason.
- **`edit_revert_cycle`**: only critical when the revert is still the file's final edit when the session ends; downgraded to a warning when further edits followed, since that means the agent reconsidered and moved on rather than staying stuck.
- **`error_recurrence`**: normalizes obviously-dynamic substrings (temp paths, ISO timestamps, long hex ids) before grouping, so the same underlying error still recurs correctly instead of looking unique each time; caps label-fallback groupings (no `errorMessage` available) below critical, since merging by tool label alone is inherently less certain than a real `errorMessage` match.
- **`runaway_steps`**: expands the complex-task keyword list to cover debugging/investigation language, which behavioral file-count signals don't reliably catch (root-causing a bug is often step-heavy without touching many files).
- **All five**: adds `temperLoopSignalSeverity` — downgrades a critical signal to a warning once a session's git outcome is known to be productive. None of the five detectors previously checked whether a session actually succeeded, so a mid-session rough patch that recovered got the same alarm level as one that never did. Wired into the on-demand git-outcome endpoints (both standalone and the VS Code extension) rather than eager per-session computation, since `GitOutcome` is deliberately lazy.

**Not shipped**: a windowed/median baseline was also tried for `token_runaway`, to reduce sensitivity to an atypical first LLM call skewing the whole comparison, but reverted after the existing test suite showed it suppresses detection on genuine runaways more often than it prevents false positives.

**Open question, not resolved here**: whether there's a labeled dataset (real sessions marked "this was actually a loop" vs. "this was fine") to validate any of these thresholds against ground truth rather than engineering judgment. Every constant in this file, old and new, is still a reasonable-sounding guess rather than a measured precision/recall number.

## Test plan

- [x] Full test suite passing
- [x] `token_runaway` baseline change reverted after test suite showed it made detection worse

🤖 Generated with [Claude Code](https://claude.com/claude-code)