### PR TITLE
feat: add hallucinated-import and failed-check-submission detectors

### DIFF
--- a/media/src/types.ts
+++ b/media/src/types.ts
@@ -36,6 +36,8 @@ export type LoopSignalType =
   | 'error_recurrence'
   | 'runaway_steps'
   | 'token_runaway'
+  | 'hallucinated_import'
+  | 'failed_check_submission'
 
 export interface LoopSignal {
   type: LoopSignalType

--- a/src/dashboardPanel.ts
+++ b/src/dashboardPanel.ts
@@ -7,6 +7,7 @@ import { computeBaseline } from './instructionEffectiveness'
 import { autoConfigureCopilot, autoConfigureClaudeCode, autoConfigureCodex } from './autoConfig'
 import { serializeExport, exportFileExtension, type ExportFormat } from './exportFormats'
 import { classifySessionOutcome, type GitOutcome } from './gitOutcome'
+import { detectSessionRiskSignals } from './sessionRiskSignals'
 
 function isExportFormat(value: unknown): value is ExportFormat {
   return value === 'json' || value === 'csv' || value === 'markdown'
@@ -281,13 +282,19 @@ export class DashboardPanel {
   }
 
   private async sendGitOutcome(sessionId: string, workspace: string, filesChanged: string[], startTime: string, endTime: string): Promise<void> {
+    let outcome: GitOutcome | null
     if (this.gitOutcomeCache.has(sessionId)) {
-      this.panel.webview.postMessage({ type: 'gitOutcome', sessionId, outcome: this.gitOutcomeCache.get(sessionId) })
-      return
+      outcome = this.gitOutcomeCache.get(sessionId) ?? null
+    } else {
+      outcome = await classifySessionOutcome(workspace, filesChanged, startTime, endTime)
+      this.gitOutcomeCache.set(sessionId, outcome)
     }
-    const outcome = await classifySessionOutcome(workspace, filesChanged, startTime, endTime)
-    this.gitOutcomeCache.set(sessionId, outcome)
-    this.panel.webview.postMessage({ type: 'gitOutcome', sessionId, outcome })
+    // Post-hoc risk signals (hallucinated import, submitted-despite-a-failing-check) are only
+    // knowable once the session is complete, same lifecycle as git-outcome classification —
+    // computed here rather than eagerly for every session. See sessionRiskSignals.ts.
+    const card = this.repo.listSessions().find(s => s.sessionId === sessionId) ?? null
+    const riskSignals = card ? detectSessionRiskSignals(card, workspace) : []
+    this.panel.webview.postMessage({ type: 'gitOutcome', sessionId, outcome, riskSignals })
   }
 
   private async exportSessions(redact: boolean, ids: Set<string> | null = null, format: ExportFormat = 'json'): Promise<void> {

--- a/src/loopDetector.ts
+++ b/src/loopDetector.ts
@@ -10,6 +10,13 @@
  *   5. token_runaway      — context growing rapidly while output stays flat/declines
  *
  * Each detector is exported individually so tests can exercise them in isolation.
+ *
+ * Two more signal types (hallucinated_import, failed_check_submission) share this file's
+ * PATTERN_NAMES/LOOP_SIGNAL_ACTIONS taxonomy but are detected elsewhere, by
+ * src/sessionRiskSignals.ts — they're post-hoc checks (only knowable once a session, or at least
+ * an edit, is complete) rather than the real-time in-session signals this file computes, so they
+ * live in a separate on-demand module instead of detectLoopSignals below. See that file's
+ * docstring for why.
  */
 
 import { LoopSignal, LoopSignalType } from './types'
@@ -17,12 +24,14 @@ import { SessionSummaryCard } from './spanSummarizer'
 
 // ── Pattern taxonomy names ───────────────────────────────────────────────────
 
-const PATTERN_NAMES: Record<LoopSignalType, string> = {
+export const PATTERN_NAMES: Record<LoopSignalType, string> = {
   exact_tool_repeat: 'Tool Call Deadlock',
   edit_revert_cycle: 'State Corruption Spiral',
   error_recurrence:  'Hallucination Amplification Loop',
   runaway_steps:     'Ambiguous Success / Escalating Scope',
   token_runaway:     'Infinite Loop — Context Accumulation',
+  hallucinated_import:     'Fabricated Dependency',
+  failed_check_submission: 'Unverified Submission',
 }
 
 // ── Actionable recommendations per signal type ──────────────────────────────
@@ -53,6 +62,15 @@ export const LOOP_SIGNAL_ACTIONS: Record<LoopSignalType, string> = {
     'Input context is growing rapidly while useful output is declining — the agent is accumulating context without making forward progress. '
     + 'This pattern often accompanies tool-call loops or repeated failed fixes. '
     + 'Start a fresh session with a focused prompt, or explicitly tell the agent what it has already tried and what to do differently.',
+
+  hallucinated_import:
+    'An edit imports a package that is not declared in the project\'s manifest (package.json, requirements.txt) and does not resolve on disk — '
+    + 'a likely hallucinated dependency that will fail at install or runtime. '
+    + 'Verify the package actually exists and is spelled correctly before asking the agent to use it, or add it to the manifest yourself if it is intentional.',
+
+  failed_check_submission:
+    'The last test/build check run in this session reported a failure, with no further fix attempt before the session ended. '
+    + 'Ask the agent to re-run the check and confirm it passes before considering the task done, or review the failure yourself before accepting the change.',
 }
 
 // ── Public API ───────────────────────────────────────────────────────────────

--- a/src/sessionRiskSignals.ts
+++ b/src/sessionRiskSignals.ts
@@ -1,0 +1,227 @@
+/**
+ * Post-hoc session risk signals — malfunction patterns that only show up once a session (or at
+ * least an edit) is complete, unlike loopDetector.ts's real-time signals which fire mid-session.
+ * Computed on demand (session detail view), the same lifecycle as gitOutcome.ts's classification —
+ * not eagerly for every loaded session, since detectHallucinatedImports reads files from the
+ * workspace on disk.
+ *
+ * Two detectors:
+ *   - detectFailedCheckSubmission — the session's last test/build run failed and nothing followed.
+ *   - detectHallucinatedImports   — an edit imports a package absent from the project's manifest
+ *                                   and unresolvable on disk.
+ *
+ * Both are deliberately narrow. See .staged-issues/additional-malfunction-detections.md for the
+ * broader set of failure modes considered and rejected as too false-positive-prone to ship —
+ * these two are the ones that survived that review.
+ */
+
+import * as fs from 'fs'
+import * as path from 'path'
+import { LoopSignal } from './types'
+import { SessionSummaryCard } from './spanSummarizer'
+import { PATTERN_NAMES, LOOP_SIGNAL_ACTIONS } from './loopDetector'
+
+// ── Detector: failed check submission ────────────────────────────────────────
+
+const TEST_RUNNER_PATTERN =
+  /\b(npm\s+(run\s+)?test|yarn\s+test|pnpm\s+test|pytest|python3?\s+-m\s+pytest|go\s+test|cargo\s+test|jest|vitest|mvn\s+test|rspec)\b/i
+const FAILURE_TEXT_PATTERN = /\bfail(ed|ure|ing)?\b|✗|✘|✖/i
+
+/**
+ * Precision-good, recall-poor by design: most sessions never invoke a test runner unless
+ * explicitly told to, so this only catches the slice of failures where the agent happened to
+ * check its own work and ignored the result. Only looks at the *last* tool call in the timeline —
+ * a failing check followed by more edits (a fix attempt) is not what this flags.
+ */
+export function detectFailedCheckSubmission(session: SessionSummaryCard): LoopSignal | null {
+  const timeline = session.timeline
+  let lastTool: SessionSummaryCard['timeline'][number] | null = null
+  for (let i = timeline.length - 1; i >= 0; i--) {
+    if (timeline[i].type === 'tool') { lastTool = timeline[i]; break }
+  }
+  if (!lastTool) { return null }
+
+  const invocation = lastTool.toolInput || lastTool.label || ''
+  if (!TEST_RUNNER_PATTERN.test(invocation)) { return null }
+
+  const resultText = lastTool.resultSummary || lastTool.fullResult || ''
+  const failed = lastTool.isError || FAILURE_TEXT_PATTERN.test(resultText)
+  if (!failed) { return null }
+
+  return {
+    type: 'failed_check_submission',
+    severity: 'warning',
+    evidence: 'The last check run in this session reported a failure, with no further fix attempt before the session ended.',
+    count: 1,
+    examples: [invocation.slice(0, 100)],
+    patternName: PATTERN_NAMES.failed_check_submission,
+    action: LOOP_SIGNAL_ACTIONS.failed_check_submission,
+  }
+}
+
+// ── Detector: hallucinated import ────────────────────────────────────────────
+
+const JS_TS_EXTENSIONS = new Set(['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs'])
+const PYTHON_EXTENSIONS = new Set(['.py'])
+
+// Not exhaustive — covers the common cases well enough to avoid the dominant false-positive
+// source (every Python file imports `os`/`sys`, neither belongs in requirements.txt).
+const NODE_BUILTINS = new Set([
+  'assert', 'buffer', 'child_process', 'cluster', 'crypto', 'dns', 'events', 'fs', 'http', 'https',
+  'net', 'os', 'path', 'querystring', 'readline', 'stream', 'string_decoder', 'timers', 'tls',
+  'tty', 'url', 'util', 'v8', 'vm', 'worker_threads', 'zlib', 'process', 'module', 'perf_hooks',
+])
+const PYTHON_STDLIB = new Set([
+  'os', 'sys', 'json', 're', 'math', 'time', 'datetime', 'collections', 'itertools', 'functools',
+  'pathlib', 'subprocess', 'typing', 'dataclasses', 'unittest', 'logging', 'threading', 'asyncio',
+  'socket', 'http', 'urllib', 'shutil', 'tempfile', 'io', 'csv', 'sqlite3', 'random', 'string',
+  'copy', 'enum', 'abc', 'contextlib', 'argparse', 'hashlib', 'base64', 'pickle', 'struct',
+  'traceback', 'warnings', 'inspect', 'importlib', 'glob', 'fnmatch', 'textwrap', 'pprint',
+  'operator', 'queue', 'multiprocessing', 'xml', 'html', 'email', 'ftplib', 'smtplib', 'ssl',
+  'ipaddress', 'uuid', 'decimal', 'fractions', 'statistics', 'array', 'bisect', 'heapq', 'weakref',
+  'gc', 'platform', 'getpass', 'configparser', 'zipfile', 'tarfile', 'gzip', 'bz2', 'lzma',
+  'signal', 'shlex', 'difflib',
+])
+
+const JS_IMPORT_PATTERN = /import\s+(?:type\s+)?(?:[\w*${},\s]+\sfrom\s+)?['"]([^'"]+)['"]/g
+const JS_REQUIRE_PATTERN = /require\(\s*['"]([^'"]+)['"]\s*\)/g
+const PY_IMPORT_PATTERN = /^\s*import\s+([\w.]+)/gm
+const PY_FROM_IMPORT_PATTERN = /^\s*from\s+([\w.]+)\s+import/gm
+
+function addJsPackageName(names: Set<string>, specifier: string): void {
+  if (specifier.startsWith('.') || specifier.startsWith('/') || specifier.startsWith('node:')) { return }
+  const parts = specifier.split('/')
+  const pkg = specifier.startsWith('@') ? parts.slice(0, 2).join('/') : parts[0]
+  if (!pkg || NODE_BUILTINS.has(pkg)) { return }
+  names.add(pkg)
+}
+
+function extractJsTsPackageNames(code: string): Set<string> {
+  const names = new Set<string>()
+  for (const m of code.matchAll(JS_IMPORT_PATTERN)) { addJsPackageName(names, m[1]) }
+  for (const m of code.matchAll(JS_REQUIRE_PATTERN)) { addJsPackageName(names, m[1]) }
+  return names
+}
+
+function addPythonPackageName(names: Set<string>, dotted: string): void {
+  if (dotted.startsWith('.')) { return }
+  const top = dotted.split('.')[0]
+  if (!top || PYTHON_STDLIB.has(top)) { return }
+  names.add(top)
+}
+
+function extractPythonPackageNames(code: string): Set<string> {
+  const names = new Set<string>()
+  for (const m of code.matchAll(PY_IMPORT_PATTERN)) { addPythonPackageName(names, m[1]) }
+  for (const m of code.matchAll(PY_FROM_IMPORT_PATTERN)) { addPythonPackageName(names, m[1]) }
+  return names
+}
+
+function readJsManifestDeps(workspaceRoot: string): Set<string> | null {
+  try {
+    const pkgPath = path.join(workspaceRoot, 'package.json')
+    if (!fs.existsSync(pkgPath)) { return null }
+    const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8')) as Record<string, Record<string, string> | undefined>
+    const deps = new Set<string>()
+    for (const field of ['dependencies', 'devDependencies', 'peerDependencies', 'optionalDependencies']) {
+      for (const name of Object.keys(pkg[field] ?? {})) { deps.add(name) }
+    }
+    return deps
+  } catch {
+    return null
+  }
+}
+
+function readPythonManifestDeps(workspaceRoot: string): Set<string> | null {
+  try {
+    const reqPath = path.join(workspaceRoot, 'requirements.txt')
+    if (!fs.existsSync(reqPath)) { return null }
+    const deps = new Set<string>()
+    for (const line of fs.readFileSync(reqPath, 'utf-8').split('\n')) {
+      const trimmed = line.trim()
+      if (!trimmed || trimmed.startsWith('#')) { continue }
+      const name = trimmed.split(/[=<>!~;\s[]/)[0].trim()
+      if (name) { deps.add(name.toLowerCase().replace(/_/g, '-')) }
+    }
+    return deps
+  } catch {
+    return null
+  }
+}
+
+function nodeModulesHasPackage(workspaceRoot: string, pkg: string): boolean {
+  try {
+    return fs.existsSync(path.join(workspaceRoot, 'node_modules', pkg))
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Requires real scoping to hold up, not just "the data is there":
+ *   - Excludes each language's built-ins/stdlib (every Python file imports os/sys — neither
+ *     belongs in requirements.txt).
+ *   - Excludes relative/local imports.
+ *   - Excludes anything that resolves under node_modules on disk, even if absent from
+ *     package.json's declared fields — covers monorepo workspace packages (`@myorg/shared`
+ *     resolved via workspace protocol) without needing to parse workspace globs, a real
+ *     false-positive source this project's own repo shape would hit otherwise.
+ *
+ * Returns null (says nothing) rather than a false negative when there's no manifest to check
+ * against at all — silence, not a claim of cleanliness.
+ */
+export function detectHallucinatedImports(session: SessionSummaryCard, workspaceRoot: string): LoopSignal | null {
+  if (!workspaceRoot) { return null }
+
+  const jsDeps = readJsManifestDeps(workspaceRoot)
+  const pyDeps = readPythonManifestDeps(workspaceRoot)
+  if (!jsDeps && !pyDeps) { return null }
+
+  const suspects = new Map<string, string>()
+
+  for (const entry of session.timeline) {
+    if (!entry.editDetails) { continue }
+    for (const detail of entry.editDetails) {
+      const code = detail.newString || detail.content || ''
+      if (!code || !detail.filePath) { continue }
+      const ext = path.extname(detail.filePath).toLowerCase()
+
+      if (jsDeps && JS_TS_EXTENSIONS.has(ext)) {
+        for (const pkg of extractJsTsPackageNames(code)) {
+          if (jsDeps.has(pkg)) { continue }
+          if (nodeModulesHasPackage(workspaceRoot, pkg)) { continue }
+          if (!suspects.has(pkg)) { suspects.set(pkg, detail.filePath) }
+        }
+      }
+      if (pyDeps && PYTHON_EXTENSIONS.has(ext)) {
+        for (const pkg of extractPythonPackageNames(code)) {
+          const normalized = pkg.toLowerCase().replace(/_/g, '-')
+          if (pyDeps.has(normalized) || pyDeps.has(pkg.toLowerCase())) { continue }
+          if (!suspects.has(pkg)) { suspects.set(pkg, detail.filePath) }
+        }
+      }
+    }
+  }
+
+  if (suspects.size === 0) { return null }
+
+  return {
+    type: 'hallucinated_import',
+    severity: 'warning',
+    evidence: `${suspects.size} import(s) reference a package not declared in the project's manifest and not present on disk`,
+    count: suspects.size,
+    examples: [...suspects.entries()].slice(0, 3).map(([pkg, file]) => `${pkg} (${file.split('/').pop()})`),
+    patternName: PATTERN_NAMES.hallucinated_import,
+    action: LOOP_SIGNAL_ACTIONS.hallucinated_import,
+  }
+}
+
+/** Runs both post-hoc detectors and returns whatever fired. */
+export function detectSessionRiskSignals(session: SessionSummaryCard, workspaceRoot: string): LoopSignal[] {
+  const signals: LoopSignal[] = []
+  const failedCheck = detectFailedCheckSubmission(session)
+  if (failedCheck) { signals.push(failedCheck) }
+  const hallucinatedImport = detectHallucinatedImports(session, workspaceRoot)
+  if (hallucinatedImport) { signals.push(hallucinatedImport) }
+  return signals
+}

--- a/src/test/sessionRiskSignals.test.ts
+++ b/src/test/sessionRiskSignals.test.ts
@@ -1,0 +1,237 @@
+import * as assert from 'assert'
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+import {
+  detectFailedCheckSubmission,
+  detectHallucinatedImports,
+  detectSessionRiskSignals,
+} from '../sessionRiskSignals'
+import { SessionSummaryCard, TimelineEntry } from '../spanSummarizer'
+
+// ── Factories ────────────────────────────────────────────────────────────────
+
+function makeSession(overrides: Partial<SessionSummaryCard> = {}): SessionSummaryCard {
+  return {
+    sessionId: 'sess-1',
+    traceId: 'trace-1',
+    source: 'claude_code',
+    dataSource: 'otel',
+    workspace: '',
+    userRequest: 'fix the bug',
+    model: 'claude-3-5-sonnet',
+    turns: 3,
+    inputTokens: 5000,
+    outputTokens: 800,
+    cacheReadTokens: 0,
+    cacheCreateTokens: 0,
+    cacheHitRate: 0,
+    durationMs: 12000,
+    startTime: new Date().toISOString(),
+    filesRead: [],
+    filesSearched: [],
+    filesChanged: [],
+    filesWritten: [],
+    toolCounts: {},
+    totalToolCalls: 5,
+    totalLlmCalls: 3,
+    errors: 0,
+    outcome: 'unknown',
+    timeline: [],
+    backgroundSpans: [],
+    loopSignals: [],
+    ...overrides,
+  }
+}
+
+function makeToolCall(opts: { label: string; toolInput?: string; isError?: boolean; resultSummary?: string }): TimelineEntry {
+  return {
+    type: 'tool',
+    spanId: 'span-' + Math.random().toString(36).slice(2, 8),
+    label: opts.label,
+    toolInput: opts.toolInput,
+    durationMs: 100,
+    isError: opts.isError ?? false,
+    resultSummary: opts.resultSummary,
+    timestamp: new Date().toISOString(),
+  }
+}
+
+function makeLlm(): TimelineEntry {
+  return {
+    type: 'llm',
+    spanId: 'span-' + Math.random().toString(36).slice(2, 8),
+    label: 'claude-3-5-sonnet',
+    model: 'claude-3-5-sonnet',
+    inputTokens: 1000,
+    outputTokens: 200,
+    durationMs: 1000,
+    isError: false,
+    timestamp: new Date().toISOString(),
+  }
+}
+
+function makeEdit(filePath: string, newString: string): TimelineEntry {
+  return {
+    type: 'tool',
+    spanId: 'span-' + Math.random().toString(36).slice(2, 8),
+    label: `edit_file ${filePath}`,
+    durationMs: 50,
+    isError: false,
+    timestamp: new Date().toISOString(),
+    editDetails: [{ filePath, oldString: '', newString }],
+  }
+}
+
+function tmpWorkspace(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'agentlens-risk-test-'))
+}
+
+// ── detectFailedCheckSubmission ─────────────────────────────────────────────
+
+suite('detectFailedCheckSubmission', () => {
+  test('null when the last tool call is not a test runner', () => {
+    const session = makeSession({ timeline: [makeToolCall({ label: 'read_file' })] })
+    assert.strictEqual(detectFailedCheckSubmission(session), null)
+  })
+
+  test('null when the last tool call is a test runner that passed', () => {
+    const session = makeSession({
+      timeline: [makeToolCall({ label: 'bash', toolInput: 'npm test', resultSummary: 'All 12 tests passed' })],
+    })
+    assert.strictEqual(detectFailedCheckSubmission(session), null)
+  })
+
+  test('flags a session that ends right after a failing test run', () => {
+    const session = makeSession({
+      timeline: [makeToolCall({ label: 'bash', toolInput: 'npm test', isError: true, resultSummary: '3 tests failed' })],
+    })
+    const signal = detectFailedCheckSubmission(session)
+    assert.ok(signal)
+    assert.strictEqual(signal!.type, 'failed_check_submission')
+    assert.strictEqual(signal!.severity, 'warning')
+  })
+
+  test('does not flag when a fix attempt follows the failing test', () => {
+    const session = makeSession({
+      timeline: [
+        makeToolCall({ label: 'bash', toolInput: 'npm test', isError: true, resultSummary: '3 tests failed' }),
+        makeEdit('src/a.ts', 'fixed'),
+        makeToolCall({ label: 'bash', toolInput: 'npm test', resultSummary: 'All tests passed' }),
+      ],
+    })
+    assert.strictEqual(detectFailedCheckSubmission(session), null)
+  })
+
+  test('detects a pytest failure via result text even without isError set', () => {
+    const session = makeSession({
+      timeline: [makeToolCall({ label: 'bash', toolInput: 'pytest tests/', resultSummary: '2 failed, 8 passed' })],
+    })
+    assert.ok(detectFailedCheckSubmission(session))
+  })
+
+  test('null for an empty timeline', () => {
+    assert.strictEqual(detectFailedCheckSubmission(makeSession({ timeline: [] })), null)
+  })
+})
+
+// ── detectHallucinatedImports ───────────────────────────────────────────────
+
+suite('detectHallucinatedImports', () => {
+  test('null when there is no manifest at all', () => {
+    const dir = tmpWorkspace()
+    const session = makeSession({ timeline: [makeEdit('src/a.ts', "import foo from 'not-a-real-package'")] })
+    assert.strictEqual(detectHallucinatedImports(session, dir), null)
+  })
+
+  test('flags an import not present in package.json and not on disk', () => {
+    const dir = tmpWorkspace()
+    fs.writeFileSync(path.join(dir, 'package.json'), JSON.stringify({ dependencies: { express: '^4.0.0' } }))
+    const session = makeSession({
+      timeline: [makeEdit('src/a.ts', "import leftpad from 'left-pad-totally-fake'\nimport express from 'express'")],
+    })
+    const signal = detectHallucinatedImports(session, dir)
+    assert.ok(signal)
+    assert.strictEqual(signal!.count, 1)
+    assert.ok(signal!.examples[0].startsWith('left-pad-totally-fake'))
+  })
+
+  test('does not flag a declared dependency', () => {
+    const dir = tmpWorkspace()
+    fs.writeFileSync(path.join(dir, 'package.json'), JSON.stringify({ dependencies: { express: '^4.0.0' } }))
+    const session = makeSession({ timeline: [makeEdit('src/a.ts', "import express from 'express'")] })
+    assert.strictEqual(detectHallucinatedImports(session, dir), null)
+  })
+
+  test('does not flag Node built-ins', () => {
+    const dir = tmpWorkspace()
+    fs.writeFileSync(path.join(dir, 'package.json'), JSON.stringify({ dependencies: {} }))
+    const session = makeSession({ timeline: [makeEdit('src/a.ts', "import fs from 'fs'\nimport path from 'node:path'")] })
+    assert.strictEqual(detectHallucinatedImports(session, dir), null)
+  })
+
+  test('does not flag relative imports', () => {
+    const dir = tmpWorkspace()
+    fs.writeFileSync(path.join(dir, 'package.json'), JSON.stringify({ dependencies: {} }))
+    const session = makeSession({ timeline: [makeEdit('src/a.ts', "import { helper } from './utils'")] })
+    assert.strictEqual(detectHallucinatedImports(session, dir), null)
+  })
+
+  test('does not flag a package that resolves under node_modules even if undeclared (monorepo workspace case)', () => {
+    const dir = tmpWorkspace()
+    fs.writeFileSync(path.join(dir, 'package.json'), JSON.stringify({ dependencies: {} }))
+    fs.mkdirSync(path.join(dir, 'node_modules', '@myorg', 'shared'), { recursive: true })
+    const session = makeSession({ timeline: [makeEdit('src/a.ts', "import { thing } from '@myorg/shared'")] })
+    assert.strictEqual(detectHallucinatedImports(session, dir), null)
+  })
+
+  test('Python: flags an undeclared package and excludes stdlib', () => {
+    const dir = tmpWorkspace()
+    fs.writeFileSync(path.join(dir, 'requirements.txt'), 'requests==2.31.0\n')
+    const session = makeSession({ timeline: [makeEdit('app.py', 'import os\nimport requests\nimport not_a_real_pkg\n')] })
+    const signal = detectHallucinatedImports(session, dir)
+    assert.ok(signal)
+    assert.strictEqual(signal!.count, 1)
+    assert.ok(signal!.examples[0].startsWith('not_a_real_pkg'))
+  })
+
+  test('ignores entries without editDetails', () => {
+    const dir = tmpWorkspace()
+    fs.writeFileSync(path.join(dir, 'package.json'), JSON.stringify({ dependencies: {} }))
+    const session = makeSession({ timeline: [makeToolCall({ label: 'read_file' })] })
+    assert.strictEqual(detectHallucinatedImports(session, dir), null)
+  })
+
+  test('null when workspaceRoot is empty', () => {
+    const session = makeSession({ timeline: [makeEdit('src/a.ts', "import foo from 'bar'")] })
+    assert.strictEqual(detectHallucinatedImports(session, ''), null)
+  })
+})
+
+// ── detectSessionRiskSignals ────────────────────────────────────────────────
+
+suite('detectSessionRiskSignals', () => {
+  test('empty when neither detector fires', () => {
+    const dir = tmpWorkspace()
+    fs.writeFileSync(path.join(dir, 'package.json'), JSON.stringify({ dependencies: {} }))
+    const session = makeSession({ timeline: [makeLlm()] })
+    assert.deepStrictEqual(detectSessionRiskSignals(session, dir), [])
+  })
+
+  test('returns both signals when both fire', () => {
+    const dir = tmpWorkspace()
+    fs.writeFileSync(path.join(dir, 'package.json'), JSON.stringify({ dependencies: {} }))
+    const session = makeSession({
+      timeline: [
+        makeEdit('src/a.ts', "import fake from 'totally-fake-pkg'"),
+        makeToolCall({ label: 'bash', toolInput: 'npm test', isError: true, resultSummary: 'failed' }),
+      ],
+    })
+    const signals = detectSessionRiskSignals(session, dir)
+    assert.strictEqual(signals.length, 2)
+    assert.deepStrictEqual(
+      new Set(signals.map(s => s.type)),
+      new Set(['hallucinated_import', 'failed_check_submission']),
+    )
+  })
+})

--- a/src/types.ts
+++ b/src/types.ts
@@ -36,6 +36,11 @@ export type LoopSignalType =
   | 'error_recurrence'
   | 'runaway_steps'
   | 'token_runaway'
+  // Detected post-hoc by src/sessionRiskSignals.ts, not by the real-time loopDetector.ts — a
+  // session completing cleanly doesn't rule out these two, so they're checked on demand alongside
+  // git-outcome classification rather than eagerly for every session. See that file's docstring.
+  | 'hallucinated_import'
+  | 'failed_check_submission'
 
 export interface LoopSignal {
   type: LoopSignalType

--- a/standalone/server.ts
+++ b/standalone/server.ts
@@ -19,6 +19,7 @@ import { startMcpHttpServer } from '../src/mcpServer'
 import { LogReader, type OpenCodeSqlFactory } from '../src/logReader'
 import { computeOneShotStats } from '../src/oneShotRate'
 import { classifySessionOutcome, type GitOutcome } from '../src/gitOutcome'
+import { detectSessionRiskSignals } from '../src/sessionRiskSignals'
 import { generateSuggestions } from '../src/instructionAdvisor'
 import { detectInstructionFiles, appendSuggestion } from '../src/instructionFiles'
 import type { Span } from '../src/types'
@@ -1474,8 +1475,13 @@ const uiServer = http.createServer((req, res) => {
           )
           gitOutcomeCache.set(sessionId, outcome)
         }
+        // Post-hoc risk signals (hallucinated import, submitted-despite-a-failing-check) are only
+        // knowable once the session is complete, same lifecycle as git-outcome classification —
+        // computed here rather than eagerly for every session. See sessionRiskSignals.ts.
+        const card = buildSessionSummary()?.sessions.find(s => s.sessionId === sessionId) ?? null
+        const riskSignals = card ? detectSessionRiskSignals(card, body.workspace ?? '') : []
         res.writeHead(200, { 'Content-Type': 'application/json' })
-        res.end(JSON.stringify({ sessionId, outcome }))
+        res.end(JSON.stringify({ sessionId, outcome, riskSignals }))
       } catch (e) {
         console.warn('[AgentLens] Malformed /api/git-outcome body:', e)
         res.writeHead(400); res.end()


### PR DESCRIPTION
## Summary

The existing loop/malfunction taxonomy (`exact_tool_repeat`, `edit_revert_cycle`, `error_recurrence`, `runaway_steps`, `token_runaway`) covers agents that are visibly stuck. It doesn't cover an agent that completes cleanly, submits a normal-looking diff, and the result is still wrong in ways that only show up on review.

Two new post-hoc malfunction signals, in a new `src/sessionRiskSignals.ts` module rather than `loopDetector.ts`'s real-time taxonomy — both are only knowable once a session (or at least an edit) is complete:

- **`hallucinated_import`**: an edit imports a package absent from the project's manifest (`package.json`/`requirements.txt`) and unresolvable under `node_modules` on disk. The `node_modules` existence check (rather than just parsing `package.json`'s declared fields) is what makes this safe in a monorepo — a workspace-protocol package like `@myorg/shared` resolves on disk without being a direct dependency entry, which would otherwise be the dominant false-positive source. Also excludes each language's built-ins/stdlib and relative imports.
- **`failed_check_submission`**: the session's last tool call was a test/build runner that reported failure, with nothing after it. Deliberately precision-good/recall-poor — most sessions never invoke a test runner unless told to, so this only catches the slice where the agent checked its own work and ignored the result.

Wired into the same on-demand git-outcome endpoints (standalone server and the VS Code extension) rather than eager per-session-card computation, matching `gitOutcome.ts`'s own on-demand model — `detectHallucinatedImports` reads the workspace on disk, so running it eagerly for every loaded session would be real, avoidable cost.

**Considered and explicitly not built** (each looked plausible before failing a false-positive check against normal, successful sessions): unscoped commit sweeps (`git add -A`), unsafe in-place editing (`sed -i`), general no-verification-before-submission, repetitive questioning, displaced/refused work, naming inconsistency, scope creep.

## Test plan

- [x] Full test suite passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)