### PR TITLE
chore: refresh model pricing (2026-08-26) + add promotional-pricing note

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -898,7 +898,7 @@ flowchart TD
 
 `contextWindowTokens` (stored in `src/pricing.ts`) enables the `Projection` calculation: given current session token usage and burn rate, estimate time to context exhaustion and final cost.
 
-Pricing data covers: OpenAI (GPT-4.1 through GPT-5.6), Anthropic (Claude Haiku 3.5/4.5, Sonnet 4.x/5, Opus 4.x/5, Fable 5), Google (Gemini 2.5–3.6), Codex, third-party Copilot-marketplace models (Grok, Kimi, MAI-Code), OpenCode Zen free models, and fine-tuned models. Some models also carry a per-model tiered "long context" surcharge above a token-per-call threshold — see `PRICING_SOURCES.md`. Refreshed per the runbook in `PRICING_SOURCES.md`. Last updated: 2026-08-12.
+Pricing data covers: OpenAI (GPT-4.1 through GPT-5.6), Anthropic (Claude Haiku 3.5/4.5, Sonnet 4.x/5, Opus 4.x/5, Fable 5), Google (Gemini 2.5–3.7), Codex, third-party Copilot-marketplace models (Grok, Kimi, MAI-Code), OpenCode Zen free models, and fine-tuned models. Some models also carry a per-model tiered "long context" surcharge above a token-per-call threshold — see `PRICING_SOURCES.md`. Refreshed per the runbook in `PRICING_SOURCES.md`. Last updated: 2026-08-26.
 
 ---
 

--- a/PRICING_SOURCES.md
+++ b/PRICING_SOURCES.md
@@ -44,7 +44,7 @@ Copilot has three billing models depending on plan type and date.
 
 **Who it applies to:** All Copilot plans on the new billing model, default from June 1, 2026.
 
-**Source:** <https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing> (verified 2026-08-12)
+**Source:** <https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing> (verified 2026-08-26)
 
 **What this page provides:**
 
@@ -134,7 +134,13 @@ sessions; don't expect to re-verify them.
   `kimi-k2.7-code`, and `mai-code-1-flash` existed in `media/src/pricing.ts` (browser) but had never
   been added to `src/pricing.ts` (extension host) — a real sync gap, not a rate error, that made
   `cost_usd` store as `0` rather than the correct amount for any Copilot session using them. Fixed
-  2026-08-12; both files now match.
+  2026-08-12; both files now match. `grok-4.6` and `gemini-3.7-flash` added 2026-08-26, same basis
+  (new on the Copilot pricing page this refresh, slug guessed from display name) — added to both
+  files together this time, no sync gap introduced. `gemini-3.6-flash` was corrected the same pass:
+  its price dropped from $1.50/$0.15/$7.50 to $0.75/$0.075/$3.75, labeled on Copilot's page as
+  "promotional pricing through Dec 31, 2026" — the same promotional rate the new 3.7-flash launched
+  at. `gpt-5.6-cyber` also added 2026-08-26, confirmed on OpenAI's own API pricing page rather than
+  Copilot's (not yet independently confirmed as reachable through Copilot specifically).
 
 ---
 
@@ -146,7 +152,7 @@ Claude Code CLI uses Anthropic API token-based pricing only — no request-multi
 
 **Who it applies to:** All Claude Code CLI users billed through the Anthropic API.
 
-**Source:** <https://platform.claude.com/docs/en/about-claude/pricing> (verified 2026-08-12)
+**Source:** <https://platform.claude.com/docs/en/about-claude/pricing> (verified 2026-08-26 — every rate below re-checked and confirmed unchanged, including the Sonnet 5 introductory-pricing-now-permanent note and fast-mode model support)
 
 **Formula:**
 
@@ -175,7 +181,7 @@ On `claude_code.llm_request` spans (per-API-call):
 - `ttft_ms` — time to first token in ms
 - `stop_reason` — e.g. `tool_use`, `end_turn`
 
-**Rates (USD per 1M tokens, verified 2026-08-12):**
+**Rates (USD per 1M tokens, verified 2026-08-26 — every row below unchanged from the last check):**
 
 | Model                                                                  | Input  | Cache Write (5m) | Cache Write (1h) | Cache Read | Output  |
 | ----------------------------------------------------------------------- | ------ | ----------------- | ----------------- | ---------- | ------- |
@@ -283,27 +289,32 @@ On `session_task.turn` spans (per-turn aggregate):
 
 Model name available on `codex.user_prompt`, `codex.turn_ttft`, and `codex.tool_decision` spans via `model` attribute.
 
-**Rates (USD per 1M tokens, verified 2026-08-12):**
+**Rates (USD per 1M tokens, verified 2026-08-26):**
 
 | Model                   | Input   | Cached Input | Cache Write | Output  | Cache discount | Notes                                          |
 | ----------------------- | ------- | ------------ | ----------- | ------- | -------------- | ---------------------------------------------- |
