### PR TITLE
docs: name the copyright holder, state project scope, add a CLA

### DIFF
--- a/.github/CLA.md
+++ b/.github/CLA.md
@@ -1,0 +1,67 @@
+# AgentLens Individual Contributor License Agreement
+
+Thank you for your interest in contributing to AgentLens ("the Project"), maintained by Roger Reed
+("the Maintainer"). This is a short agreement covering the rights you grant when you contribute.
+It does not change your rights to use your own contribution however you like elsewhere — it only
+grants the Maintainer additional rights to use it, alongside the rights everyone already gets under
+the Project's MIT license.
+
+By commenting "I have read the CLA Document and I hereby sign the CLA" on a pull request, you agree
+to the terms below for that contribution and all future contributions you submit to this Project,
+unless you state otherwise in writing.
+
+## 1. Definitions
+
+**"You"** means the individual submitting a Contribution to the Project. **"Contribution"** means
+any original work of authorship, including code, documentation, or other material, that you
+intentionally submit to the Project for inclusion (e.g., via a pull request).
+
+## 2. Copyright license
+
+You grant the Maintainer a perpetual, worldwide, non-exclusive, royalty-free, irrevocable copyright
+license to reproduce, prepare derivative works of, publicly display, publicly perform, sublicense,
+and distribute your Contributions and derivative works thereof — including the right to relicense
+your Contribution, alone or as part of the Project, under any license terms the Maintainer chooses
+(open source or otherwise).
+
+This is the operative clause: it's what lets the Maintainer offer parts of the Project under a
+different license in the future (for example, a source-available license for a separately built
+team/enterprise product) without needing to track you down individually. Everything you contribute
+remains available to everyone under the Project's current MIT license as well — this grant adds
+rights, it doesn't take any away from how your own code can be used.
+
+## 3. Patent license
+
+You grant the Maintainer a perpetual, worldwide, non-exclusive, royalty-free, irrevocable patent
+license to make, have made, use, offer to sell, sell, import, and otherwise transfer your
+Contribution, for any patent claims you own or control that are necessarily infringed by your
+Contribution alone or in combination with the Project.
+
+## 4. Your representations
+
+You represent that:
+
+- Each Contribution is your original creation, or you have sufficient rights to submit it under the
+  terms of this agreement (for example, if a portion is based on other work, you have the right to
+  submit that portion).
+- Your Contribution does not, to your knowledge, violate any third party's copyrights, trademarks,
+  patents, or other intellectual property rights.
+- You are legally entitled to grant the above licenses — for example, if your employer has rights
+  to intellectual property you create, you have received permission to contribute on your
+  employer's behalf, or your employer has waived such rights for this Contribution.
+
+## 5. No warranty
+
+Contributions are provided "as is," without warranty of any kind, to the extent permitted by
+applicable law.
+
+## 6. Notice of inaccuracy
+
+You agree to notify the Maintainer if you become aware that any of the representations in Section 4
+are inaccurate for a Contribution you've already submitted.
+
+---
+
+*This document is a template, not a substitute for legal advice. It has not been reviewed by a
+lawyer. If you have questions about how it applies to you (particularly around employer IP rights),
+consult your own counsel before signing.*

--- a/.github/CLA.md
+++ b/.github/CLA.md
@@ -59,9 +59,3 @@ applicable law.
 
 You agree to notify the Maintainer if you become aware that any of the representations in Section 4
 are inaccurate for a Contribution you've already submitted.
