### PR TITLE
feat: promote two frontend checks to backend signals, add malformed-tool-call

### DIFF
--- a/media/src/tabs/Help.tsx
+++ b/media/src/tabs/Help.tsx
@@ -182,13 +182,16 @@ function OverviewSection() {
       <h3 class="help-heading">{HELP_SECTIONS.overview.heading}</h3>
       <div class="help-overview-body">
         <p><strong>AgentLens</strong> is a local observability tool that makes AI <a href="#gl-agent">agent</a> sessions more transparent — see what's happening inside each run. Available as a VS Code-family IDE extension (VS Code, Cursor, Windsurf, VSCodium, Trae, Kiro), a local web app (npx), or Docker, with no data leaving your machine. It captures <a href="#gl-otlp">OpenTelemetry</a> <a href="#gl-trace">traces</a> from GitHub Copilot, Claude Code, and Codex, and also reads <strong>local session files and databases</strong> written automatically by each agent as a zero-config fallback — including OpenCode's local SQLite database — so history loads even without OTEL configured. Both sources feed one unified dashboard and surface efficiency metrics, session cost estimates, human-readable summaries, and actionable insights in real time.</p>
-        <p style="font-size:13px;margin:10px 0 4px"><strong>AgentLens detects five loop / malfunction patterns</strong> — each with a ready-to-paste correction prompt (see <a href="#help-loops">Loop Detection</a> below for details):</p>
+        <p style="font-size:13px;margin:10px 0 4px"><strong>AgentLens detects eight loop / malfunction patterns</strong> — each with a ready-to-paste correction prompt (see <a href="#help-loops">Loop Detection</a> below for details):</p>
         <ul style="margin:0 0 0 18px;padding:0;font-size:13px;color:var(--muted);line-height:1.75">
           <li><a href="#help-tool-deadlock">Tool Call Deadlock</a> — the same tool call repeated 5+ times</li>
           <li><a href="#help-state-spiral">State Corruption Spiral</a> — a file edited then reverted, oscillating</li>
           <li><a href="#help-hallucination">Hallucination Amplification Loop</a> — the same error recurring 3+ times</li>
           <li><a href="#help-runaway-steps">Ambiguous Success / Escalating Scope</a> — runaway step count, no stopping condition</li>
           <li><a href="#help-context-accumulation">Infinite Loop — Context Accumulation</a> — input tokens growing while output collapses</li>
+          <li><a href="#help-chronic-tool-unreliability">Chronic Tool Unreliability</a> — an unusually high share of tool calls failing</li>
+          <li><a href="#help-context-flooding-risk">Context Flooding Risk</a> — a tool result too large for the model to use well</li>
+          <li><a href="#help-malformed-tool-call">Malformed Tool Call</a> — the agent's own harness rejected a call before it ran</li>
         </ul>
       </div>
     </div>
@@ -557,6 +560,24 @@ function SessionsSection() {
             example="First call: 8K in → 600 out (7.5%). Last call: 65K in → 80 out (0.12%). Five turns reading the same files without edits."
             steps={`<li>Stop immediately — cost compounds with no progress.</li><li>Start fresh with a focused prompt stating what was already read.</li><li>Include the specific target state, not just the problem.</li><li>Use the Traces tab to review what was accomplished.</li>`}
             impact="Catching at 4 calls instead of 10 saves ~390,000 input tokens at peak context size."
+          />
+          <LoopBlock id="help-chronic-tool-unreliability" title="Chronic Tool Unreliability"
+            why="An unusually high share of this session's tool calls failed — 20%+ with at least 5 calls made, well above the ordinary rate of an occasional wrong path corrected along the way. Unlike the Hallucination Amplification Loop above, this doesn't require the same error to repeat — it catches a session with many different one-off failures."
+            example="7 of 12 tool calls failed (58%): bash ×4 (command not found), read_file ×3 (path guessed incorrectly)."
+            steps={`<li>Be explicit about file locations and the exact commands available.</li><li>State the package manager and runtime in use.</li><li>Verify paths and commands exist before prompting.</li>`}
+            impact="Each eliminated failure saves a full LLM recovery turn — roughly 30,000 wasted tokens per cascade."
+          />
+          <LoopBlock id="help-context-flooding-risk" title="Context Flooding Risk"
+            why="A tool call returned a result over 10,000 characters, which gets appended to context in full and crowds out everything else for the rest of the session."
+            example="A read_file call on a 300-line file added 45KB (~11,000 tokens) to every subsequent call in the session."
+            steps={`<li>Use line-range reads instead of whole files.</li><li>Tighten search patterns.</li><li>Pipe command output through something that limits it.</li>`}
+            impact="Replacing a 300-line read with a 30-line read saves ~2,700 tokens per turn for the rest of the session."
+          />
+          <LoopBlock id="help-malformed-tool-call" title="Malformed Tool Call"
+            why="The agent's own harness rejected a call before it ran — a wrong argument name, an unknown tool, or malformed arguments. This is different from a normal runtime failure (a grep that finds nothing, a build that fails on real code): it means the agent's call didn't match what the tool expected, not that the codebase has a problem. Fires on a single occurrence, unlike the other signals here."
+            example={`<code style="font-size:10px;background:var(--panel-bg);padding:1px 3px;border-radius:2px">Invalid tool call: missing required parameter "path"</code>`}
+            steps={`<li>If this recurs, the agent may be working from an outdated or incorrect idea of what tools are available.</li><li>Check whether a tool definition changed recently.</li>`}
+            impact="Each rejected call is a full round-trip to the model that produced nothing but an error to recover from."
           />
         </div>
         <p style="margin-top:16px;font-size:12px;color:var(--muted)">Loop signals appear in the Insights panel inside the <strong>Overview</strong> sub-tab of each session, sorted by severity. Use the <strong>Loops</strong> filter pill to view only malfunction signals. Use <strong>Ignore</strong> to dismiss a signal if it was intentional behavior.</p>

--- a/media/src/tabs/Insights.tsx
+++ b/media/src/tabs/Insights.tsx
@@ -26,6 +26,11 @@ function noActiveTakeawayText(filter: InsightFilter): string {
   return 'No significant inefficiencies detected. Token usage looks healthy.'
 }
 
+// Promoted to the backend taxonomy (src/loopDetector.ts) — matched by _loopType here rather than
+// title text, since their titles are now "patternName — evidence" instead of the old ad-hoc
+// "N tool failure(s)" / "Large tool results" wording that the title-matching below used to catch.
+const TOOL_ISSUE_LOOP_TYPES = new Set(['chronic_tool_failures', 'context_flooding_risk', 'malformed_tool_call'])
+
 function summarizeTakeaways(insights: Insight[]): InsightTakeaways {
   const summary: InsightTakeaways = {
     loopCount: 0,
@@ -40,7 +45,7 @@ function summarizeTakeaways(insights: Insight[]): InsightTakeaways {
     if (insight.category === 'loop') summary.loopCount++
     if (title.includes('context grew') || title.includes('starts with')) summary.hasContextBloat = true
     if (title.includes('cache hit')) summary.hasCacheIssue = true
-    if (title.includes('tool failure') || title.includes('tool definitions') || title.includes('large tool')) summary.hasToolIssue = true
+    if (title.includes('tool definitions') || (insight._loopType && TOOL_ISSUE_LOOP_TYPES.has(insight._loopType))) summary.hasToolIssue = true
     if (title.includes('files read multiple') || title.includes('duplicate searches') || title.includes('files appear')) summary.hasRepeatedOperations = true
   }
 
@@ -64,6 +69,9 @@ const HELP_WHY: Record<string, string> = {
   'help-hallucination':        'Each failed fix attempt adds the error to context, which anchors the model further from the real solution — the longer it runs, the harder it self-corrects.',
   'help-runaway-steps':        'Scope creep compounds: each extra step the agent takes grows context for all future steps. 90-step sessions can cost 10–20× a well-scoped 5-step equivalent.',
   'help-context-accumulation': 'Input tokens are growing while output shrinks — cost per call is compounding with diminishing returns. Continuing will likely hit the context limit with nothing saved.',
+  'help-chronic-tool-unreliability': 'Each failure adds error text to context and forces a recovery turn. A cascade of 3 failures can waste 30,000+ tokens before a single useful edit is made.',
+  'help-context-flooding-risk': 'Tool results are appended to context in full. A 50 KB file read adds ~12,500 tokens to every subsequent call in that session — not just the call that read it.',
+  'help-malformed-tool-call':  'A rejected call means the round-trip to the model happened for nothing — no result, just an error to recover from. Unlike a runtime failure, this is unambiguously the agent\'s call not matching what the tool expected.',
 }
 
 // ── Insight generation ────────────────────────────────────────────────────────
@@ -184,64 +192,20 @@ export function generateInsights(
       })
     }
 
-    // Tool failures
-    const failedTools: Record<string, number> = {}
-    ;(sess.timeline ?? []).forEach(e => {
-      if (e.type === 'tool' && e.isError) {
-        const t = (e.label ?? '').split(' ')[0]; failedTools[t] = (failedTools[t] ?? 0) + 1
-      }
-    })
-    const failedEntries = Object.keys(failedTools)
-    if (failedEntries.length > 0) {
-      const totalFails = failedEntries.reduce((s, t) => s + failedTools[t], 0)
-      const toolAdvice = failedEntries.slice(0, 3).map(t => {
-        const n = failedTools[t]
-        if (t === 'bash' || t === 'run_command') return t + ' ×' + n + ' (check the command exists in your environment)'
-        if (t === 'read_file' || t === 'view') return t + ' ×' + n + ' (verify file paths are correct)'
-        if (t === 'grep_search' || t === 'search_files') return t + ' ×' + n + ' (use more specific patterns)'
-        return t + ' ×' + n
-      }).join('; ')
-      insights.push({
-        severity: totalFails > 2 ? 'warning' : 'info', category: 'efficiency', sessionIdx: idx,
-        helpId: 'help-tool-failures',
-        title: '[Session ' + globalNum + '] ' + totalFails + ' tool failure(s)',
-        detail: 'Failed: ' + toolAdvice + '. Each failure forces an extra LLM call to recover.',
-        action: 'Tool failures happen when the agent guesses paths or uses incorrect arguments. '
-          + 'Be explicit in your prompt about file locations and command availability.',
-      })
-    }
-
-    // Large tool results
-    const largeResults: Array<{ tool: string; size: number }> = []
-    ;(sess.timeline ?? []).forEach(e => {
-      if (e.type === 'tool' && e.fullResult && e.fullResult.length > 10000) {
-        largeResults.push({ tool: (e.label ?? '').split(' ')[0], size: e.fullResult.length })
-      }
-    })
-    if (largeResults.length > 0) {
-      largeResults.sort((a, b) => b.size - a.size)
-      const totalKb = largeResults.reduce((s, r) => s + r.size, 0) / 1024
-      const topResult = largeResults[0]
-      insights.push({
-        severity: totalKb > 100 ? 'warning' : 'info', category: 'efficiency', sessionIdx: idx,
-        helpId: 'help-large-results',
-        title: '[Session ' + globalNum + '] Large tool results (' + totalKb.toFixed(0) + 'KB)',
-        detail: largeResults.length + ' tool call(s) returned large results: '
-          + largeResults.slice(0, 3).map(r => r.tool + ' (' + (r.size / 1024).toFixed(1) + 'KB)').join(', ') + '.',
-        action: topResult.tool.includes('read')
-          ? 'Use narrower reads — specify line ranges (e.g. read_file src/app.ts L1-50) instead of reading whole files.'
-          : 'The largest result came from ' + topResult.tool + ' (' + (topResult.size / 1024).toFixed(0) + 'KB). '
-            + 'Use more targeted reads — specify line ranges with read_file, or tighter grep patterns.',
-      })
-    }
-
-    // Loop signals
+    // Loop signals — includes chronic_tool_failures and context_flooding_risk, which used to be
+    // computed here as separate ad-hoc "Tool failures" / "Large tool results" checks. Promoted
+    // into the shared backend taxonomy (src/loopDetector.ts) so MCP tools and the Instruction
+    // Advisor's cross-session aggregation can see them too, not just this tab — removed the
+    // duplicate local computation rather than compute the same thing twice.
     const loopHelpIds: Record<string, string> = {
       exact_tool_repeat:  'help-tool-deadlock',
       edit_revert_cycle:  'help-state-spiral',
       error_recurrence:   'help-hallucination',
       runaway_steps:      'help-runaway-steps',
       token_runaway:      'help-context-accumulation',
+      chronic_tool_failures: 'help-chronic-tool-unreliability',
+      context_flooding_risk: 'help-context-flooding-risk',
+      malformed_tool_call:   'help-malformed-tool-call',
     }
     ;(sess.loopSignals ?? []).forEach(sig => {
       const examplesText = sig.examples?.length > 0 ? '\n\nExamples: ' + sig.examples.join(' · ') : ''

--- a/media/src/types.ts
+++ b/media/src/types.ts
@@ -36,6 +36,9 @@ export type LoopSignalType =
   | 'error_recurrence'
   | 'runaway_steps'
   | 'token_runaway'
+  | 'chronic_tool_failures'
+  | 'context_flooding_risk'
+  | 'malformed_tool_call'
 
 export interface LoopSignal {
   type: LoopSignalType

--- a/src/loopDetector.ts
+++ b/src/loopDetector.ts
@@ -1,13 +1,21 @@
 /**
  * Loop and malfunction detector for agent sessions.
  *
- * Detects 5 signal types that indicate an agent is stuck in a loop or spiraling:
+ * Detects 8 signal types that indicate an agent is stuck, spiraling, or working unreliably:
  *
- *   1. exact_tool_repeat  — identical tool call (by label) executed 3+ times
- *   2. edit_revert_cycle  — a file was edited then reverted to a prior state
- *   3. error_recurrence   — the same error message appearing 3+ times
- *   4. runaway_steps      — too many steps relative to inferred task complexity
- *   5. token_runaway      — context growing rapidly while output stays flat/declines
+ *   1. exact_tool_repeat     — identical tool call (by label) executed 3+ times
+ *   2. edit_revert_cycle     — a file was edited then reverted to a prior state
+ *   3. error_recurrence      — the same error message appearing 3+ times
+ *   4. runaway_steps         — too many steps relative to inferred task complexity
+ *   5. token_runaway         — context growing rapidly while output stays flat/declines
+ *   6. chronic_tool_failures — an unusually high share of tool calls in the session failed
+ *   7. context_flooding_risk — a tool call returned a result too large for the model to use well
+ *   8. malformed_tool_call   — the agent's own harness rejected a call before it even executed
+ *
+ * The last 3 started as ad-hoc frontend-only checks (media/src/tabs/Insights.tsx) and a new
+ * pattern found during a later failure-mode review, promoted here so MCP tools and the
+ * Instruction Advisor's cross-session aggregation — everything that reads session.loopSignals —
+ * can see them too, not just the Insights tab.
  *
  * Each detector is exported individually so tests can exercise them in isolation.
  */
@@ -17,12 +25,15 @@ import { SessionSummaryCard } from './spanSummarizer'
 
 // ── Pattern taxonomy names ───────────────────────────────────────────────────
 
-const PATTERN_NAMES: Record<LoopSignalType, string> = {
+export const PATTERN_NAMES: Record<LoopSignalType, string> = {
   exact_tool_repeat: 'Tool Call Deadlock',
   edit_revert_cycle: 'State Corruption Spiral',
   error_recurrence:  'Hallucination Amplification Loop',
   runaway_steps:     'Ambiguous Success / Escalating Scope',
   token_runaway:     'Infinite Loop — Context Accumulation',
+  chronic_tool_failures: 'Chronic Tool Unreliability',
+  context_flooding_risk: 'Context Flooding Risk',
+  malformed_tool_call:   'Malformed Tool Call',
 }
 
 // ── Actionable recommendations per signal type ──────────────────────────────
@@ -53,6 +64,20 @@ export const LOOP_SIGNAL_ACTIONS: Record<LoopSignalType, string> = {
     'Input context is growing rapidly while useful output is declining — the agent is accumulating context without making forward progress. '
     + 'This pattern often accompanies tool-call loops or repeated failed fixes. '
     + 'Start a fresh session with a focused prompt, or explicitly tell the agent what it has already tried and what to do differently.',
+
+  chronic_tool_failures:
+    'A high share of this session\'s tool calls failed — well above the ordinary rate of an occasional wrong path corrected along the way. '
+    + 'Be explicit in your prompt about file locations, available commands, and the runtime/package manager in use. '
+    + 'Verify paths and commands exist before asking the agent to use them.',
+
+  context_flooding_risk:
+    'One or more tool calls returned a very large result, which gets appended to context in full and crowds out everything else for the rest of the session. '
+    + 'Use narrower reads — specify line ranges instead of whole files, tighten search patterns, or pipe command output through something that limits it.',
+
+  malformed_tool_call:
+    'The agent\'s own harness rejected a tool call before it ran — a wrong argument name, an unknown tool, or malformed arguments. '
+    + 'This is different from a normal runtime failure: it means the agent\'s call didn\'t match what the tool expected, not that the codebase has a problem. '
+    + 'If this recurs, the agent may be working from an outdated or incorrect idea of what tools are available.',
 }
 
 // ── Public API ───────────────────────────────────────────────────────────────
@@ -64,6 +89,9 @@ export function detectLoopSignals(session: SessionSummaryCard): LoopSignal[] {
   detectErrorRecurrence(session, signals)
   detectRunawaySteps(session, signals)
   detectTokenRunaway(session, signals)
+  detectChronicToolFailures(session, signals)
+  detectContextFloodingRisk(session, signals)
+  detectMalformedToolCall(session, signals)
   return signals
 }
 
@@ -334,5 +362,123 @@ export function detectTokenRunaway(session: SessionSummaryCard, signals: LoopSig
     ],
     patternName: PATTERN_NAMES.token_runaway,
     action: LOOP_SIGNAL_ACTIONS.token_runaway,
+  })
+}
+
+// ── Detector 6: Chronic tool failures ────────────────────────────────────────
+
+// Below this, an occasional wrong path corrected along the way is normal exploratory behavior,
+// not a reliability problem — the threshold needs to sit clearly above that ambient baseline.
+// Guessed at 20%/40% pending real calibration against labeled sessions (see
+// .staged-issues/tool-reliability-signals.md's open questions) — not measured.
+const CHRONIC_FAILURE_WARNING_RATE = 0.2
+const CHRONIC_FAILURE_CRITICAL_RATE = 0.4
+const CHRONIC_FAILURE_MIN_SAMPLE = 5
+
+/**
+ * Promoted from an ad-hoc frontend-only check in Insights.tsx. Unlike error_recurrence (which
+ * only fires when the *same* error recurs 3+ times), this catches a session with many different
+ * one-off tool failures — a real gap the recurrence-based detector can't see, since nothing here
+ * has to repeat.
+ *
+ * Requires at least 5 tool calls before evaluating, so a 2-of-3 session doesn't read the same as
+ * a 20-of-50 one.
+ */
+export function detectChronicToolFailures(session: SessionSummaryCard, signals: LoopSignal[]): void {
+  const toolEntries = session.timeline.filter(e => e.type === 'tool')
+  if (toolEntries.length < CHRONIC_FAILURE_MIN_SAMPLE) { return }
+
+  const failedByLabel: Record<string, number> = {}
+  let failedCount = 0
+  for (const entry of toolEntries) {
+    if (!entry.isError) { continue }
+    failedCount++
+    const key = (entry.label || '').split(' ')[0] || 'unknown'
+    failedByLabel[key] = (failedByLabel[key] || 0) + 1
+  }
+  if (failedCount === 0) { return }
+
+  const rate = failedCount / toolEntries.length
+  if (rate < CHRONIC_FAILURE_WARNING_RATE) { return }
+
+  const topFailing = Object.entries(failedByLabel).sort((a, b) => b[1] - a[1])
+
+  signals.push({
+    type: 'chronic_tool_failures',
+    severity: rate >= CHRONIC_FAILURE_CRITICAL_RATE ? 'critical' : 'warning',
+    evidence: `${failedCount} of ${toolEntries.length} tool calls failed (${(rate * 100).toFixed(0)}%)`,
+    count: failedCount,
+    examples: topFailing.slice(0, 3).map(([tool, n]) => `${tool} ×${n}`),
+    patternName: PATTERN_NAMES.chronic_tool_failures,
+    action: LOOP_SIGNAL_ACTIONS.chronic_tool_failures,
+  })
+}
+
+// ── Detector 7: Context flooding risk ────────────────────────────────────────
+
+const LARGE_RESULT_CHARS = 10_000
+const LARGE_RESULT_CRITICAL_KB = 300
+
+/**
+ * Promoted from an ad-hoc frontend-only check in Insights.tsx — same underlying threshold
+ * (10,000 characters per result). Worth confirming during rollout whether fullResult is already
+ * truncated somewhere upstream in the capture pipeline before this check runs on it; if so this
+ * threshold needs to be checked against whatever that cap actually is.
+ */
+export function detectContextFloodingRisk(session: SessionSummaryCard, signals: LoopSignal[]): void {
+  const largeResults: Array<{ tool: string; size: number }> = []
+  for (const entry of session.timeline) {
+    if (entry.type !== 'tool' || !entry.fullResult) { continue }
+    if (entry.fullResult.length <= LARGE_RESULT_CHARS) { continue }
+    largeResults.push({ tool: (entry.label || '').split(' ')[0] || 'unknown', size: entry.fullResult.length })
+  }
+  if (largeResults.length === 0) { return }
+
+  largeResults.sort((a, b) => b.size - a.size)
+  const totalKb = largeResults.reduce((s, r) => s + r.size, 0) / 1024
+
+  signals.push({
+    type: 'context_flooding_risk',
+    severity: totalKb >= LARGE_RESULT_CRITICAL_KB ? 'critical' : 'warning',
+    evidence: `${largeResults.length} tool call(s) returned large results (${totalKb.toFixed(0)}KB total)`,
+    count: largeResults.length,
+    examples: largeResults.slice(0, 3).map(r => `${r.tool} (${(r.size / 1024).toFixed(1)}KB)`),
+    patternName: PATTERN_NAMES.context_flooding_risk,
+    action: LOOP_SIGNAL_ACTIONS.context_flooding_risk,
+  })
+}
+
+// ── Detector 8: Malformed tool call ──────────────────────────────────────────
+
+// Matches an agent harness rejecting a call before execution, not a normal runtime failure.
+// Best-guess wording, not verified against real session text from each agent (Claude Code, Codex,
+// and Copilot each have their own harness and error format) — see this signal's open question in
+// .staged-issues/tool-reliability-signals.md before trusting this in production.
+const MALFORMED_CALL_PATTERN =
+  /\b(invalid tool call|unknown tool|unrecognized tool|missing required (parameter|argument|field)|failed to parse (arguments|input)|invalid (arguments|argument|parameters)|unrecognized (field|argument|parameter)|tool .* not found|no such tool)\b/i
+
+/**
+ * Unlike error_recurrence, this doesn't need 3+ occurrences to fire — a single rejected call
+ * already means the agent's call didn't match what the tool expected, which is categorically more
+ * certain than an arbitrary runtime error (a failing grep or a broken build is often legitimate
+ * signal about the codebase, not the agent).
+ */
+export function detectMalformedToolCall(session: SessionSummaryCard, signals: LoopSignal[]): void {
+  const matches: string[] = []
+  for (const entry of session.timeline) {
+    if (entry.type !== 'tool' || !entry.isError) { continue }
+    const text = entry.errorMessage || entry.label || ''
+    if (MALFORMED_CALL_PATTERN.test(text)) { matches.push(text.slice(0, 100)) }
+  }
+  if (matches.length === 0) { return }
+
+  signals.push({
+    type: 'malformed_tool_call',
+    severity: matches.length >= 3 ? 'critical' : 'warning',
+    evidence: `${matches.length} tool call(s) rejected by the agent's own harness before executing`,
+    count: matches.length,
+    examples: matches.slice(0, 3),
+    patternName: PATTERN_NAMES.malformed_tool_call,
+    action: LOOP_SIGNAL_ACTIONS.malformed_tool_call,
   })
 }

--- a/src/test/loopDetector.test.ts
+++ b/src/test/loopDetector.test.ts
@@ -6,6 +6,9 @@ import {
   detectErrorRecurrence,
   detectRunawaySteps,
   detectTokenRunaway,
+  detectChronicToolFailures,
+  detectContextFloodingRisk,
+  detectMalformedToolCall,
   inferTaskComplexity,
   getFileEditCounts,
   LOOP_SIGNAL_ACTIONS,
@@ -88,6 +91,18 @@ function makeEdit(filePath: string, oldString: string, newString: string): Timel
 
 function makeErrorTool(label: string, errorMessage: string): TimelineEntry {
   return makeTool(label, true, errorMessage)
+}
+
+function makeResultTool(label: string, fullResult: string): TimelineEntry {
+  return {
+    type: 'tool',
+    spanId: 'span-' + Math.random().toString(36).slice(2, 8),
+    label,
+    durationMs: 100,
+    isError: false,
+    fullResult,
+    timestamp: new Date().toISOString(),
+  }
 }
 
 // ── inferTaskComplexity ───────────────────────────────────────────────────────
@@ -617,6 +632,150 @@ suite('detectTokenRunaway', () => {
   })
 })
 
+// ── detectChronicToolFailures ───────────────────────────────────────────────
+
+suite('detectChronicToolFailures', () => {
+  test('no signal below the minimum sample size, even at 100% failure', () => {
+    const signals: LoopSignal[] = []
+    const session = makeSession({ timeline: [makeTool('bash', true), makeTool('bash', true)] })
+    detectChronicToolFailures(session, signals)
+    assert.strictEqual(signals.length, 0)
+  })
+
+  test('no signal for a normal, low ambient failure rate (1/6 ≈ 17%, under the 20% floor)', () => {
+    const signals: LoopSignal[] = []
+    const session = makeSession({
+      timeline: [
+        makeTool('bash', true), makeTool('bash'), makeTool('bash'),
+        makeTool('bash'), makeTool('bash'), makeTool('bash'),
+      ],
+    })
+    detectChronicToolFailures(session, signals)
+    assert.strictEqual(signals.length, 0)
+  })
+
+  test('warning at a rate between the two thresholds (2/7 ≈ 29%)', () => {
+    const signals: LoopSignal[] = []
+    const session = makeSession({
+      timeline: [
+        makeTool('bash', true), makeTool('bash', true),
+        makeTool('read_file'), makeTool('read_file'), makeTool('read_file'),
+        makeTool('read_file'), makeTool('read_file'),
+      ],
+    })
+    detectChronicToolFailures(session, signals)
+    assert.strictEqual(signals.length, 1)
+    assert.strictEqual(signals[0].type, 'chronic_tool_failures')
+    assert.strictEqual(signals[0].severity, 'warning')
+    assert.strictEqual(signals[0].count, 2)
+  })
+
+  test('critical at a very high failure rate', () => {
+    const signals: LoopSignal[] = []
+    const session = makeSession({
+      timeline: [
+        makeTool('bash', true), makeTool('bash', true), makeTool('bash', true),
+        makeTool('read_file'), makeTool('read_file'),
+      ],
+    })
+    detectChronicToolFailures(session, signals)
+    assert.strictEqual(signals.length, 1)
+    assert.strictEqual(signals[0].severity, 'critical')
+  })
+
+  test('ignores llm entries when counting the sample size', () => {
+    const signals: LoopSignal[] = []
+    const session = makeSession({
+      timeline: [makeLlm(100, 50), makeLlm(100, 50), makeLlm(100, 50), makeTool('bash', true), makeTool('bash')],
+    })
+    detectChronicToolFailures(session, signals)
+    assert.strictEqual(signals.length, 0) // only 2 tool entries, below the 5-call minimum
+  })
+})
+
+// ── detectContextFloodingRisk ───────────────────────────────────────────────
+
+suite('detectContextFloodingRisk', () => {
+  test('no signal when no result exceeds the size threshold', () => {
+    const signals: LoopSignal[] = []
+    const session = makeSession({ timeline: [makeResultTool('read_file', 'x'.repeat(500))] })
+    detectContextFloodingRisk(session, signals)
+    assert.strictEqual(signals.length, 0)
+  })
+
+  test('warning when a result exceeds the threshold but total stays under the critical size', () => {
+    const signals: LoopSignal[] = []
+    const session = makeSession({ timeline: [makeResultTool('read_file', 'x'.repeat(15_000))] })
+    detectContextFloodingRisk(session, signals)
+    assert.strictEqual(signals.length, 1)
+    assert.strictEqual(signals[0].type, 'context_flooding_risk')
+    assert.strictEqual(signals[0].severity, 'warning')
+  })
+
+  test('critical when the total accumulated size crosses the critical threshold', () => {
+    const signals: LoopSignal[] = []
+    const session = makeSession({
+      timeline: [
+        makeResultTool('read_file', 'x'.repeat(200_000)),
+        makeResultTool('grep', 'x'.repeat(150_000)),
+      ],
+    })
+    detectContextFloodingRisk(session, signals)
+    assert.strictEqual(signals.length, 1)
+    assert.strictEqual(signals[0].severity, 'critical')
+    assert.strictEqual(signals[0].count, 2)
+  })
+
+  test('ignores entries without fullResult', () => {
+    const signals: LoopSignal[] = []
+    const session = makeSession({ timeline: [makeTool('read_file')] })
+    detectContextFloodingRisk(session, signals)
+    assert.strictEqual(signals.length, 0)
+  })
+})
+
+// ── detectMalformedToolCall ─────────────────────────────────────────────────
+
+suite('detectMalformedToolCall', () => {
+  test('no signal for a normal runtime error', () => {
+    const signals: LoopSignal[] = []
+    const session = makeSession({ timeline: [makeErrorTool('bash', 'command failed with exit code 1')] })
+    detectMalformedToolCall(session, signals)
+    assert.strictEqual(signals.length, 0)
+  })
+
+  test('fires on a single rejected call, unlike error_recurrence', () => {
+    const signals: LoopSignal[] = []
+    const session = makeSession({ timeline: [makeErrorTool('bash', 'Invalid tool call: missing required parameter "path"')] })
+    detectMalformedToolCall(session, signals)
+    assert.strictEqual(signals.length, 1)
+    assert.strictEqual(signals[0].type, 'malformed_tool_call')
+    assert.strictEqual(signals[0].severity, 'warning')
+    assert.strictEqual(signals[0].count, 1)
+  })
+
+  test('critical at 3 or more rejected calls', () => {
+    const signals: LoopSignal[] = []
+    const session = makeSession({
+      timeline: [
+        makeErrorTool('bash', 'unknown tool "run_shell"'),
+        makeErrorTool('bash', 'unknown tool "run_shell"'),
+        makeErrorTool('bash', 'unknown tool "run_shell"'),
+      ],
+    })
+    detectMalformedToolCall(session, signals)
+    assert.strictEqual(signals.length, 1)
+    assert.strictEqual(signals[0].severity, 'critical')
+  })
+
+  test('ignores non-error entries', () => {
+    const signals: LoopSignal[] = []
+    const session = makeSession({ timeline: [makeTool('bash')] })
+    detectMalformedToolCall(session, signals)
+    assert.strictEqual(signals.length, 0)
+  })
+})
+
 // ── detectLoopSignals (integration) ─────────────────────────────────────────
 
 suite('detectLoopSignals', () => {
@@ -682,6 +841,9 @@ suite('LOOP_SIGNAL_ACTIONS', () => {
     'error_recurrence',
     'runaway_steps',
     'token_runaway',
+    'chronic_tool_failures',
+    'context_flooding_risk',
+    'malformed_tool_call',
   ]
 
   test('has an action string for every signal type', () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -36,6 +36,9 @@ export type LoopSignalType =
   | 'error_recurrence'
   | 'runaway_steps'
   | 'token_runaway'
+  | 'chronic_tool_failures'
+  | 'context_flooding_risk'
+  | 'malformed_tool_call'
 
 export interface LoopSignal {
   type: LoopSignalType


### PR DESCRIPTION
## Summary

Three new `LoopSignalType` entries, extending the taxonomy from 5 to 8:

- **`chronic_tool_failures`**: an unusually high share of a session's tool calls failed (rate-based, 20%/40% thresholds, minimum 5 tool calls before evaluating). Promoted from an ad-hoc frontend-only check in `Insights.tsx` that counted raw failures with no rate normalization — a 2-of-3 session and a 2-of-50 session used to look identical. Catches a session with many different one-off failures, which `error_recurrence`'s same-error-3x requirement can't see.
- **`context_flooding_risk`**: a tool call returned a result too large for the model to use well (>10,000 characters). Same promotion, same underlying threshold as the frontend check it replaces.
- **`malformed_tool_call`**: the agent's own harness rejected a call before it executed (wrong argument, unknown tool) — categorically more certain than a normal runtime failure, so it fires on a single occurrence rather than requiring 3+ recurrences like `error_recurrence`. Message-pattern matching is a best guess, not yet verified against real per-agent error text.

The first two existed only as ad-hoc computations in `media/src/tabs/Insights.tsx`, invisible to anything reading `session.loopSignals` — MCP's `get_recent_sessions`/`get_efficiency_report`, `check_automation_triggers`, and the Instruction Advisor's cross-session aggregation in `Instructions.tsx` all missed them. Removed the duplicate frontend computation now that the same information flows through the generic `loopSignals` rendering already in `Insights.tsx`, and fixed `summarizeTakeaways`'s `hasToolIssue` flag, which was matching against the old ad-hoc titles by substring — now matches by `_loopType` instead, which doesn't break when title wording changes.

Added matching `Help.tsx` `LoopBlock` entries and `Insights.tsx` tooltip text for all three, and updated the loop-signal count callout from five to eight.

**Explicitly not pursued this pass**: contradicting earlier decisions/failing to recall something established many turns ago (needs real semantic comparison, no cheap heuristic); broadening `failed_check_submission` to any trailing tool error (the narrow test-runner scope was deliberate); incomplete todo/task tracking as a signal (AgentLens doesn't capture structured per-item todo state today).

## Test plan

- [x] Full test suite passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)