-| `gpt-5.6-sol`           | $5.00   | $0.50        | $6.25       | $30.00  | 90%            | Flagship; same rate as gpt-5.5; long-context surcharge tier above 272K (2x input/cache, 1.5x output) |
+| `gpt-5.6-sol`           | $4.00   | $0.40        | $5.00       | $20.00  | 90%            | Flagship. Corrected 2026-08-26 (was $5.00/$0.50/$6.25/$30.00) — OpenAI's own page labels this "promotional pricing... at least through November 21, 2026," so re-check sooner than the usual cadence. Long-context surcharge tier above 272K (2x input/cache/cache-write, 1.5x output → $8.00/$0.80/$10.00/$30.00). Copilot separately layers its own extra 50% promotional discount on top of this figure for Copilot-sourced sessions specifically ($2.00/$0.20/$2.50/$10.00) — not modeled in `RATES` (one shared rate per model regardless of source agent); Copilot-sourced sessions will show roughly 2x their actual cost until that discount ends. |
+| `gpt-5.6-cyber`         | $12.50  | $1.25        | $15.625     | $75.00  | 90%            | Added 2026-08-26 — new on OpenAI's API pricing page. Short-context only; no long-context tier listed. |
 | `gpt-5.6-terra`         | $2.00   | $0.20        | $2.50       | $12.00  | 90%            | Mid tier. Long-context surcharge tier above 272K |
 | `gpt-5.6-luna`          | $0.20   | $0.02        | $0.25       | $1.20   | 90%            | Small/fast tier. Long-context surcharge tier above 200K (lower threshold than the rest of the 5.6 family) |
 | `gpt-5.5`               | $5.00   | $0.50        | —           | $30.00  | 90%            | Long-context surcharge tier above 272K |
 | `gpt-5.4`               | $2.50   | $0.25        | —           | $15.00  | 90%            | Long-context surcharge tier above 272K |
 | `gpt-5.4-mini`          | $0.75   | $0.075       | —           | $4.50   | 90%            |                                                 |
+| `gpt-5.4-nano`          | $0.20   | $0.02        | —           | $1.25   | 90%            |                                                 |
 | `gpt-5.3-codex`         | $1.75   | $0.175       | —           | $14.00  | 90%            | Deprecated — superseded by the GPT-5.6 family  |
 | `gpt-5.3-codex-spark`   | TBD     | TBD          | —           | TBD     | —              | Research preview; specialized low-latency hardware; not available in the API, no rates published |
 | `gpt-5.2`               | $1.75   | $0.175       | —           | $14.00  | 90%            | Deprecated                                     |
 | `gpt-5.1`               | $1.25   | $0.125       | —           | $10.00  | 90%            | Corrected 2026-08-07 (was $1.75/$14.00 — repriced down below gpt-5.2) |
-| `gpt-5.1-codex`         | $1.75   | $0.175       | —           | $14.00  | 90%            | Deprecated; not independently re-confirmed 2026-08-12 (see Known gaps) |
-| `gpt-5.1-codex-mini`    | $0.75   | $0.075       | —           | $4.50   | 90%            | Deprecated; not independently re-confirmed 2026-08-12 (see Known gaps) |
+| `gpt-5.1-codex`         | $1.75   | $0.175       | —           | $14.00  | 90%            | Deprecated; not independently re-confirmed since 2026-08-07 (see Known gaps) |
+| `gpt-5.1-codex-mini`    | $0.75   | $0.075       | —           | $4.50   | 90%            | Deprecated; not independently re-confirmed since 2026-08-07 (see Known gaps) |
+| `gpt-5`                 | $1.25   | $0.125       | —           | $10.00  | 90%            | Added 2026-08-26 — confirmed on OpenAI's general API pricing page; not independently confirmed as reachable through Codex CLI or Copilot specifically (see Known gaps) |
 | `gpt-4.1`               | $2.00   | $0.50        | —           | $8.00   | 75%            | Confirmed 2026-08-12 on OpenAI's general API pricing page (not currently on Copilot's own model list — see the Copilot section's Known gaps) |
 | `gpt-4.1-mini`          | $0.40   | $0.10        | —           | $1.60   | 75%            | Added 2026-08-12 — new to `RATES`, confirmed on the API pricing page |
+| `gpt-4.1-nano`          | $0.10   | $0.025       | —           | $0.40   | 75%            | Added 2026-08-26 — see Known gaps (same relevance caveat as `gpt-5` above) |
+| `gpt-5-nano`            | $0.05   | $0.005       | —           | $0.40   | 90%            | Added 2026-08-26 — see Known gaps (same relevance caveat as `gpt-5` above) |
 | `codex-mini-latest`     | $1.50   | $0.375       | —           | $6.00   | 75%            | Fine-tuned o4-mini; 200K ctx; deprecated       |
 
-**Credits to USD conversion:** Rates on the Codex CLI pricing page are expressed in credits. 1 USD = 25 credits — verify by checking `inputPerMTok × 25` against the listed credits figure for any current model (e.g. gpt-5.6-sol: $5.00 × 25 = 125 credits, matching the page).
+**Credits to USD conversion:** Rates on the Codex CLI pricing page are expressed in credits. 1 USD = 25 credits — verify by checking `inputPerMTok × 25` against the listed credits figure for any current model (e.g. gpt-5.6-sol: $4.00 × 25 = 100 credits, matching the page).
 
 **Known gaps:**
 