-
----
-
-*This document is a template, not a substitute for legal advice. It has not been reviewed by a
-lawyer. If you have questions about how it applies to you (particularly around employer IP rights),
-consult your own counsel before signing.*

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,40 @@
+name: CLA Assistant
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, closed, synchronize]
+
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+  statuses: write
+
+jobs:
+  cla-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: CLA Assistant
+        if: >
+          (github.event.comment.body == 'recheck' ||
+           github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') ||
+          github.event_name == 'pull_request_target'
+        uses: contributor-assistant/github-action@v2.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_SIGNATURES_TOKEN }}
+        with:
+          path-to-signatures: signatures/cla.json
+          path-to-document: https://github.com/RogerReed/agentlens/blob/main/.github/CLA.md
+          branch: main
+          allowlist: RogerReed
+          custom-notsigned-prcomment: |
+            Thanks for this contribution! Before it can be merged, please read the
+            [Contributor License Agreement](https://github.com/RogerReed/agentlens/blob/main/.github/CLA.md)
+            and sign it by commenting on this pull request with:
+
+            > I have read the CLA Document and I hereby sign the CLA
+          custom-pr-sign-comment: I have read the CLA Document and I hereby sign the CLA
+          custom-allsigned-prcomment: All contributors have signed the CLA.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,6 +75,10 @@ node esbuild.js        # Bundle — outputs to dist/ and media/
 
 Please keep PRs focused on a single change. Large refactors should be discussed in an issue first.
 
+**Contributor License Agreement:** a bot will ask you to sign the
+[CLA](.github/CLA.md) on your first pull request — a one-time comment, no account or
+external service needed. PRs can't be merged until it's signed.
+
 ## Demo data and fixtures
 
 See [DEMO.md](DEMO.md) for generating synthetic demo sessions, capturing real telemetry as a fixture, and the redaction step required before committing any fixture file.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,20 @@
 
 Thank you for your interest in contributing.
 
+## Project scope
+
+AgentLens the local agent — everything in this repo — is MIT-licensed and stays that way. Features
+that make it more useful for a single developer watching their own sessions belong here, and PRs
+for them are welcome.
+
+A few features are out of scope for this repo, reserved for a separate, source-available team
+server built on top of the local agent: cross-machine session aggregation, SSO/SCIM, RBAC,
+multi-team rollup views, extended retention and audit export, and license-key issuance. That's the
+boundary that funds the project's continued development — not a hedge against contributions, and
+not a signal that those features are unwanted in general. If you'd like to work on something in
+that list, open an issue first so we can talk about where it should live before you spend time on
+the PR.
+
 ## Reporting bugs
 
 Open an issue at <https://github.com/rogerreed/agentlens/issues> and use the bug report template. Include:

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 AgentLens Contributors
+Copyright (c) 2026 Roger Reed
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Summary

Open-core groundwork: the decisions that get more expensive once there's a second contributor. Verified before writing: single contributor (Roger Reed, 530+ commits), MIT license with a placeholder copyright holder, no contributor agreement of any kind, no stated commercial scope.

- **Copyright line**: `LICENSE`'s `Copyright (c) 2026 AgentLens Contributors` named no legal person. Changed to `Copyright (c) 2026 Roger Reed`, matching the single verified contributor. Cheap now, awkward to fix later during a procurement review.
- **Commercial scope statement**: new "Project scope" section in `CONTRIBUTING.md`, right after the intro so it's the first thing a prospective contributor reads. States the local agent stays MIT, lists what's reserved for a future source-available team server (cross-machine aggregation, SSO/SCIM, RBAC, multi-team views, extended retention/audit, license keys), states the funding rationale plainly, and asks contributors to open an issue before starting work on anything in that list — the answer to "will you merge my SSO PR?" should exist before someone spends a weekend on it.
- **Contributor License Agreement**: without one, an outside contributor's code is MIT-licensed *from them*, and can't later be relicensed into a source-available tree without tracking that person down — a one-way door starting from the first merged PR. Added:
  - `.github/CLA.md` — individual CLA (copyright + patent grant, explicitly permits relicensing the Contribution under any license terms).
  - `.github/workflows/cla.yml` — self-hosted via `contributor-assistant/github-action` (not the hosted cla-assistant.io SaaS, which needs an interactive OAuth sign-in). Comments on PRs asking for sign-off, stores signatures as a JSON file committed back into the repo, no third-party service.
  - `CONTRIBUTING.md` — one-line pointer to it under "Submitting a pull request."

**Not included in this PR** (tracked separately): forward-payload identity for a future team server (blocked on `02-forwarding-infra.md`, which doesn't exist yet) and the free-tier telemetry position (decided as "no telemetry for now," tracked in its own staged doc, not repo-visible).

## Manual steps after merge (repo settings, not code)

1. `CLA_SIGNATURES_TOKEN` repo secret — already added.
2. Add `CLA Assistant / cla-check` as a required status check in `main`'s branch protection, so the CLA workflow actually blocks merge rather than just commenting.
3. Double-check the `allowlist: RogerReed` entry in `cla.yml` matches the account that owns this repo.

## Test plan

- [x] Docs/config only — no code paths affected, no build/test verification needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)