### PR TITLE
fix: point CLA signature storage at a dedicated branch, not main

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -28,7 +28,9 @@ jobs:
         with:
           path-to-signatures: signatures/cla.json
           path-to-document: https://github.com/RogerReed/agentlens/blob/main/.github/CLA.md
-          branch: main
+          # Dedicated, unprotected branch for signature storage — main requires PRs, so the
+          # action's own commit of the signature record can't land there directly.
+          branch: cla-signatures
           allowlist: RogerReed
           custom-notsigned-prcomment: |
             Thanks for this contribution! Before it can be merged, please read the


### PR DESCRIPTION
## Summary

The `cla-check` workflow has been failing on every PR since it was merged (visible on PRs #221 and #222) with:

```
Error occurred when creating the signed contributors file: Could not create file: Changes must be made through a pull request.. Make sure the branch where signatures are stored is NOT protected.
```

`cla.yml` had `branch: main` telling the action to commit its signature record directly to `main` — but `main` has "require PRs" branch protection, so the bot's own direct commit is rejected every time. Not blocking today since it isn't configured as a required check yet, but it can never actually function as a gate until this is fixed.

Fix: created a dedicated `cla-signatures` branch (orphan, holds only `signatures/cla.json`, confirmed unprotected — this repo's branch protection is name-specific to `main`, not a wildcard pattern) and pointed the workflow's `branch:` at that instead.

## Test plan

- [x] Config-only change, no source touched — `build-and-test` CI unaffected
- [x] This PR's own `cla-check` run is the live test of the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)