### PR TITLE
feat: add system/dark/light theme toggle to standalone

### DIFF
--- a/media/src/App.tsx
+++ b/media/src/App.tsx
@@ -25,7 +25,7 @@ import { Pricing } from './tabs/Pricing'
 import { Patterns } from './tabs/Patterns'
 import { Automation, checkAutomations } from './tabs/Automation'
 import { instructionFiles, appliedSuggestions, dismissedIds } from './tabs/Instructions'
-import { IngestionToggles, McpToggle, OtelReconfigureButton } from './tabs/Settings'
+import { IngestionToggles, McpToggle, OtelReconfigureButton, ThemeToggle } from './tabs/Settings'
 
 
 // Standalone opens with the left activity sidebar collapsed by default, since it
@@ -103,6 +103,7 @@ function ConfigPanel() {
           title="Close (Esc)"
         >×</button>
       </div>
+      {!vscode && <ThemeToggle />}
       <IngestionToggles />
       <OtelReconfigureButton />
       <McpToggle />

--- a/media/src/App.tsx
+++ b/media/src/App.tsx
@@ -463,12 +463,16 @@ export function App() {
   )
 }
 
+// `color` (and `activeColor`) doubles as the pill's border in both states and, historically, its
+// active-state text — 'all' and 'opencode' used a literal #ffffff for a neutral "pop" look, which
+// is invisible (white border/text on a white page) in light mode. var(--fg) gives the same neutral
+// look correctly in both themes instead of a color that only worked against a dark background.
 const AGENT_FILTER_OPTIONS: Array<{ value: AgentFilter; label: string; color: string; activeColor?: string }> = [
-  { value: 'all',        label: 'All',      color: 'var(--vscode-descriptionForeground,#888)', activeColor: '#ffffff' },
+  { value: 'all',        label: 'All',      color: 'var(--vscode-descriptionForeground,#888)', activeColor: 'var(--fg)' },
   { value: 'copilot',    label: 'Copilot',  color: '#00EAFF' },
   { value: 'claude_code',label: 'Claude',   color: '#FFB085' },
   { value: 'codex',      label: 'Codex',    color: '#F0FF42' },
-  { value: 'opencode',   label: 'OpenCode', color: '#FFFFFF' },
+  { value: 'opencode',   label: 'OpenCode', color: 'var(--fg)' },
 ]
 
 function TimeRangePicker({ hideAgentFilter = false }: { hideAgentFilter?: boolean }) {
@@ -586,6 +590,11 @@ function TimeRangePicker({ hideAgentFilter = false }: { hideAgentFilter?: boolea
           {AGENT_FILTER_OPTIONS.map(o => {
             const active = agent === o.value
             const displayColor = (active && o.activeColor) ? o.activeColor : o.color
+            // The 20%-alpha-blend background trick below only works on a literal hex color — it's
+            // invalid CSS appended to a var() reference (var(--fg)33 isn't a thing). The 'all' and
+            // 'opencode' pills use var(--fg) as their neutral color, so they fall back to the same
+            // highlight color used for hover states elsewhere instead.
+            const activeBg = displayColor.startsWith('#') ? `${displayColor}33` : 'var(--hover)'
             return (
               <button
                 key={o.value}
@@ -594,7 +603,12 @@ function TimeRangePicker({ hideAgentFilter = false }: { hideAgentFilter?: boolea
                   'padding:2px 9px;font-size:11px;cursor:pointer;border-radius:10px;transition:all 0.1s;',
                   `border:1.5px solid ${displayColor};`,
                   active
-                    ? `background:${displayColor}33;color:${displayColor};font-weight:600`
+                    // Text always follows the theme's own foreground color rather than the agent's
+                    // brand color — several of those (codex's yellow, opencode's neutral) only have
+                    // readable contrast against a dark background; against light, brand-color-on-
+                    // brand-color-tinted-background is illegible. The border still carries the
+                    // per-agent identity color.
+                    ? `background:${activeBg};color:var(--fg);font-weight:600`
                     : 'background:transparent;color:var(--muted)',
                 ].join('')}
               >{o.label}</button>

--- a/media/src/App.tsx
+++ b/media/src/App.tsx
@@ -103,7 +103,7 @@ function ConfigPanel() {
           title="Close (Esc)"
         >×</button>
       </div>
-      {!vscode && <ThemeToggle />}
+      {window.__STANDALONE__ === true && <ThemeToggle />}
       <IngestionToggles />
       <OtelReconfigureButton />
       <McpToggle />

--- a/media/src/state.ts
+++ b/media/src/state.ts
@@ -150,6 +150,42 @@ export const ignoredInsightKeys = makeSetSignal<string>()
 export let vscode: VsCodeApi | null = null
 export function setVscode(api: VsCodeApi): void { vscode = api }
 
+// ── Theme preference (standalone only — the VS Code webview always follows the
+//    IDE's own theme, so this signal/attribute is simply never touched there) ──
+
+export type ThemePreference = 'system' | 'dark' | 'light'
+
+const THEME_STORAGE_KEY = 'agentlens-theme'
+
+function readStoredTheme(): ThemePreference {
+  try {
+    const v = localStorage.getItem(THEME_STORAGE_KEY)
+    if (v === 'dark' || v === 'light' || v === 'system') return v
+  } catch { /* localStorage unavailable (private browsing, blocked) — fall back to system */ }
+  return 'system'
+}
+
+function applyThemeAttribute(pref: ThemePreference): void {
+  const root = document.documentElement
+  if (pref === 'system') root.removeAttribute('data-theme')
+  else root.setAttribute('data-theme', pref)
+}
+
+export const themePreference = signal<ThemePreference>(readStoredTheme())
+
+// Mirrors the anti-flash inline script in standalone/server.ts's <head> — that script sets the
+// attribute before first paint using the same localStorage key; this keeps the signal (and any
+// future change via setThemePreference) in sync with it rather than a second, divergent source.
+applyThemeAttribute(themePreference.value)
+
+export function setThemePreference(pref: ThemePreference): void {
+  themePreference.value = pref
+  try {
+    localStorage.setItem(THEME_STORAGE_KEY, pref)
+  } catch { /* localStorage unavailable — preference just won't survive a reload */ }
+  applyThemeAttribute(pref)
+}
+
 // ── Navigation helpers ────────────────────────────────────────────────────────
 
 export function goToHelp(anchor: string): void {

--- a/media/src/tabs/Settings.tsx
+++ b/media/src/tabs/Settings.tsx
@@ -40,10 +40,46 @@ function ToggleRow({ label, description, checked, onChange }: {
   )
 }
 
-const THEME_OPTIONS: Array<{ value: ThemePreference; label: string }> = [
-  { value: 'system', label: 'System' },
-  { value: 'dark', label: 'Dark' },
-  { value: 'light', label: 'Light' },
+// Matches the stroke-icon style already used for the settings/bell/refresh icons in App.tsx
+// (24x24 viewBox, stroke-width 2, currentColor) rather than introducing a second icon convention.
+function IconMonitor() {
+  return (
+    <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="display:block">
+      <rect x="2" y="3" width="20" height="14" rx="2" ry="2" />
+      <line x1="8" y1="21" x2="16" y2="21" />
+      <line x1="12" y1="17" x2="12" y2="21" />
+    </svg>
+  )
+}
+
+function IconMoon() {
+  return (
+    <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="display:block">
+      <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+    </svg>
+  )
+}
+
+function IconSun() {
+  return (
+    <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="display:block">
+      <circle cx="12" cy="12" r="4" />
+      <line x1="12" y1="2" x2="12" y2="4" />
+      <line x1="12" y1="20" x2="12" y2="22" />
+      <line x1="4.22" y1="4.22" x2="5.64" y2="5.64" />
+      <line x1="18.36" y1="18.36" x2="19.78" y2="19.78" />
+      <line x1="2" y1="12" x2="4" y2="12" />
+      <line x1="20" y1="12" x2="22" y2="12" />
+      <line x1="4.22" y1="19.78" x2="5.64" y2="18.36" />
+      <line x1="18.36" y1="5.64" x2="19.78" y2="4.22" />
+    </svg>
+  )
+}
+
+const THEME_OPTIONS: Array<{ value: ThemePreference; label: string; Icon: () => preact.JSX.Element }> = [
+  { value: 'system', label: 'System', Icon: IconMonitor },
+  { value: 'dark', label: 'Dark', Icon: IconMoon },
+  { value: 'light', label: 'Light', Icon: IconSun },
 ]
 
 // Standalone only — the VS Code webview always follows the IDE's own theme (VS Code already has
@@ -61,8 +97,9 @@ export function ThemeToggle() {
             key={opt.value}
             onClick={() => setThemePreference(opt.value)}
             aria-pressed={current === opt.value}
-            style={`flex:1;padding:5px 8px;font-size:11px;cursor:pointer;border:1px solid var(--border);border-radius:3px;background:${current === opt.value ? 'var(--accent)' : 'transparent'};color:${current === opt.value ? '#fff' : 'var(--fg)'}`}
+            style={`flex:1;display:flex;align-items:center;justify-content:center;gap:5px;padding:5px 8px;font-size:11px;cursor:pointer;border:1px solid var(--border);border-radius:3px;background:${current === opt.value ? 'var(--accent)' : 'transparent'};color:${current === opt.value ? '#fff' : 'var(--fg)'}`}
           >
+            <opt.Icon />
             {opt.label}
           </button>
         ))}

--- a/media/src/tabs/Settings.tsx
+++ b/media/src/tabs/Settings.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'preact/hooks'
-import { enableOtelIngestion, enableLogIngestion, otlpPort, vscode, otelReconfigureResult, type OtelReconfigureResult } from '../state'
+import { enableOtelIngestion, enableLogIngestion, otlpPort, vscode, otelReconfigureResult, type OtelReconfigureResult, themePreference, setThemePreference, type ThemePreference } from '../state'
 
 function sendConfig(key: string, value: boolean) {
   if (vscode) {
@@ -36,6 +36,37 @@ function ToggleRow({ label, description, checked, onChange }: {
         <span class="toggle-track"><span class="toggle-thumb" /></span>
         <span class={'toggle-label' + (checked ? ' on' : '')}>{checked ? 'Enabled' : 'Disabled'}</span>
       </label>
+    </div>
+  )
+}
+
+const THEME_OPTIONS: Array<{ value: ThemePreference; label: string }> = [
+  { value: 'system', label: 'System' },
+  { value: 'dark', label: 'Dark' },
+  { value: 'light', label: 'Light' },
+]
+
+// Standalone only — the VS Code webview always follows the IDE's own theme (VS Code already has
+// its own system/dark/light/high-contrast picker), so this is never rendered there. See
+// .staged-issues/theme-toggle.md.
+export function ThemeToggle() {
+  const current = themePreference.value
+
+  return (
+    <div style="padding:12px 16px;border-bottom:1px solid var(--border)">
+      <div style="font-size:12px;font-weight:600;color:var(--fg);margin-bottom:6px">Appearance</div>
+      <div style="display:flex;gap:4px">
+        {THEME_OPTIONS.map(opt => (
+          <button
+            key={opt.value}
+            onClick={() => setThemePreference(opt.value)}
+            aria-pressed={current === opt.value}
+            style={`flex:1;padding:5px 8px;font-size:11px;cursor:pointer;border:1px solid var(--border);border-radius:3px;background:${current === opt.value ? 'var(--accent)' : 'transparent'};color:${current === opt.value ? '#fff' : 'var(--fg)'}`}
+          >
+            {opt.label}
+          </button>
+        ))}
+      </div>
     </div>
   )
 }

--- a/standalone/server.ts
+++ b/standalone/server.ts
@@ -701,6 +701,32 @@ function getHtml(): string {
       --vscode-button-background:       #0969da;
       --vscode-button-foreground:       #ffffff;
       --vscode-button-hoverBackground:  #0860ca;
+
+      /* Aliases for --vscode-* names real VS Code exposes that this shim otherwise never defined —
+         components referencing them (input fields, list selection highlight) were silently falling
+         back to their hardcoded (dark) fallback value in every theme, since an undefined custom
+         property with a var() fallback ignores the current theme entirely. Defined once here rather
+         than duplicated into the dark blocks below — custom property resolution follows the cascade
+         at use time, so these keep tracking whatever --vscode-dropdown-*/-list-hoverBackground
+         currently resolve to in each theme without needing to be redeclared per theme. */
+      --vscode-input-background:              var(--vscode-dropdown-background);
+      --vscode-input-border:                  var(--vscode-dropdown-border);
+      --vscode-input-foreground:              var(--vscode-dropdown-foreground);
+      --vscode-list-activeSelectionBackground: var(--vscode-list-hoverBackground);
+      --vscode-focusBorder:                   var(--vscode-textLink-foreground);
+
+      /* Status/chart colors — semantic accents that don't need to invert with theme (these stay
+         legible against both a white and a dark background at these saturations). Values match the
+         one fallback each call site already used consistently, so defining these doesn't also
+         change how they've looked in dark mode all along — it only fixes light mode, which
+         previously got the same dark-tuned fallback since the variable itself was never defined. */
+      --vscode-editorInfo-foreground:    #4fc3f7;
+      --vscode-editorWarning-foreground: #cca700;
+      --vscode-errorForeground:          #f48771;
+      --vscode-charts-blue:              #4fc3f7;
+      --vscode-charts-green:             #81c784;
+      --vscode-charts-red:               #e57373;
+      --vscode-charts-yellow:            #ffb74d;
     }
 
     /* System preference is dark, and the user hasn't explicitly forced Light. */

--- a/standalone/server.ts
+++ b/standalone/server.ts
@@ -678,8 +678,13 @@ function getHtml(): string {
        Not used in the VS Code webview at all — that has its own HTML in
        src/dashboardPanel.ts and always inherits the IDE's real --vscode-* values. ── */
 
-    /* Light palette — the default, before any media query or explicit override applies. */
+    /* Light palette — the default, before any media query or explicit override applies.
+       color-scheme tells the browser which mode *native* form control chrome (dropdowns,
+       checkboxes, date pickers) should render in — without it, those follow the OS/browser's own
+       dark-mode detection independently of the custom colors above, which is why they kept
+       rendering dark even when everything else correctly switched to light. */
     :root {
+      color-scheme: light;
       --vscode-editor-background:       #ffffff;
       --vscode-foreground:              #1f2328;
       --vscode-panel-border:            #d0d7de;
@@ -701,6 +706,7 @@ function getHtml(): string {
     /* System preference is dark, and the user hasn't explicitly forced Light. */
     @media (prefers-color-scheme: dark) {
       :root:not([data-theme="light"]) {
+        color-scheme: dark;
         --vscode-editor-background:       #1e1e1e;
         --vscode-foreground:              #cccccc;
         --vscode-panel-border:            #3e3e42;
@@ -721,6 +727,7 @@ function getHtml(): string {
 
     /* Explicit Dark override, regardless of system preference. */
     :root[data-theme="dark"] {
+      color-scheme: dark;
       --vscode-editor-background:       #1e1e1e;
       --vscode-foreground:              #cccccc;
       --vscode-panel-border:            #3e3e42;

--- a/standalone/server.ts
+++ b/standalone/server.ts
@@ -707,8 +707,9 @@ function getHtml(): string {
          back to their hardcoded (dark) fallback value in every theme, since an undefined custom
          property with a var() fallback ignores the current theme entirely. Defined once here rather
          than duplicated into the dark blocks below — custom property resolution follows the cascade
-         at use time, so these keep tracking whatever --vscode-dropdown-*/-list-hoverBackground
-         currently resolve to in each theme without needing to be redeclared per theme. */
+         at use time, so these keep tracking whatever --vscode-dropdown-background (etc.) and
+         --vscode-list-hoverBackground currently resolve to in each theme, without needing to be
+         redeclared per theme. */
       --vscode-input-background:              var(--vscode-dropdown-background);
       --vscode-input-border:                  var(--vscode-dropdown-border);
       --vscode-input-foreground:              var(--vscode-dropdown-foreground);

--- a/standalone/server.ts
+++ b/standalone/server.ts
@@ -651,13 +651,76 @@ function getHtml(): string {
 <html>
 <head>
   <meta charset="UTF-8">
+  <script>
+    // Applies a stored dark/light override before first paint, so the page never flashes the
+    // wrong theme for a frame — must run before the <style> block below resolves the CSS custom
+    // properties it depends on. No entry (or "system") means no attribute: the prefers-color-scheme
+    // media query in that block handles it instead. See media/src/state.ts's setThemePreference,
+    // which is the only other writer of this key.
+    (function () {
+      try {
+        var t = localStorage.getItem('agentlens-theme');
+        if (t === 'dark' || t === 'light') document.documentElement.setAttribute('data-theme', t);
+      } catch (e) { /* localStorage unavailable — falls back to system preference below */ }
+    })();
+  </script>
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>AgentLens</title>
   <link rel="icon" href="/mascot.png" type="image/png">
   <link rel="stylesheet" href="/dashboard.css">
   <style>
-    /* ── VS Code theme variable shim ─────────────────────────────────────── */
+    /* ── VS Code theme variable shim ─────────────────────────────────────────
+       Standalone has no real VS Code host to supply --vscode-* variables, so this
+       defines them directly. Three states: System (default — follows
+       prefers-color-scheme), Dark, Light (explicit override via the [data-theme]
+       attribute the script above sets). Toggle lives in Settings — see
+       media/src/tabs/Settings.tsx's ThemeToggle and .staged-issues/theme-toggle.md.
+       Not used in the VS Code webview at all — that has its own HTML in
+       src/dashboardPanel.ts and always inherits the IDE's real --vscode-* values. ── */
+
+    /* Light palette — the default, before any media query or explicit override applies. */
     :root {
+      --vscode-editor-background:       #ffffff;
+      --vscode-foreground:              #1f2328;
+      --vscode-panel-border:            #d0d7de;
+      --vscode-textLink-foreground:     #0969da;
+      --vscode-descriptionForeground:   #656d76;
+      --vscode-list-hoverBackground:    #f3f4f6;
+      --vscode-editorWidget-background: #f6f8fa;
+      --vscode-testing-iconFailed:      #cf222e;
+      --vscode-testing-iconPassed:      #1a7f37;
+      --vscode-font-family:             -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+      --vscode-dropdown-background:     #ffffff;
+      --vscode-dropdown-border:         #d0d7de;
+      --vscode-dropdown-foreground:     #1f2328;
+      --vscode-button-background:       #0969da;
+      --vscode-button-foreground:       #ffffff;
+      --vscode-button-hoverBackground:  #0860ca;
+    }
+
+    /* System preference is dark, and the user hasn't explicitly forced Light. */
+    @media (prefers-color-scheme: dark) {
+      :root:not([data-theme="light"]) {
+        --vscode-editor-background:       #1e1e1e;
+        --vscode-foreground:              #cccccc;
+        --vscode-panel-border:            #3e3e42;
+        --vscode-textLink-foreground:     #4fc3f7;
+        --vscode-descriptionForeground:   #9d9d9d;
+        --vscode-list-hoverBackground:    #2a2d2e;
+        --vscode-editorWidget-background: #252526;
+        --vscode-testing-iconFailed:      #f44747;
+        --vscode-testing-iconPassed:      #4ec994;
+        --vscode-dropdown-background:     #3c3c3c;
+        --vscode-dropdown-border:         #616161;
+        --vscode-dropdown-foreground:     #f0f0f0;
+        --vscode-button-background:       #0e639c;
+        --vscode-button-foreground:       #ffffff;
+        --vscode-button-hoverBackground:  #1177bb;
+      }
+    }
+
+    /* Explicit Dark override, regardless of system preference. */
+    :root[data-theme="dark"] {
       --vscode-editor-background:       #1e1e1e;
       --vscode-foreground:              #cccccc;
       --vscode-panel-border:            #3e3e42;
@@ -667,7 +730,6 @@ function getHtml(): string {
       --vscode-editorWidget-background: #252526;
       --vscode-testing-iconFailed:      #f44747;
       --vscode-testing-iconPassed:      #4ec994;
-      --vscode-font-family:             -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
       --vscode-dropdown-background:     #3c3c3c;
       --vscode-dropdown-border:         #616161;
       --vscode-dropdown-foreground:     #f0f0f0;


### PR DESCRIPTION
## Summary

Standalone (browser/npx/Docker) had no theme switching at all — `standalone/server.ts` hardcoded a single fixed dark palette directly into the page's inline `<style>` block, with no light palette, no OS/browser preference detection. The VS Code webview already inherits VS Code's own light/dark/high-contrast setting automatically, so this is standalone-only; `Settings.tsx`'s new control simply doesn't render in the VS Code webview.

- New light palette (real design work — contrast ratios, not a mechanical invert of the dark one) plus a restructured `:root` theme shim in `standalone/server.ts`: base light `:root`, a `prefers-color-scheme: dark` media block, and an explicit `[data-theme="dark"]` override, each setting `color-scheme` so native form controls (dropdowns, checkboxes) render correctly per theme too.
- Three states — **System** (default, follows `prefers-color-scheme`), **Dark**, **Light** — via a `[data-theme]` attribute on `<html>`, persisted to `localStorage`, applied by a blocking inline script in `<head>` before first paint to avoid a flash of the wrong theme.
- New `ThemeToggle` control at the top of `Settings.tsx` (icon-based 3-way switch), gated on `window.__STANDALONE__ === true`.
- Fixed several theme bugs found during testing: a `!vscode` context check that was always true in both VS Code and standalone (both polyfill `acquireVsCodeApi`); several `--vscode-*` CSS variables referenced throughout `media/src/` but never defined in the standalone shim, so they silently fell back to hardcoded dark literals regardless of theme; an alpha-blend hex-suffix trick that broke when applied to a `var()` reference instead of a literal hex color (agent-filter pills going unreadable in one state); and a CSS comment containing a literal `*/` mid-sentence that prematurely closed the comment and silently corrupted the next declaration.

**Out of scope**: high-contrast mode (VS Code's third theme kind beyond light/dark) — only the three requested states are covered.

## Test plan

- [x] Verified in-browser with Playwright across all three theme states
- [x] Confirmed native form controls (dropdowns, filter/project selectors, Advisor suggestion boxes) render correctly in light mode
- [x] Confirmed agent-filter pills (OpenCode, Codex) are readable in both themes
- [x] Full test suite passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)