@@ -311,9 +322,19 @@ Model name available on `codex.user_prompt`, `codex.turn_ttft`, and `codex.tool_
 - Reasoning tokens (`codex.usage.reasoning_output_tokens`): included in `gen_ai.usage.output_tokens` and billed at the standard output rate per available data; verify against the official rate card once it's fetchable (see Sources above).
 - Which GPT-5.6 variant (Sol/Terra/Luna) is the actual default model invoked by plain `codex` CLI runs (as opposed to an explicit model flag) is not confirmed by public docs.
 - `gpt-5.1-codex`, `gpt-5.1-codex-mini`, `gpt-5.1-codex-max`: absent from the general API pricing
-  page during both the 2026-08-07 and 2026-08-12 refreshes (only base `gpt-5.1` is listed, and it
-  had in fact been repriced back on 2026-08-07). Left unchanged on the assumption they didn't move
-  — re-verify next refresh, ideally against the auth-gated rate card directly.
+  page during the 2026-08-07, 2026-08-12, and 2026-08-26 refreshes (only base `gpt-5.1` is listed,
+  and it had in fact been repriced back on 2026-08-07). Left unchanged on the assumption they didn't
+  move — re-verify next refresh, ideally against the auth-gated rate card directly.
+- `gpt-5`, `gpt-4.1-nano`, `gpt-5-nano`: added 2026-08-26 from OpenAI's general API pricing page, but
+  neither Copilot's nor Codex CLI's own docs mentioned any of them this pass — unconfirmed whether
+  they're actually reachable through either agent, or just present on the underlying API that
+  neither currently exposes. Added anyway per this file's own philosophy (a model that's never used
+  costs nothing to have listed); re-check relevance next pass rather than remove speculatively.
+- `gpt-5.6-sol`: OpenAI's own page describes the current rate as promotional, guaranteed only through
+  November 21, 2026 — re-check before then even if the usual refresh cadence wouldn't otherwise
+  trigger it. Copilot's additional 50%-off layer on top of this rate isn't modeled (see the rate
+  table row above) — sessions sourced from Copilot specifically will overstate cost by roughly 2x for
+  this model until that promotion ends.
 
 ---
 
@@ -325,7 +346,7 @@ OpenCode uses token-based pricing for third-party models (routed through its pro
 
 **Who it applies to:** Users of OpenCode's built-in Zen model tier during each model's limited evaluation period.
 
-**Source:** <https://opencode.ai/docs/zen/> (verified 2026-08-12)
+**Source:** <https://opencode.ai/docs/zen/> (verified 2026-08-26)
 
 **Rates:** $0 — free during evaluation. All token fields (`inputPerMTok`, `cacheReadPerMTok`, `cacheWritePerMTok`, `outputPerMTok`) are set to 0 in the rate table.
 
@@ -340,6 +361,16 @@ OpenCode uses token-based pricing for third-party models (routed through its pro
 
 - All of the above are free "during limited evaluation" — any may become paid in the future. Check the source URL and update `RATES` when rates are published.
 - Two models previously listed in this file's Known gaps — **North Mini Code Free** and **LongCat-2.0 Free** — were not found on the Zen docs page during the 2026-08-12 refresh. Unclear whether they were renamed, retired, or just missed by this pass; not removed from anywhere since they were never added to `RATES` in the first place. Re-check next refresh.
+- **`deepseek-v4-flash-free`, `laguna-s-2.1-free`, `ling-3.0-tiny-free`** — added just last refresh
+  (2026-08-12) — did not turn up in the 2026-08-26 pass either. Same treatment as North Mini Code
+  Free / LongCat-2.0 Free above: not removed from `RATES` (they're $0 either way, so an incorrect
+  "still listed" costs nothing), genuinely unclear whether retired or just missed. Re-check next
+  refresh with a direct read of the page rather than a summarized fetch, since this is now two
+  refreshes in a row where free-model visibility on this specific page has been inconsistent.
+- **A new free model, "Muse Spark 1.2 Contributor Free,"** appeared on the Zen docs page this pass.
+  Not added to `RATES` — unlike the marketplace-model slug-guessing precedent elsewhere in this file
+  (safe because a wrong guess just shows `~$?`), this one's exact telemetry-ready ID wasn't confirmed
+  closely enough this pass to guess reasonably. Add next refresh once the exact slug is confirmed.
 - OpenCode Zen also lists 40+ paid third-party models (GPT, Claude, Gemini, Grok, DeepSeek, Qwen, MiniMax, GLM, Kimi families) not covered here — those are billed by the underlying provider at standard rates; AgentLens applies the provider's published rates for those models automatically via the existing per-provider entries in `RATES` (not OpenCode-specific ones).
 - Other models used through OpenCode (e.g. Anthropic, OpenAI, or Google models routed via OpenCode's provider abstraction) are billed by the underlying provider at their standard rates. AgentLens applies the provider's published rates for those models automatically.
 

--- a/PRICING_SOURCES.md
+++ b/PRICING_SOURCES.md
@@ -30,8 +30,18 @@ and revert independently if a source turns out to have been misread.
      sections below and drive the "verified `<date>`" text shown on the in-app Pricing page itself
    - `ARCHITECTURE.md`'s "Cost Calculation" section — it has its own "Last updated: `<date>`" line
      independent of the two constants above (found missed once already; check it every time)
-5. Run `tsc --noEmit` (both configs), `eslint src media/src`, and `mocha` to confirm nothing broke.
-6. If a rate or model can't be confirmed from a source, add it to that section's "Known gaps"
+5. If a source explicitly labels a rate as promotional/temporary (its own wording, not your
+   inference), set `promoNote` on that model's entry in `media/src/pricing.ts` — free text, quote
+   or closely paraphrase the source's own wording including any stated end date (e.g. `'OpenAI:
+   promotional pricing, at least through Nov 21, 2026'`). This surfaces as a hover-note `‡` marker
+   next to the model name on the in-app Pricing page. Deliberately not a computed
+   expiration/start-stop date — vendors don't reliably honor their own stated windows, so don't
+   build logic that treats the note as expired once its date passes; just re-verify the rate (and
+   the note) at the next refresh like any other rate, regardless of whether the stated window has
+   technically ended. Clear `promoNote` only once a source confirms the rate is no longer
+   promotional (folded into the standard rate, or reverted).
+6. Run `tsc --noEmit` (both configs), `eslint src media/src`, and `mocha` to confirm nothing broke.
+7. If a rate or model can't be confirmed from a source, add it to that section's "Known gaps"
    instead of guessing.
 
 ---

--- a/media/src/pricing.ts
+++ b/media/src/pricing.ts
@@ -2,7 +2,7 @@
 // Token rates (post Jun 1, 2026):        https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing
 // Request multipliers (pre Jun 1, 2026): https://docs.github.com/en/copilot/concepts/billing/copilot-requests
 // Annual-plan multipliers (post Jun 1):  https://docs.github.com/en/copilot/reference/copilot-billing/model-multipliers-for-annual-plans
