### PR TITLE
fix: forward riskSignals and temperedLoopSignals through the standalone relay

### DIFF
--- a/standalone/server.ts
+++ b/standalone/server.ts
@@ -1187,7 +1187,7 @@ function getHtml(): string {
               .then(function(r) { return r.json(); })
               .then(function(data) {
                 window.dispatchEvent(new MessageEvent('message', {
-                  data: { type: 'gitOutcome', sessionId: data.sessionId, outcome: data.outcome }
+                  data: { type: 'gitOutcome', sessionId: data.sessionId, outcome: data.outcome, riskSignals: data.riskSignals, temperedLoopSignals: data.temperedLoopSignals }
                 }));
               })
               .catch(function(e) { console.warn('[AgentLens] git outcome fetch failed', e); });


### PR DESCRIPTION
## Summary

Found during manual Playwright verification of the recently-merged loop-detector PRs: the standalone server's browser-side `acquireVsCodeApi` polyfill translates `postMessage({type: 'getGitOutcome', ...})` calls into a `fetch('/api/git-outcome')` and re-dispatches the response as a synthetic `message` event — but it only forwarded `outcome`, silently dropping `riskSignals` and `temperedLoopSignals`, which two recent PRs (#215, #216) each independently added to that endpoint's JSON response.

Not a regression from either PR individually — neither touched this relay when it added its field. Harmless today since nothing in the frontend currently consumes either field (confirmed: both were deliberately backend-only, with UI consumption explicitly deferred per their original design docs). But the VS Code webview path posts the full response object directly to the webview with no relay step in between, so this would have silently worked in VS Code and silently failed in standalone the moment someone builds UI consumption for either field.

One-line fix: forward both fields through the relay alongside `outcome`.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `eslint src media/src` — 0 errors
- [x] Full `mocha` suite — 340/340 passing
- [x] Manually verified in-browser (Playwright) that the auth flow, theme toggle, pricing promo notes, and this exact `/api/git-outcome` code path all work correctly on the merged `main` before finding this gap

🤖 Generated with [Claude Code](https://claude.com/claude-code)