### PR TITLE
fix: OTEL badge unreadable in light mode (white on white)

### DIFF
--- a/media/src/App.tsx
+++ b/media/src/App.tsx
@@ -646,13 +646,13 @@ function TimeRangePicker({ hideAgentFilter = false }: { hideAgentFilter?: boolea
 }
 
 const DATA_SOURCE_FILTER_OPTIONS: Array<{ value: DataSourceFilter; label: string; color: string; activeColor?: string }> = [
-  { value: 'all',  label: 'All',  color: 'var(--vscode-descriptionForeground,#888)', activeColor: '#ffffff' },
-  { value: 'otel', label: 'OTEL', color: '#ffffff' },
+  { value: 'all',  label: 'All',  color: 'var(--vscode-descriptionForeground,#888)', activeColor: 'var(--fg)' },
+  { value: 'otel', label: 'OTEL', color: 'var(--fg)' },
   { value: 'log',  label: 'Log',  color: '#90a4ae' },
 ]
 
 const INITIATOR_FILTER_OPTIONS: Array<{ value: InitiatorFilter; label: string; color: string; activeColor?: string }> = [
-  { value: 'all',   label: 'All',   color: 'var(--vscode-descriptionForeground,#888)', activeColor: '#ffffff' },
+  { value: 'all',   label: 'All',   color: 'var(--vscode-descriptionForeground,#888)', activeColor: 'var(--fg)' },
   { value: 'user',  label: 'User',  color: '#4a90d9' },
   { value: 'agent', label: 'Agent', color: '#b0bec5' },
   { value: 'api',   label: 'API',   color: '#90a4ae' },
@@ -668,6 +668,11 @@ function FilterPills<T extends string>({ options, value, onChange }: {
       {options.map(o => {
         const active = value === o.value
         const displayColor = (active && o.activeColor) ? o.activeColor : o.color
+        // Same fix as AGENT_FILTER_OPTIONS below: the alpha-blend trick only works on a literal
+        // hex color, and active text needs to follow the theme's own foreground rather than the
+        // option's own color, since a neutral var(--fg)/white color is illegible against a
+        // same-color-tinted background in light mode.
+        const activeBg = displayColor.startsWith('#') ? `${displayColor}33` : 'var(--hover)'
         return (
           <button
             key={o.value}
@@ -676,7 +681,7 @@ function FilterPills<T extends string>({ options, value, onChange }: {
               'padding:2px 7px;font-size:11px;cursor:pointer;border-radius:10px;transition:all 0.1s;',
               `border:1.5px solid ${displayColor};`,
               active
-                ? `background:${displayColor}33;color:${displayColor};font-weight:600`
+                ? `background:${activeBg};color:var(--fg);font-weight:600`
                 : 'background:transparent;color:var(--muted)',
             ].join('')}
             title={o.title}

--- a/media/src/utils.ts
+++ b/media/src/utils.ts
@@ -371,7 +371,7 @@ const DATA_SOURCE_TOOLTIP = {
 export function getDataSourceBadgeHtml(dataSource: 'otel' | 'log' | undefined): string {
   const ds = dataSource ?? 'otel'
   const label = ds === 'log' ? 'Log' : 'OTEL'
-  const color = ds === 'log' ? '#90a4ae' : '#ffffff'
+  const color = ds === 'log' ? '#90a4ae' : 'var(--fg)'
   const tooltip = DATA_SOURCE_TOOLTIP[ds]
   return `<span style="font-size:9px;font-weight:600;padding:1px 4px;border-radius:2px;border:1px solid ${color};color:${color};letter-spacing:0.03em;vertical-align:middle;cursor:default" title="${tooltip}">${label}</span>`
 }


### PR DESCRIPTION
## Summary

Reported: the OTEL badge in the session list is white on white in light mode, unreadable.

Same root cause as the agent-filter-pill bug fixed earlier this cycle: the OTEL data source's color was hardcoded `#ffffff` instead of a theme-aware value, so it was only ever readable against a dark background.

- `media/src/utils.ts`'s `getDataSourceBadgeHtml()` — the per-row "OTEL" badge shown next to every session — used `color: '#ffffff'` for its border and text. Changed to `var(--fg)`.
- `media/src/App.tsx`'s `DATA_SOURCE_FILTER_OPTIONS` — the "SOURCE" filter bar's OTEL pill — had the same hardcoded white, which becomes both the border color and (when selected) the text/background color via the shared `FilterPills` component. Same fix.
- `FilterPills` itself had the same class of bug already fixed once for the agent-filter pills but never applied here: the 20%-alpha-blend background trick is invalid CSS on a `var()` reference (`var(--fg)33` isn't a thing), and text color should always follow the theme's own foreground rather than the option's own color when active. Applied the same fix pattern already used for `AGENT_FILTER_OPTIONS`.
- Also fixed the identical hardcoded-white `activeColor` on `DATA_SOURCE_FILTER_OPTIONS`'s and `INITIATOR_FILTER_OPTIONS`'s `'all'` entries for consistency — same bug, not yet reported broken, but same fix already applied to `AGENT_FILTER_OPTIONS`'s `'all'` entry.

## Test plan

- [x] `tsc --noEmit` (both configs) clean
- [x] `eslint src media/src` — 0 errors
- [x] Full `mocha` suite — 340/340 passing
- [x] Manually verified in-browser (Playwright): both the per-row OTEL badge and the active SOURCE filter pill are clearly readable in light mode after the fix (screenshot confirmed dark border/text on light background)

🤖 Generated with [Claude Code](https://claude.com/claude-code)