-export const PRICING_LAST_UPDATED = '2026-08-12'
+export const PRICING_LAST_UPDATED = '2026-08-26'
 
 // Three billing modes:
 //   'token'          — new token-based AI Credits billing, effective Jun 1, 2026
@@ -66,7 +66,21 @@ export const RATES: Record<string, ModelRates> = {
   // output per Copilot's docs) — not implemented; see PRICING_SOURCES.md Known gaps.
   'gpt-5.6-luna':        { inputPerMTok: 0.20,  cacheReadPerMTok: 0.02,   cacheWritePerMTok: 0.25, outputPerMTok: 1.20,  multiplier: 0,    multiplierAnnualPostJun1: 0 },
   'gpt-5.6-terra':       { inputPerMTok: 2.00,  cacheReadPerMTok: 0.20,   cacheWritePerMTok: 2.50, outputPerMTok: 12.00, multiplier: 0,    multiplierAnnualPostJun1: 0 },
-  'gpt-5.6-sol':         { inputPerMTok: 5.00,  cacheReadPerMTok: 0.50,   cacheWritePerMTok: 6.25, outputPerMTok: 30.00, multiplier: 0,    multiplierAnnualPostJun1: 0 },
+  // gpt-5.6-sol: corrected 2026-08-26 — OpenAI's own API page dropped this from $5.00/$0.50/$6.25/$30.00 to
+  // $4.00/$0.40/$5.00/$20.00, noted on the source page as "promotional pricing... at least through November 21,
+  // 2026." Copilot additionally layers its own extra 50% promotional discount on top of this for Copilot-sourced
+  // sessions specifically ($2.00/$0.20/$2.50/$10.00) — not modeled here (one shared rate per model regardless of
+  // source agent, same as everywhere else in this file); see PRICING_SOURCES.md Known gaps.
+  'gpt-5.6-sol':         { inputPerMTok: 4.00,  cacheReadPerMTok: 0.40,   cacheWritePerMTok: 5.00, outputPerMTok: 20.00, multiplier: 0,    multiplierAnnualPostJun1: 0 },
+  // gpt-5.6-cyber: added 2026-08-26 — new on OpenAI's API pricing page.
+  'gpt-5.6-cyber':       { inputPerMTok: 12.50, cacheReadPerMTok: 1.25,   cacheWritePerMTok: 15.625, outputPerMTok: 75.00, multiplier: 0,  multiplierAnnualPostJun1: 0 },
+  // gpt-4.1-nano, gpt-5-nano, gpt-5 (base): added 2026-08-26 — confirmed on OpenAI's general API pricing page, not
+  // independently confirmed as reachable through Copilot specifically this pass.
+  'gpt-4.1-nano':        { inputPerMTok: 0.10,  cacheReadPerMTok: 0.025,  cacheWritePerMTok: 0, outputPerMTok: 0.40,  multiplier: 0,    multiplierAnnualPostJun1: 0 },
+  'gpt-5-nano':          { inputPerMTok: 0.05,  cacheReadPerMTok: 0.005,  cacheWritePerMTok: 0, outputPerMTok: 0.40,  multiplier: 0,    multiplierAnnualPostJun1: 0 },
+  // gpt-5 (base) predates the token-billing cutover, so it likely has a real legacy multiplier — left at 0 rather
+  // than guessed; re-check against the legacy/annual multiplier pages next pass if it turns up in real telemetry.
+  'gpt-5':               { inputPerMTok: 1.25,  cacheReadPerMTok: 0.125,  cacheWritePerMTok: 0, outputPerMTok: 10.00, multiplier: 0,    multiplierAnnualPostJun1: 0 },
   // ── Codex-only models ──────────────────────────────────────────────────────────────────────────
   // codex-mini-latest: fine-tuned o4-mini; 75% cache discount (not the usual 90%); deprecated
   'codex-mini-latest':   { inputPerMTok: 1.50,  cacheReadPerMTok: 0.375,  cacheWritePerMTok: 0, outputPerMTok: 6.00,  multiplier: 0,    multiplierAnnualPostJun1: 0 },
@@ -112,8 +126,11 @@ export const RATES: Record<string, ModelRates> = {
   'gemini-3-pro':     { inputPerMTok: 2.00, cacheReadPerMTok: 0.20,  cacheWritePerMTok: 0, outputPerMTok: 12.00, multiplier: 1,    multiplierAnnualPostJun1: 6 },
   'gemini-3.1-pro':   { inputPerMTok: 2.00, cacheReadPerMTok: 0.20,  cacheWritePerMTok: 0, outputPerMTok: 12.00, multiplier: 1,    multiplierAnnualPostJun1: 6 },  // long-context surcharge (>200K tokens) not implemented
   'gemini-3.5-flash': { inputPerMTok: 1.50, cacheReadPerMTok: 0.15,  cacheWritePerMTok: 0, outputPerMTok: 9.00,  multiplier: 14,   multiplierAnnualPostJun1: 14 },
-  // gemini-3.6-flash: added 2026-08-07, new on the Copilot pricing page. Not yet on the annual multiplier page.
-  'gemini-3.6-flash': { inputPerMTok: 1.50, cacheReadPerMTok: 0.15,  cacheWritePerMTok: 0, outputPerMTok: 7.50,  multiplier: 0,    multiplierAnnualPostJun1: 0 },
+  // gemini-3.6-flash: corrected 2026-08-26 — was $1.50/$0.15/$7.50, Copilot's pricing page now shows
+  // $0.75/$0.075/$3.75, labeled "promotional pricing through Dec 31, 2026."
+  'gemini-3.6-flash': { inputPerMTok: 0.75, cacheReadPerMTok: 0.075, cacheWritePerMTok: 0, outputPerMTok: 3.75,  multiplier: 0,    multiplierAnnualPostJun1: 0 },
+  // gemini-3.7-flash: added 2026-08-26 — new on the Copilot pricing page, same promotional rate as 3.6-flash above.
+  'gemini-3.7-flash': { inputPerMTok: 0.75, cacheReadPerMTok: 0.075, cacheWritePerMTok: 0, outputPerMTok: 3.75,  multiplier: 0,    multiplierAnnualPostJun1: 0 },
   // ── Fine-tuned ─────────────────────────────────────────────────────────────────────────────────
   // raptor-mini: no longer included/$0 as of 2026-07-19 — now billed at the same standard rate as gpt-5-mini.
   'raptor-mini': { inputPerMTok: 0.25, cacheReadPerMTok: 0.025, cacheWritePerMTok: 0, outputPerMTok: 2.00,  multiplier: 0, multiplierAnnualPostJun1: 0.33 },
@@ -130,6 +147,8 @@ export const RATES: Record<string, ModelRates> = {
   // the Copilot docs display name, matching the existing naming convention) — a wrong guess fails safe (falls
   // back to ~$? rather than mis-pricing), same risk tolerance as the OpenCode Zen free-model gaps below.
   'grok-4.5':         { inputPerMTok: 2.00, cacheReadPerMTok: 0.50,  cacheWritePerMTok: 0, outputPerMTok: 6.00, multiplier: 0, multiplierAnnualPostJun1: 0 },
+  // grok-4.6: added 2026-08-26 — new on the Copilot pricing page, same rate as grok-4.5.
+  'grok-4.6':         { inputPerMTok: 2.00, cacheReadPerMTok: 0.50,  cacheWritePerMTok: 0, outputPerMTok: 6.00, multiplier: 0, multiplierAnnualPostJun1: 0 },
   'kimi-k3':          { inputPerMTok: 3.00, cacheReadPerMTok: 0.30,  cacheWritePerMTok: 0, outputPerMTok: 15.00, multiplier: 0, multiplierAnnualPostJun1: 0 },
   // ── OpenCode Zen  https://opencode.ai/docs/zen/ ────────────────────────────
   // big-pickle: OpenCode's stealth model, free during limited evaluation period.
@@ -161,22 +180,22 @@ export interface PricingSection {
 export const PRICING_SECTIONS: PricingSection[] = [
   {
     label: 'OpenAI (GPT / Codex family)',
-    verified: '2026-08-12',
+    verified: '2026-08-26',
     sources: [
       { label: 'Copilot model pricing', url: 'https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing' },
       { label: 'OpenAI API pricing', url: 'https://developers.openai.com/api/docs/pricing' },
       { label: 'Codex CLI pricing', url: 'https://learn.chatgpt.com/docs/pricing' },
     ],
     modelKeys: [
-      'gpt-4.1', 'gpt-4.1-mini', 'gpt-5-mini', 'gpt-5 mini', 'gpt-4o', 'gpt-4o-mini',
+      'gpt-4.1', 'gpt-4.1-mini', 'gpt-4.1-nano', 'gpt-5', 'gpt-5-nano', 'gpt-5-mini', 'gpt-5 mini', 'gpt-4o', 'gpt-4o-mini',
       'gpt-5.1', 'gpt-5.1-codex', 'gpt-5.1-codex-mini', 'gpt-5.1-codex-max',
       'gpt-5.2', 'gpt-5.2-codex', 'gpt-5.3-codex', 'gpt-5.4', 'gpt-5.4-mini', 'gpt-5.4-nano',
-      'gpt-5.5', 'gpt-5.6-luna', 'gpt-5.6-terra', 'gpt-5.6-sol', 'codex-mini-latest',
+      'gpt-5.5', 'gpt-5.6-luna', 'gpt-5.6-terra', 'gpt-5.6-sol', 'gpt-5.6-cyber', 'codex-mini-latest',
     ],
   },
   {
     label: 'Anthropic (Claude)',
-    verified: '2026-08-12',
+    verified: '2026-08-26',
     sources: [
       { label: 'Anthropic API pricing', url: 'https://platform.claude.com/docs/en/about-claude/pricing' },
       { label: 'Copilot model pricing', url: 'https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing' },
@@ -191,23 +210,23 @@ export const PRICING_SECTIONS: PricingSection[] = [
   },
   {
     label: 'Google (Gemini)',
-    verified: '2026-08-12',
+    verified: '2026-08-26',
     sources: [
       { label: 'Copilot model pricing', url: 'https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing' },
     ],
-    modelKeys: ['gemini-2.5-pro', 'gemini-3-flash', 'gemini-3-pro', 'gemini-3.1-pro', 'gemini-3.5-flash', 'gemini-3.6-flash'],
+    modelKeys: ['gemini-2.5-pro', 'gemini-3-flash', 'gemini-3-pro', 'gemini-3.1-pro', 'gemini-3.5-flash', 'gemini-3.6-flash', 'gemini-3.7-flash'],
   },
   {
     label: 'Fine-tuned & other Copilot-marketplace models',
-    verified: '2026-08-12',
+    verified: '2026-08-26',
     sources: [
       { label: 'Copilot model pricing', url: 'https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing' },
     ],
-    modelKeys: ['raptor-mini', 'goldeneye', 'mai-code-1-flash', 'mai-code-1.1-flash', 'kimi-k2.7-code', 'grok-4.5', 'kimi-k3'],
+    modelKeys: ['raptor-mini', 'goldeneye', 'mai-code-1-flash', 'mai-code-1.1-flash', 'kimi-k2.7-code', 'grok-4.5', 'grok-4.6', 'kimi-k3'],
   },
   {
     label: 'OpenCode Zen (free evaluation models)',
-    verified: '2026-08-12',
+    verified: '2026-08-26',
     sources: [
       { label: 'OpenCode Zen docs', url: 'https://opencode.ai/docs/zen/' },
     ],

--- a/media/src/pricing.ts
+++ b/media/src/pricing.ts
@@ -24,6 +24,13 @@ export interface ModelRates {
   outputAbove200kPerMTok?: number
   cacheReadAbove200kPerMTok?: number
   cacheWriteAbove200kPerMTok?: number
+  // Set when a source explicitly labels this rate as temporary/promotional rather than the vendor's
+  // standard price. Free-text, vendor's own wording — deliberately NOT a machine-checked expiration
+  // date. Vendors don't reliably honor their own stated end dates (see claude-sonnet-5's cancelled
+  // Sept 1 2026 increase below), so computing "is this still active" would assert a certainty the
+  // refresh process can't back up. Displayed as-is on the in-app Pricing page; re-verify promotional
+  // rates at the next refresh regardless of whether their stated window has technically passed.
+  promoNote?: string
 }
 
 // Keyed by normalized model ID (lowercase, no date suffix).
@@ -71,7 +78,8 @@ export const RATES: Record<string, ModelRates> = {
   // 2026." Copilot additionally layers its own extra 50% promotional discount on top of this for Copilot-sourced
   // sessions specifically ($2.00/$0.20/$2.50/$10.00) — not modeled here (one shared rate per model regardless of
   // source agent, same as everywhere else in this file); see PRICING_SOURCES.md Known gaps.
-  'gpt-5.6-sol':         { inputPerMTok: 4.00,  cacheReadPerMTok: 0.40,   cacheWritePerMTok: 5.00, outputPerMTok: 20.00, multiplier: 0,    multiplierAnnualPostJun1: 0 },
+  'gpt-5.6-sol':         { inputPerMTok: 4.00,  cacheReadPerMTok: 0.40,   cacheWritePerMTok: 5.00, outputPerMTok: 20.00, multiplier: 0,    multiplierAnnualPostJun1: 0,
+                           promoNote: 'OpenAI: promotional pricing, at least through Nov 21, 2026' },
   // gpt-5.6-cyber: added 2026-08-26 — new on OpenAI's API pricing page.
   'gpt-5.6-cyber':       { inputPerMTok: 12.50, cacheReadPerMTok: 1.25,   cacheWritePerMTok: 15.625, outputPerMTok: 75.00, multiplier: 0,  multiplierAnnualPostJun1: 0 },
   // gpt-4.1-nano, gpt-5-nano, gpt-5 (base): added 2026-08-26 — confirmed on OpenAI's general API pricing page, not
@@ -128,9 +136,11 @@ export const RATES: Record<string, ModelRates> = {
   'gemini-3.5-flash': { inputPerMTok: 1.50, cacheReadPerMTok: 0.15,  cacheWritePerMTok: 0, outputPerMTok: 9.00,  multiplier: 14,   multiplierAnnualPostJun1: 14 },
   // gemini-3.6-flash: corrected 2026-08-26 — was $1.50/$0.15/$7.50, Copilot's pricing page now shows
   // $0.75/$0.075/$3.75, labeled "promotional pricing through Dec 31, 2026."
-  'gemini-3.6-flash': { inputPerMTok: 0.75, cacheReadPerMTok: 0.075, cacheWritePerMTok: 0, outputPerMTok: 3.75,  multiplier: 0,    multiplierAnnualPostJun1: 0 },
+  'gemini-3.6-flash': { inputPerMTok: 0.75, cacheReadPerMTok: 0.075, cacheWritePerMTok: 0, outputPerMTok: 3.75,  multiplier: 0,    multiplierAnnualPostJun1: 0,
+                        promoNote: 'Copilot: promotional pricing through Dec 31, 2026' },
   // gemini-3.7-flash: added 2026-08-26 — new on the Copilot pricing page, same promotional rate as 3.6-flash above.
-  'gemini-3.7-flash': { inputPerMTok: 0.75, cacheReadPerMTok: 0.075, cacheWritePerMTok: 0, outputPerMTok: 3.75,  multiplier: 0,    multiplierAnnualPostJun1: 0 },
+  'gemini-3.7-flash': { inputPerMTok: 0.75, cacheReadPerMTok: 0.075, cacheWritePerMTok: 0, outputPerMTok: 3.75,  multiplier: 0,    multiplierAnnualPostJun1: 0,
+                        promoNote: 'Copilot: promotional pricing through Dec 31, 2026' },
   // ── Fine-tuned ─────────────────────────────────────────────────────────────────────────────────
   // raptor-mini: no longer included/$0 as of 2026-07-19 — now billed at the same standard rate as gpt-5-mini.
   'raptor-mini': { inputPerMTok: 0.25, cacheReadPerMTok: 0.025, cacheWritePerMTok: 0, outputPerMTok: 2.00,  multiplier: 0, multiplierAnnualPostJun1: 0.33 },

--- a/media/src/tabs/Pricing.tsx
+++ b/media/src/tabs/Pricing.tsx
@@ -37,6 +37,7 @@ function SourceLinks({ sources }: { sources: { label: string; url: string }[] })
 function RatesTable({ modelKeys }: { modelKeys: string[] }) {
   const hasTier = (r: ModelRates) => r.inputAbove200kPerMTok !== undefined
   const anyTiered = modelKeys.some(k => RATES[k] && hasTier(RATES[k]))
+  const anyPromo = modelKeys.some(k => RATES[k] && RATES[k].promoNote)
 
   return (
     <>
@@ -58,7 +59,11 @@ function RatesTable({ modelKeys }: { modelKeys: string[] }) {
             if (!r) return null
             return (
               <tr key={key}>
-                <td style={tdBold}>{key}{hasTier(r) ? <sup style="margin-left:2px;color:var(--muted)">†</sup> : null}</td>
+                <td style={tdBold}>
+                  {key}
+                  {hasTier(r) ? <sup style="margin-left:2px;color:var(--muted)">†</sup> : null}
+                  {r.promoNote ? <sup title={r.promoNote} style="margin-left:2px;color:var(--muted);cursor:help">‡</sup> : null}
+                </td>
                 <td style={tdNum}>{fmtRate(r.inputPerMTok)}</td>
                 <td style={tdNum}>{fmtRate(r.cacheReadPerMTok)}</td>
                 <td style={tdNum}>{fmtRate(r.cacheWritePerMTok)}</td>
@@ -73,6 +78,11 @@ function RatesTable({ modelKeys }: { modelKeys: string[] }) {
       {anyTiered && (
         <div style="font-size:10px;color:var(--muted);margin:-4px 0 12px">
           † Tiered — a higher rate applies above 200K tokens in a single call. Not broken out in this table; see <code>PRICING_SOURCES.md</code> for the full tier.
+        </div>
+      )}
+      {anyPromo && (
+        <div style="font-size:10px;color:var(--muted);margin:-4px 0 12px">
+          ‡ Promotional pricing — hover the marker for the vendor's own note on the rate and its stated window. Not guaranteed permanent; see <code>PRICING_SOURCES.md</code> for details.
         </div>
       )}
     </>

--- a/src/pricing.ts
+++ b/src/pricing.ts
@@ -1,6 +1,6 @@
 // Pricing data for extension-host cost computation (cost_usd stored in sessions table).
 // Rate table is kept in sync with media/src/pricing.ts — update both when rates change.
-// PRICING_LAST_UPDATED: 2026-08-12
+// PRICING_LAST_UPDATED: 2026-08-26
 
 export interface ModelRates {
   inputPerMTok: number
@@ -62,15 +62,36 @@ const RATES: Record<string, ModelRates> = {
   'gpt-5.6-terra':      { inputPerMTok: 2.00,  cacheReadPerMTok: 0.20,   cacheWritePerMTok: 2.50, outputPerMTok: 12.00, contextWindowTokens: 256_000,
                           longContextThresholdTokens: 272_000,
                           inputAboveThresholdPerMTok: 4.00, cacheReadAboveThresholdPerMTok: 0.40, cacheWriteAboveThresholdPerMTok: 5.00, outputAboveThresholdPerMTok: 18.00 },
-  'gpt-5.6-sol':        { inputPerMTok: 5.00,  cacheReadPerMTok: 0.50,   cacheWritePerMTok: 6.25, outputPerMTok: 30.00, contextWindowTokens: 256_000,
+  // gpt-5.6-sol: corrected 2026-08-26 — OpenAI's own API page dropped this from $5.00/$0.50/$6.25/$30.00 to
+  // $4.00/$0.40/$5.00/$20.00 (long-context tier $10.00/$1.00/$12.50/$45.00 → $8.00/$0.80/$10.00/$30.00), noted on
+  // the source page as "promotional pricing... at least through November 21, 2026" — re-check sooner than usual.
+  // Copilot additionally layers its own extra 50% promotional discount on top of this for Copilot-sourced sessions
+  // specifically ($2.00/$0.20/$2.50/$10.00) — not modeled here, since RATES has one shared rate per model
+  // regardless of source agent; see PRICING_SOURCES.md Known gaps. Codex/API-sourced sessions price correctly;
+  // Copilot-sourced sessions using this model will show roughly 2x their actual cost until that discount ends.
+  'gpt-5.6-sol':        { inputPerMTok: 4.00,  cacheReadPerMTok: 0.40,   cacheWritePerMTok: 5.00, outputPerMTok: 20.00, contextWindowTokens: 256_000,
                           longContextThresholdTokens: 272_000,
-                          inputAboveThresholdPerMTok: 10.00, cacheReadAboveThresholdPerMTok: 1.00, cacheWriteAboveThresholdPerMTok: 12.50, outputAboveThresholdPerMTok: 45.00 },
+                          inputAboveThresholdPerMTok: 8.00, cacheReadAboveThresholdPerMTok: 0.80, cacheWriteAboveThresholdPerMTok: 10.00, outputAboveThresholdPerMTok: 30.00 },
+  // gpt-5.6-cyber: added 2026-08-26 — new on OpenAI's API pricing page. Short-context only; no long-context tier
+  // listed on the source page (unlike the rest of the 5.6 family).
+  'gpt-5.6-cyber':      { inputPerMTok: 12.50, cacheReadPerMTok: 1.25,   cacheWritePerMTok: 15.625, outputPerMTok: 75.00, contextWindowTokens: 0 },
+  // gpt-4.1-nano, gpt-5-nano, gpt-5 (base): added 2026-08-26 — confirmed on OpenAI's general API pricing page, but
+  // not independently confirmed as reachable through Copilot or Codex CLI specifically (neither's own docs
+  // mentioned them this pass). Added on this file's existing philosophy that a model which never appears in
+  // telemetry costs nothing to have listed, while one that does and isn't listed silently shows ~$?.
+  'gpt-4.1-nano':       { inputPerMTok: 0.10,  cacheReadPerMTok: 0.025,  cacheWritePerMTok: 0, outputPerMTok: 0.40,  contextWindowTokens: 1_000_000 },
+  'gpt-5-nano':         { inputPerMTok: 0.05,  cacheReadPerMTok: 0.005,  cacheWritePerMTok: 0, outputPerMTok: 0.40,  contextWindowTokens: 0 },
+  'gpt-5':              { inputPerMTok: 1.25,  cacheReadPerMTok: 0.125,  cacheWritePerMTok: 0, outputPerMTok: 10.00, contextWindowTokens: 0 },
   // ── Copilot marketplace third-party models ──────────────────────────────────
   // These four were already present in media/src/pricing.ts (browser-side) but missing here — a real sync gap
   // that made cost_usd store as 0 (not ~$?) for any Copilot session using them, silently under-reporting rather
   // than flagging as unknown. Added 2026-08-12 to restore parity; rates confirmed against the Copilot pricing page.
   // grok-4.5: long-context surcharge above 200K tokens/call confirmed 2026-08-12 (2x input/cache-read, 1.5x output).
   'grok-4.5':           { inputPerMTok: 2.00,  cacheReadPerMTok: 0.50,   cacheWritePerMTok: 0, outputPerMTok: 6.00,  contextWindowTokens: 0,
+                          longContextThresholdTokens: 200_000,
+                          inputAboveThresholdPerMTok: 4.00, cacheReadAboveThresholdPerMTok: 1.00, outputAboveThresholdPerMTok: 12.00 },
+  // grok-4.6: added 2026-08-26 — new on the Copilot pricing page, same rate structure as grok-4.5.
+  'grok-4.6':           { inputPerMTok: 2.00,  cacheReadPerMTok: 0.50,   cacheWritePerMTok: 0, outputPerMTok: 6.00,  contextWindowTokens: 0,
                           longContextThresholdTokens: 200_000,
                           inputAboveThresholdPerMTok: 4.00, cacheReadAboveThresholdPerMTok: 1.00, outputAboveThresholdPerMTok: 12.00 },
   'kimi-k3':            { inputPerMTok: 3.00,  cacheReadPerMTok: 0.30,   cacheWritePerMTok: 0, outputPerMTok: 15.00, contextWindowTokens: 0 },
@@ -121,8 +142,11 @@ const RATES: Record<string, ModelRates> = {
                        longContextThresholdTokens: 200_000,
                        inputAboveThresholdPerMTok: 4.00, cacheReadAboveThresholdPerMTok: 0.40, outputAboveThresholdPerMTok: 18.00 },
   'gemini-3.5-flash':{ inputPerMTok: 1.50, cacheReadPerMTok: 0.15,  cacheWritePerMTok: 0, outputPerMTok:  9.00, contextWindowTokens: 1_000_000 },
-  // gemini-3.6-flash: added 2026-08-07, new on the Copilot pricing page.
-  'gemini-3.6-flash':{ inputPerMTok: 1.50, cacheReadPerMTok: 0.15,  cacheWritePerMTok: 0, outputPerMTok:  7.50, contextWindowTokens: 1_000_000 },
+  // gemini-3.6-flash: corrected 2026-08-26 — was $1.50/$0.15/$7.50, Copilot's pricing page now shows
+  // $0.75/$0.075/$3.75, labeled "promotional pricing through Dec 31, 2026."
+  'gemini-3.6-flash':{ inputPerMTok: 0.75, cacheReadPerMTok: 0.075, cacheWritePerMTok: 0, outputPerMTok:  3.75, contextWindowTokens: 1_000_000 },
+  // gemini-3.7-flash: added 2026-08-26 — new on the Copilot pricing page, same promotional rate as 3.6-flash above.
+  'gemini-3.7-flash':{ inputPerMTok: 0.75, cacheReadPerMTok: 0.075, cacheWritePerMTok: 0, outputPerMTok:  3.75, contextWindowTokens: 1_000_000 },
   // ── Fine-tuned ─────────────────────────────────────────────────────────────
   // raptor-mini: no longer an included/$0 model as of the 2026-07-19 Copilot pricing page — now billed at standard rates.
   'raptor-mini': { inputPerMTok: 0.25, cacheReadPerMTok: 0.025, cacheWritePerMTok: 0, outputPerMTok:  2.00,  contextWindowTokens: 0 },


### PR DESCRIPTION
## Summary

**Pricing refresh** (per `PRICING_SOURCES.md`'s runbook, last verified 2026-08-12):

- `gpt-5.6-sol` price dropped: OpenAI's own pricing page now shows $4.00/$0.40/$5.00/$20.00 short-context (down from $5.00/$0.50/$6.25/$30.00), $8.00/$0.80/$10.00/$30.00 long-context (>272K). Page labels this "promotional pricing... at least through November 21, 2026."
- `gemini-3.6-flash` price dropped: $1.50/$0.15/—/$7.50 → $0.75/$0.075/—/$3.75, labeled "promotional pricing through Dec 31, 2026" on Copilot's page.
- New models added: `gpt-5.6-cyber`, `gemini-3.7-flash`, `grok-4.6`, `gpt-4.1-nano`, `gpt-5-nano`, `gpt-5` (base).
- Self-caught a scanning mistake during the refresh: initially flagged `gpt-5.4-nano` as a cross-file sync gap; it was already present in `src/pricing.ts`, just missed on a manual read. Caught by TypeScript's duplicate-key error before it shipped as a false finding.
- Unconfirmed items recorded as "Known gaps" in `PRICING_SOURCES.md` rather than guessed (a few OpenCode free-model visibility gaps, the Copilot-specific extra discount layered on top of `gpt-5.6-sol`).

**Promotional-pricing note** (built alongside, since the refresh surfaced two models vendors explicitly label as promotional/temporary):

- New `promoNote?: string` field on `ModelRates` — free text, vendor's own wording, deliberately **not** a computed expiration/start-stop date. Vendors don't reliably honor their own stated end dates (`gpt-5.6-sol`'s own page hedges with "at least"), so a computed window would assert a certainty the refresh process can't back up.
- Set on `gpt-5.6-sol`, `gemini-3.6-flash`, `gemini-3.7-flash`.
- Surfaced on the in-app Pricing page as a `‡` hover-note marker next to the model name, mirroring the existing `†` tiered-rate convention, with a footnote when any model in a table has one.
- Added as a new step in `PRICING_SOURCES.md`'s refresh runbook so future refreshes set this field when a source calls out promotional pricing.

## Test plan

- [x] `tsc --noEmit` (both configs) clean
- [x] `eslint src media/src` — 0 errors (pre-existing warnings only, none in touched files)
- [x] Full `mocha` suite — 273/273 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)