### PR TITLE
fix: split log-sourced sessions on prompt boundaries (Claude Code, Codex, Copilot VS Code)

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -293,8 +293,10 @@ export async function activate(context: vscode.ExtensionContext) {
           let written = 0
           for (let i = idx; i < Math.min(idx + batchSize, files.length); i++) {
             try {
-              const result = lr.parseFile(files[i].filePath, files[i].agentKey)
-              if (result) {
+              // Usually one result; a Claude Code transcript split by a large gap between
+              // prompts (see splitClaudeLinesOnPromptGaps) can yield more than one.
+              const results = lr.parseFile(files[i].filePath, files[i].agentKey)
+              for (const result of results) {
                 result.card.loopSignals = detectLoopSignals(result.card)
                 result.card.oneShotStats = computeOneShotStats(result.card)
                 writer!.enqueue(result.card, result.workspace || ws)

--- a/src/logReader.ts
+++ b/src/logReader.ts
@@ -276,7 +276,7 @@ export class LogReader {
       case 'claude':              return this._processFileMulti(filePath, () => this._parseClaudeFile(filePath))
       case 'codex':               return this._processFileMulti(filePath, () => this._parseCodexFile(filePath))
       case 'copilot':             return _single(this._processFile(filePath, () => this._parseCopilotFile(filePath, sessionId)))
-      case 'copilot_vscode':      return _single(this._processFile(filePath, () => this._parseCopilotVSCodeFile(filePath, sessionId)))
+      case 'copilot_vscode':      return this._processFileMulti(filePath, () => this._parseCopilotVSCodeFile(filePath))
       case 'copilot_vscode_json': return _single(this._processFile(filePath, () => this._parseCopilotVSCodeJsonFile(filePath, sessionId)))
       case 'opencode':            return []  // OpenCode DB returns multiple sessions; use _scanOpenCode
       default:                    return []
@@ -785,9 +785,7 @@ export class LogReader {
           for (const name of names) {
             if (name.endsWith('.jsonl')) {
               const filePath = path.join(chatDir, name)
-              const sessionId = path.basename(filePath, '.jsonl')
-              const result = this._processFile(filePath, () => this._parseCopilotVSCodeFile(filePath, sessionId))
-              if (result) results.push(result)
+              results.push(...this._processFileMulti(filePath, () => this._parseCopilotVSCodeFile(filePath)))
             } else if (name.endsWith('.json') && !jsonlIds.has(name.slice(0, -5))) {
               const filePath = path.join(chatDir, name)
               const sessionId = path.basename(filePath, '.json')
@@ -801,11 +799,25 @@ export class LogReader {
     return results
   }
 
-  private _parseCopilotVSCodeFile(filePath: string, sessionId: string): LogSessionResult | null {
+  /** Reads a Copilot Chat (VS Code) transcript and splits it into one or more session results —
+   *  same one-file-can-span-real-days problem as Claude Code and Codex (confirmed on real data:
+   *  files spanning up to 121.7 real hours, one gap alone 61.5 hours). See
+   *  splitCopilotVSCodeLinesOnPromptGaps for what counts as a new prompt in this format. No
+   *  cumulative-counter issue like Codex's (this format's token counts are already keyed per-turn
+   *  index, not a running total) and no duplicate-uuid issue like Claude Code's found in this
+   *  format during validation — but a different wrinkle unique to this format: a `kind: 1` update
+   *  (e.g. `k: ["requests", N, "completionTokens"]`) addresses request N by its position in the
+   *  *whole session's* requests array, not a position relative to whichever segment it happens to
+   *  fall in. Re-parsing each segment's lines starting a local turn counter at 0 would misalign
+   *  every kind=1 update after the first segment. _parseCopilotVSCodeSegment takes the number of
+   *  requests already pushed by prior segments as startingTurnIndex and continues counting from
+   *  there, so a segment's own turn-index keys line up with what kind=1 updates actually address. */
+  private _parseCopilotVSCodeFile(filePath: string): LogSessionResult[] {
     const lines = this._readNewLines(filePath)
-    if (!lines) return null
+    if (!lines) return []
 
     // Workspace from sibling workspace.json two levels up (workspaceStorage/<hash>/workspace.json)
+    // — read once per file, not per segment, since it's the same for every segment in this file.
     const workspaceJsonPath = path.join(path.dirname(filePath), '..', 'workspace.json')
     let workspace = ''
     try {
@@ -819,6 +831,29 @@ export class LogReader {
       }
     } catch { /* no workspace.json — no-folder or untitled window */ }
 
+    const baseSessionId = path.basename(filePath, '.jsonl')
+    const segments = splitCopilotVSCodeLinesOnPromptGaps(lines)
+    const results: LogSessionResult[] = []
+    let startingTurnIndex = 0
+    segments.forEach((segmentLines, segmentIndex) => {
+      const parsed = this._parseCopilotVSCodeSegment(
+        segmentLines,
+        claudeSegmentSessionId(baseSessionId, segmentIndex),
+        workspace,
+        startingTurnIndex,
+      )
+      if (parsed.result) results.push(parsed.result)
+      startingTurnIndex += parsed.turnsPushed
+    })
+    return results
+  }
+
+  private _parseCopilotVSCodeSegment(
+    lines: string[],
+    sessionId: string,
+    workspace: string,
+    startingTurnIndex: number,
+  ): { result: LogSessionResult | null; turnsPushed: number } {
     let sessionCreatedMs = 0
     let model = ''
     let userRequest = ''
@@ -834,7 +869,9 @@ export class LogReader {
     const turnCompletionTokens = new Map<number, number>()
     const turnPromptTokens = new Map<number, number>()  // Format C only
     const turnTimestamps: number[] = []
-    let requestPushCount = 0  // tracks implicit turn index for kind=2 pushes
+    // Continues the whole session's turn numbering rather than starting at 0 — see this method's
+    // own doc comment on _parseCopilotVSCodeFile for why.
+    let requestPushCount = startingTurnIndex
 
     for (const line of lines) {
       let entry: Record<string, unknown>
@@ -867,8 +904,11 @@ export class LogReader {
           if (typeof req['completionTokens'] === 'number' && !turnCompletionTokens.has(turnIdx)) {
             turnCompletionTokens.set(turnIdx, req['completionTokens'])
           }
-          // Format B: message.text is the raw user prompt — much cleaner than renderedUserMessage
-          if (turnIdx === 0 && !userRequest) {
+          // Format B: message.text is the raw user prompt — much cleaner than renderedUserMessage.
+          // Checks against this *segment's* own first turn (startingTurnIndex), not the whole
+          // session's global turn 0 — every segment after the first needs its own prompt captured
+          // from its own first turn, not just the file's very first one.
+          if (turnIdx === startingTurnIndex && !userRequest) {
             const msg = req['message'] as Record<string, unknown> | undefined
             if (typeof msg?.['text'] === 'string' && (msg['text'] as string).trim()) {
               userRequest = (msg['text'] as string).trim()
@@ -922,16 +962,26 @@ export class LogReader {
     let totalInput = 0
     for (const tokens of turnPromptTokens.values()) totalInput += tokens
     const turns = turnCompletionTokens.size
-    if (turns === 0 || sessionCreatedMs === 0) return null
-
-    const startTs = new Date(sessionCreatedMs).toISOString()
     const validTs = turnTimestamps.filter((n): n is number => n !== undefined)
-    const lastTurnMs = validTs.length > 0 ? Math.max(...validTs) : sessionCreatedMs
+    if (turns === 0) return { result: null, turnsPushed: 0 }
+
+    // Prefers the earliest real turn timestamp over sessionCreatedMs (the kind=0 snapshot, when
+    // the chat panel itself was first created) for two reasons: it's only present in whichever
+    // segment happens to contain the file's very first line, so every later segment needs a
+    // fallback anyway — and confirmed on real data, even segment 0 needs it: a chat panel can sit
+    // open for many hours before its first real message, which made sessionCreatedMs alone show a
+    // 66-73 hour "duration" for sessions whose actual turns spanned well under 90 minutes.
+    const startMs = validTs.length > 0 ? Math.min(...validTs) : sessionCreatedMs
+    if (startMs === 0) return { result: null, turnsPushed: 0 }
+    const startTs = new Date(startMs).toISOString()
+    const lastTurnMs = validTs.length > 0 ? Math.max(...validTs) : startMs
     const endTs = new Date(lastTurnMs).toISOString()
 
     return {
-      workspace,
-      card: _buildCard(sessionId, 'copilot', model || 'copilot', startTs, endTs, {
+      turnsPushed: requestPushCount - startingTurnIndex,
+      result: {
+        workspace,
+        card: _buildCard(sessionId, 'copilot', model || 'copilot', startTs, endTs, {
         totalInput,
         totalOutput,
         totalCacheRead: 0,
@@ -947,7 +997,8 @@ export class LogReader {
         userRequest: userRequest.slice(0, 500),
         timeline: [],
         initiator: 'user',
-      }, workspace),
+        }, workspace),
+      },
     }
   }
 
@@ -1554,30 +1605,37 @@ const WALKBACK_EPSILON_MS = 2000
  * identifies as a new prompt, walked back over any immediately-preceding near-simultaneous
  * bookkeeping lines (see WALKBACK_EPSILON_MS) — a segment's tool calls and assistant responses
  * always stay grouped with the prompt that triggered them, never split mid-turn. What counts as
- * "a new prompt" differs per log format (Claude Code: `type: 'user'`; Codex: an `event_msg` whose
- * payload type is `user_message`), so each format gets its own thin wrapper below rather than
- * sharing one predicate — this function holds only the boundary/gap algorithm itself, tested once
- * and reused by all of them.
+ * "a new prompt," and where its timestamp lives, differs per log format (Claude Code: `type:
+ * 'user'`, top-level `timestamp` string; Codex: an `event_msg` whose payload type is
+ * `user_message`/`turn_aborted`, same top-level string; Copilot VS Code chat: a `kind: 2` push to
+ * `requests`, numeric epoch-ms nested inside `v[0].timestamp`), so each format gets its own thin
+ * wrapper below rather than sharing one predicate — this function holds only the boundary/gap
+ * algorithm itself, tested once and reused by all of them. getBoundaryTimestampMs defaults to the
+ * top-level-string extraction (Claude/Codex); Copilot VS Code's wrapper overrides it. The
+ * walkback's own per-line timestamps always use the top-level-string form regardless — no format
+ * checked so far has shown a bookkeeping-cluster-bleed issue whose fix needs anything else, and a
+ * format where most lines simply lack a top-level timestamp (Copilot VS Code) makes the walkback a
+ * natural no-op rather than needing its own special-casing.
  *
  * Pure and independently testable on purpose: this only needs the raw lines and produces raw
  * line groups, so it can be verified against real transcript data without touching any of the
  * token/tool/file accounting in each format's own per-segment parser.
  */
+function defaultLineTimestampMs(entry: Record<string, unknown>): number | null {
+  const ts = entry['timestamp'] as string | undefined
+  const tsMs = ts ? Date.parse(ts) : NaN
+  return Number.isFinite(tsMs) ? tsMs : null
+}
+
 function splitLinesOnPromptGaps(
   lines: string[],
   isPromptBoundary: (entry: Record<string, unknown>) => boolean,
+  getBoundaryTimestampMs: (entry: Record<string, unknown>) => number | null = defaultLineTimestampMs,
 ): string[][] {
   if (lines.length === 0) return []
 
   const timestamps: Array<number | null> = lines.map(line => {
-    try {
-      const entry = JSON.parse(line) as Record<string, unknown>
-      const ts = entry['timestamp'] as string | undefined
-      const tsMs = ts ? Date.parse(ts) : NaN
-      return Number.isFinite(tsMs) ? tsMs : null
-    } catch {
-      return null
-    }
+    try { return defaultLineTimestampMs(JSON.parse(line) as Record<string, unknown>) } catch { return null }
   })
 
   const boundaries: number[] = [0]
@@ -1593,7 +1651,7 @@ function splitLinesOnPromptGaps(
     try { entry = JSON.parse(lines[i]) as Record<string, unknown> } catch { continue }
     if (!isPromptBoundary(entry)) continue
 
-    const tsMs = timestamps[i]
+    const tsMs = getBoundaryTimestampMs(entry)
     if (tsMs === null) continue
 
     if (maxTs !== null && tsMs - maxTs > SESSION_SPLIT_GAP_MS) {
@@ -1641,6 +1699,34 @@ export function splitCodexLinesOnPromptGaps(lines: string[]): string[][] {
     const payload = entry['payload'] as Record<string, unknown> | undefined
     return payload?.['type'] === 'user_message' || payload?.['type'] === 'turn_aborted'
   })
+}
+
+function isCopilotVSCodeRequestsPush(entry: Record<string, unknown>): boolean {
+  const k = entry['k']
+  return entry['kind'] === 2 && Array.isArray(k) && k.length === 1 && k[0] === 'requests'
+    && Array.isArray(entry['v']) && (entry['v'] as unknown[]).length > 0
+}
+
+// A `kind: 2` push to `requests` is how VS Code's delta-log format for the Copilot Chat panel
+// records a new turn — timestamp is numeric epoch-ms nested at v[0].timestamp, not a top-level
+// ISO string (this format's own convention, confirmed against real transcripts, unlike Claude
+// Code's/Codex's). A push can batch more than one new request at once (confirmed on real data —
+// rare, ~6% of pushes in one file, but real); since a single line can't be split, this uses the
+// batch's first request's timestamp for gap detection, which is the earliest new activity in it.
+// Token/turn accounting for this format is already keyed per-turn-index rather than a cumulative
+// running total (unlike Codex's total_token_usage), so — unlike Codex — no baseline-diffing is
+// needed between segments; each segment's own per-line accumulation over just its own lines is
+// already correct on its own.
+export function splitCopilotVSCodeLinesOnPromptGaps(lines: string[]): string[][] {
+  return splitLinesOnPromptGaps(
+    lines,
+    isCopilotVSCodeRequestsPush,
+    entry => {
+      const first = (entry['v'] as Array<Record<string, unknown>>)[0]
+      const ts = first?.['timestamp']
+      return typeof ts === 'number' ? ts : null
+    },
+  )
 }
 
 /** Segment 0 keeps the file's own session ID unchanged — the common case (a file that never

--- a/src/logReader.ts
+++ b/src/logReader.ts
@@ -274,7 +274,7 @@ export class LogReader {
 
     switch (agentKey) {
       case 'claude':              return this._processFileMulti(filePath, () => this._parseClaudeFile(filePath))
-      case 'codex':               return _single(this._processFile(filePath, () => this._parseCodexFile(filePath, '')))
+      case 'codex':               return this._processFileMulti(filePath, () => this._parseCodexFile(filePath))
       case 'copilot':             return _single(this._processFile(filePath, () => this._parseCopilotFile(filePath, sessionId)))
       case 'copilot_vscode':      return _single(this._processFile(filePath, () => this._parseCopilotVSCodeFile(filePath, sessionId)))
       case 'copilot_vscode_json': return _single(this._processFile(filePath, () => this._parseCopilotVSCodeJsonFile(filePath, sessionId)))
@@ -497,18 +497,50 @@ export class LogReader {
     const results: LogSessionResult[] = []
     for (const sessionsDir of codexSessionsDirs()) {
       this._collectJsonlFiles(sessionsDir).forEach(filePath => {
-        const result = this._processFile(filePath, () => this._parseCodexFile(filePath, sessionsDir))
-        if (result) results.push(result)
+        results.push(...this._processFileMulti(filePath, () => this._parseCodexFile(filePath)))
       })
     }
     return results
   }
 
-  private _parseCodexFile(filePath: string, _sessionsDir: string): LogSessionResult | null {
+  /** Reads a Codex CLI transcript and splits it into one or more session results — same
+   *  one-file-can-span-real-days problem as Claude Code (confirmed on real data: files spanning
+   *  two real weeks with multi-day gaps between prompts), same fix. See
+   *  splitCodexLinesOnPromptGaps for what counts as a new prompt in this format. No duplicate-uuid
+   *  issue found in Codex's format during validation (unlike Claude Code's — see dedupeByUuid),
+   *  so no dedup step here; revisit if real data ever shows otherwise.
+   *
+   *  One thing splitting alone doesn't handle: Codex's token_count events report a
+   *  total_token_usage that's cumulative for the *entire file*, not per-turn — confirmed on real
+   *  data (input_tokens climbing 16k → 33k → ... → 489k monotonically across an 8-day span with
+   *  no resets). Slicing lines into segments without accounting for this would give every segment
+   *  after the first the *entire session's* running total, not its own — segment 3 would report
+   *  segments 0+1+2+3's combined tokens as if they were its own. _parseCodexSegment takes the
+   *  previous segment's ending cumulative usage as a baseline and subtracts it, so each segment
+   *  reports only its own delta; running_totalTokenUsage carries that baseline forward across
+   *  segments (including ones with no token_count events of their own, which must inherit the
+   *  prior segment's cumulative value unchanged, not reset to zero). */
+  private _parseCodexFile(filePath: string): LogSessionResult[] {
     const lines = this._readNewLines(filePath)
-    if (!lines) return null
+    if (!lines) return []
 
-    const sessionId = path.basename(filePath, '.jsonl')
+    const baseSessionId = path.basename(filePath, '.jsonl')
+    const segments = splitCodexLinesOnPromptGaps(lines)
+    const results: LogSessionResult[] = []
+    let runningTotalTokenUsage: Record<string, number> | undefined
+    segments.forEach((segmentLines, segmentIndex) => {
+      const parsed = this._parseCodexSegment(segmentLines, claudeSegmentSessionId(baseSessionId, segmentIndex), runningTotalTokenUsage)
+      if (parsed.result) results.push(parsed.result)
+      if (parsed.cumulativeUsage) runningTotalTokenUsage = parsed.cumulativeUsage
+    })
+    return results
+  }
+
+  private _parseCodexSegment(
+    lines: string[],
+    sessionId: string,
+    baselineUsage: Record<string, number> | undefined,
+  ): { result: LogSessionResult | null; cumulativeUsage: Record<string, number> | undefined } {
     let workspace = ''
 
     let model = ''
@@ -563,19 +595,35 @@ export class LogReader {
       }
     }
 
-    if (!firstTimestamp) return null
+    if (!firstTimestamp) return { result: null, cumulativeUsage: undefined }
 
-    // Use final total_token_usage; input_tokens includes cached, so subtract to get
-    // the raw (non-cached) portion that _buildCard will re-add alongside cacheRead.
-    const totalCacheRead  = lastTotalUsage?.['cached_input_tokens']    ?? 0
-    const totalInput      = Math.max(0, (lastTotalUsage?.['input_tokens'] ?? 0) - totalCacheRead)
-    // Include reasoning tokens in output — they're billed at the output rate for o-series.
-    const totalOutput     = (lastTotalUsage?.['output_tokens'] ?? 0)
-                          + (lastTotalUsage?.['reasoning_output_tokens'] ?? 0)
+    // total_token_usage is cumulative for the whole file — this segment's own contribution is
+    // the delta from the previous segment's ending cumulative value (0 for segment 0). A segment
+    // with no token_count events of its own (lastTotalUsage undefined) contributed nothing new.
+    let totalCacheRead = 0, totalInput = 0, totalOutput = 0
+    if (lastTotalUsage) {
+      const baseCacheRead = baselineUsage?.['cached_input_tokens'] ?? 0
+      const baseInputRaw  = Math.max(0, (baselineUsage?.['input_tokens'] ?? 0) - baseCacheRead)
+      const baseOutput    = (baselineUsage?.['output_tokens'] ?? 0) + (baselineUsage?.['reasoning_output_tokens'] ?? 0)
+
+      const curCacheRead = lastTotalUsage['cached_input_tokens'] ?? 0
+      // input_tokens includes cached, so subtract to get the raw (non-cached) portion that
+      // _buildCard will re-add alongside cacheRead.
+      const curInputRaw  = Math.max(0, (lastTotalUsage['input_tokens'] ?? 0) - curCacheRead)
+      // Include reasoning tokens in output — they're billed at the output rate for o-series.
+      const curOutput    = (lastTotalUsage['output_tokens'] ?? 0) + (lastTotalUsage['reasoning_output_tokens'] ?? 0)
+
+      totalCacheRead = Math.max(0, curCacheRead - baseCacheRead)
+      totalInput     = Math.max(0, curInputRaw - baseInputRaw)
+      totalOutput    = Math.max(0, curOutput - baseOutput)
+    }
 
     return {
-      workspace,
-      card: _buildCard(sessionId, 'codex', model || 'codex', firstTimestamp, lastTimestamp, { totalInput, totalOutput, totalCacheRead, totalCacheCreate: 0, peakContextPerTurn: 0, turns, totalToolCalls: 0, toolCounts: {}, filesRead: new Set(), filesChanged: new Set(), filesWritten: new Set(), filesSearched: new Set(), userRequest: userRequest.slice(0, 500), timeline: [], initiator: 'user' }, workspace),
+      result: {
+        workspace,
+        card: _buildCard(sessionId, 'codex', model || 'codex', firstTimestamp, lastTimestamp, { totalInput, totalOutput, totalCacheRead, totalCacheCreate: 0, peakContextPerTurn: 0, turns, totalToolCalls: 0, toolCounts: {}, filesRead: new Set(), filesChanged: new Set(), filesWritten: new Set(), filesSearched: new Set(), userRequest: userRequest.slice(0, 500), timeline: [], initiator: 'user' }, workspace),
+      },
+      cumulativeUsage: lastTotalUsage,
     }
   }
 
@@ -1488,39 +1536,82 @@ export function dedupeByUuid(lines: string[]): string[] {
 // question on whether to also force a split at real calendar-day boundaries.
 export const SESSION_SPLIT_GAP_MS = 30 * 60_000
 
+// A chain of bookkeeping events immediately preceding a real prompt (Codex: thread_settings_
+// applied, task_started, and — only discovered by checking a second real file, after task_started
+// alone turned out to have exactly the same problem as user_message — turn_aborted when the prior
+// turn was interrupted rather than completed cleanly) all get logged within milliseconds of the
+// new turn's own timestamp, arriving *before* the actual prompt-boundary line in file order.
+// Anchoring the split purely on a fixed set of named event types is a losing game — every real
+// file checked so far has turned up one more type in the cluster. WALKBACK_EPSILON_MS instead
+// walks the boundary backward over *any* immediately-preceding lines within this tight a gap of
+// each other, regardless of type, so an unrecognized future bookkeeping event is handled the same
+// way as the ones already found rather than needing its own name added to a list.
+const WALKBACK_EPSILON_MS = 2000
+
 /**
- * Splits a Claude Code JSONL transcript's lines into segments, one per group of consecutive user
- * prompts with no gap between them exceeding SESSION_SPLIT_GAP_MS. A split point always falls
- * immediately before a `type: 'user'` line — a segment's tool calls and assistant responses
- * always stay grouped with the prompt that triggered them, never split mid-turn.
+ * Splits a log's lines into segments, one per group of consecutive prompts with no gap between
+ * them exceeding SESSION_SPLIT_GAP_MS. A split point always falls before a line isPromptBoundary
+ * identifies as a new prompt, walked back over any immediately-preceding near-simultaneous
+ * bookkeeping lines (see WALKBACK_EPSILON_MS) — a segment's tool calls and assistant responses
+ * always stay grouped with the prompt that triggered them, never split mid-turn. What counts as
+ * "a new prompt" differs per log format (Claude Code: `type: 'user'`; Codex: an `event_msg` whose
+ * payload type is `user_message`), so each format gets its own thin wrapper below rather than
+ * sharing one predicate — this function holds only the boundary/gap algorithm itself, tested once
+ * and reused by all of them.
  *
  * Pure and independently testable on purpose: this only needs the raw lines and produces raw
  * line groups, so it can be verified against real transcript data without touching any of the
- * token/tool/file accounting in _parseClaudeSegment.
+ * token/tool/file accounting in each format's own per-segment parser.
  */
-export function splitClaudeLinesOnPromptGaps(lines: string[]): string[][] {
+function splitLinesOnPromptGaps(
+  lines: string[],
+  isPromptBoundary: (entry: Record<string, unknown>) => boolean,
+): string[][] {
   if (lines.length === 0) return []
 
+  const timestamps: Array<number | null> = lines.map(line => {
+    try {
+      const entry = JSON.parse(line) as Record<string, unknown>
+      const ts = entry['timestamp'] as string | undefined
+      const tsMs = ts ? Date.parse(ts) : NaN
+      return Number.isFinite(tsMs) ? tsMs : null
+    } catch {
+      return null
+    }
+  })
+
   const boundaries: number[] = [0]
-  // Tracks the highest user-prompt timestamp seen so far, not just the most recently seen one —
-  // real transcripts can contain an isolated out-of-order timestamp (confirmed on real data: one
-  // entry mid-file stamped a full day earlier than its neighbors, apparently from Claude Code's
-  // own resume/continuation handling). Comparing against the max rather than the last value keeps
-  // a single such anomaly from corrupting the gap baseline for every comparison after it.
-  let maxUserTs: number | null = null
+  // Tracks the highest prompt timestamp seen so far, not just the most recently seen one — real
+  // transcripts can contain an isolated out-of-order timestamp (confirmed on real Claude Code
+  // data: one entry mid-file stamped a full day earlier than its neighbors, apparently from
+  // Claude Code's own resume/continuation handling). Comparing against the max rather than the
+  // last value keeps a single such anomaly from corrupting the gap baseline for every comparison
+  // after it.
+  let maxTs: number | null = null
   for (let i = 0; i < lines.length; i++) {
     let entry: Record<string, unknown>
     try { entry = JSON.parse(lines[i]) as Record<string, unknown> } catch { continue }
-    if (entry['type'] !== 'user') continue
+    if (!isPromptBoundary(entry)) continue
 
-    const ts = entry['timestamp'] as string | undefined
-    const tsMs = ts ? Date.parse(ts) : NaN
-    if (!Number.isFinite(tsMs)) continue
+    const tsMs = timestamps[i]
+    if (tsMs === null) continue
 
-    if (maxUserTs !== null && tsMs - maxUserTs > SESSION_SPLIT_GAP_MS) {
-      boundaries.push(i)
+    if (maxTs !== null && tsMs - maxTs > SESSION_SPLIT_GAP_MS) {
+      let boundary = i
+      while (boundary > 0) {
+        const prevTs = timestamps[boundary - 1]
+        const curTs = timestamps[boundary]
+        if (prevTs === null || curTs === null) break
+        const delta = curTs - prevTs
+        if (delta < 0 || delta > WALKBACK_EPSILON_MS) break
+        boundary--
+      }
+      // Never walk back past (or onto) the previous boundary — a segment must keep at least one
+      // line, and the previous segment's own real content must stay its own.
+      const prevBoundary = boundaries[boundaries.length - 1]
+      boundaries.push(Math.max(boundary, prevBoundary + 1))
     }
-    maxUserTs = Math.max(maxUserTs ?? tsMs, tsMs)
+    maxTs = Math.max(maxTs ?? tsMs, tsMs)
   }
 
   const segments: string[][] = []
@@ -1532,8 +1623,30 @@ export function splitClaudeLinesOnPromptGaps(lines: string[]): string[][] {
   return segments
 }
 
+export function splitClaudeLinesOnPromptGaps(lines: string[]): string[][] {
+  return splitLinesOnPromptGaps(lines, entry => entry['type'] === 'user')
+}
+
+// Also treats turn_aborted as a boundary trigger, not just user_message. Confirmed on real data:
+// when a turn was left incomplete and the user comes back later, Codex logs turn_aborted stamped
+// with the *resumption* time — but the delta from turn_aborted to the following turn's
+// thread_settings_applied/task_started varies too widely (0.1s to 31s across 7 real occurrences
+// in one file) for WALKBACK_EPSILON_MS to reliably absorb it into the same cluster. turn_aborted
+// needs to trigger gap detection on its own rather than relying on being swept in by a later
+// anchor — unlike thread_settings_applied/task_started, which are reliably near-simultaneous with
+// their user_message and are handled by the walkback instead.
+export function splitCodexLinesOnPromptGaps(lines: string[]): string[][] {
+  return splitLinesOnPromptGaps(lines, entry => {
+    if (entry['type'] !== 'event_msg') return false
+    const payload = entry['payload'] as Record<string, unknown> | undefined
+    return payload?.['type'] === 'user_message' || payload?.['type'] === 'turn_aborted'
+  })
+}
+
 /** Segment 0 keeps the file's own session ID unchanged — the common case (a file that never
- *  needs splitting) gets no ID churn at all. Later segments get a stable, deterministic suffix. */
+ *  needs splitting) gets no ID churn at all. Later segments get a stable, deterministic suffix.
+ *  Shared by every log format's splitting — the naming is Claude-specific only because it shipped
+ *  first; the logic itself is format-agnostic. */
 export function claudeSegmentSessionId(baseSessionId: string, segmentIndex: number): string {
   return segmentIndex === 0 ? baseSessionId : `${baseSessionId}#${segmentIndex}`
 }

--- a/src/logReader.ts
+++ b/src/logReader.ts
@@ -172,6 +172,12 @@ export interface LogSessionResult {
   workspace: string
 }
 
+/** Wraps a single-or-null result as an array, for parsers that only ever produce one session
+ *  per file (everything except Claude Code — see splitClaudeLinesOnPromptGaps). */
+function _single(result: LogSessionResult | null): LogSessionResult[] {
+  return result ? [result] : []
+}
+
 export class LogReader {
   private readonly log: (msg: string) => void
   private readonly sqlFactory: OpenCodeSqlFactory | undefined
@@ -254,10 +260,12 @@ export class LogReader {
   }
 
   /**
-   * Parses a single file identified by collectFileMeta() and returns a result if
-   * the file is new or has grown since the last scan. Returns null if unchanged.
+   * Parses a single file identified by collectFileMeta() and returns any results if the file is
+   * new or has grown since the last scan (usually one; Claude Code transcripts can yield more
+   * than one when a large gap between prompts splits the file into multiple sessions — see
+   * splitClaudeLinesOnPromptGaps). Returns [] if unchanged.
    */
-  parseFile(filePath: string, agentKey: string): LogSessionResult | null {
+  parseFile(filePath: string, agentKey: string): LogSessionResult[] {
     const sessionId = agentKey === 'copilot'
       ? path.basename(path.dirname(filePath))  // directory name is session UUID
       : agentKey === 'copilot_vscode_json'
@@ -265,13 +273,13 @@ export class LogReader {
         : path.basename(filePath, '.jsonl')
 
     switch (agentKey) {
-      case 'claude':              return this._processFile(filePath, () => this._parseClaudeFile(filePath))
-      case 'codex':               return this._processFile(filePath, () => this._parseCodexFile(filePath, ''))
-      case 'copilot':             return this._processFile(filePath, () => this._parseCopilotFile(filePath, sessionId))
-      case 'copilot_vscode':      return this._processFile(filePath, () => this._parseCopilotVSCodeFile(filePath, sessionId))
-      case 'copilot_vscode_json': return this._processFile(filePath, () => this._parseCopilotVSCodeJsonFile(filePath, sessionId))
-      case 'opencode':            return null  // OpenCode DB returns multiple sessions; use _scanOpenCode
-      default:                    return null
+      case 'claude':              return this._processFileMulti(filePath, () => this._parseClaudeFile(filePath))
+      case 'codex':               return _single(this._processFile(filePath, () => this._parseCodexFile(filePath, '')))
+      case 'copilot':             return _single(this._processFile(filePath, () => this._parseCopilotFile(filePath, sessionId)))
+      case 'copilot_vscode':      return _single(this._processFile(filePath, () => this._parseCopilotVSCodeFile(filePath, sessionId)))
+      case 'copilot_vscode_json': return _single(this._processFile(filePath, () => this._parseCopilotVSCodeJsonFile(filePath, sessionId)))
+      case 'opencode':            return []  // OpenCode DB returns multiple sessions; use _scanOpenCode
+      default:                    return []
     }
   }
 
@@ -306,19 +314,31 @@ export class LogReader {
     const results: LogSessionResult[] = []
     for (const projectsDir of claudeProjectsDirs()) {
       this._collectJsonlFiles(projectsDir).forEach(filePath => {
-        const result = this._processFile(filePath, () => this._parseClaudeFile(filePath))
-        if (result) results.push(result)
+        results.push(...this._processFileMulti(filePath, () => this._parseClaudeFile(filePath)))
       })
     }
     return results
   }
 
-  private _parseClaudeFile(filePath: string): LogSessionResult | null {
-    const lines = this._readNewLines(filePath)
-    if (!lines) return null
+  /** Reads a Claude Code transcript and splits it into one or more session results — see
+   *  splitClaudeLinesOnPromptGaps for why a single file can yield more than one session, and
+   *  dedupeByUuid for why duplicate lines are dropped before any of that runs. */
+  private _parseClaudeFile(filePath: string): LogSessionResult[] {
+    const rawLines = this._readNewLines(filePath)
+    if (!rawLines) return []
+    const lines = dedupeByUuid(rawLines)
 
-    const sessionId = path.basename(filePath, '.jsonl')
+    const baseSessionId = path.basename(filePath, '.jsonl')
+    const segments = splitClaudeLinesOnPromptGaps(lines)
+    const results: LogSessionResult[] = []
+    segments.forEach((segmentLines, segmentIndex) => {
+      const result = this._parseClaudeSegment(segmentLines, claudeSegmentSessionId(baseSessionId, segmentIndex))
+      if (result) results.push(result)
+    })
+    return results
+  }
 
+  private _parseClaudeSegment(lines: string[], sessionId: string): LogSessionResult | null {
     let workspace = ''
     let model = ''
     let firstTimestamp = ''
@@ -1384,6 +1404,22 @@ export class LogReader {
       return null
     }
   }
+
+  /** Same change-detection as _processFile, for parsers that can return multiple session results
+   *  from one file (currently only Claude Code). */
+  private _processFileMulti(
+    filePath: string,
+    parseFn: () => LogSessionResult[],
+  ): LogSessionResult[] {
+    try {
+      const stat = fs.statSync(filePath)
+      const prev = this.fileState.get(filePath)
+      if (prev && stat.mtimeMs === prev.mtimeMs && stat.size === prev.bytesRead) return []
+      return parseFn()
+    } catch {
+      return []
+    }
+  }
 }
 
 // ── Shared card builder ───────────────────────────────────────────────────────
@@ -1404,6 +1440,102 @@ interface CardAccum {
   userRequest: string
   timeline: TimelineEntry[]
   initiator: 'user' | 'agent' | 'api'
+}
+
+// ── Session splitting on prompt boundaries ──────────────────────────────────
+//
+// A Claude Code CLI transcript file is one continuous JSONL log for as long as the terminal
+// session stays open — which can span real days if the user leaves it running, comes back later,
+// and keeps typing prompts into the same window. Treating that whole file as one "session" is
+// what made session duration read as wildly inflated (see .staged-issues/
+// split-sessions-on-prompt-boundaries.md for the empirical data that proved a smaller idle-gap-
+// capping fix wasn't enough on its own). This splits the file into segments at a genuinely large
+// gap between two consecutive user prompts — never mid-turn — so each segment is a complete,
+// coherent chunk of work rather than an arbitrarily severed one.
+
+/**
+ * Drops any line whose `uuid` was already seen earlier in the file, keeping the first
+ * occurrence. Confirmed on real transcript data: Claude Code can re-serialize and re-append a
+ * large block of earlier conversation history into the same file — observed as a ~466-entry
+ * (user/assistant/attachment) block sharing exact uuids and timestamps with much earlier entries,
+ * differing only by one added field, plausibly a resume-across-version artifact rather than
+ * anything this tool controls. Left uncaught, that block's old timestamps land late in the file
+ * and get read as real new activity, and its content gets double-counted into turns/tokens/tool
+ * calls. Lines with no `uuid` at all (session_meta, turn_context, and other non-message event
+ * types) are never deduplicated — there's no reliable key to dedupe them by, and they're not
+ * the source of this problem.
+ */
+export function dedupeByUuid(lines: string[]): string[] {
+  const seen = new Set<string>()
+  const result: string[] = []
+  for (const line of lines) {
+    let entry: Record<string, unknown>
+    try { entry = JSON.parse(line) as Record<string, unknown> } catch { result.push(line); continue }
+    const uuid = entry['uuid']
+    if (typeof uuid !== 'string') { result.push(line); continue }
+    if (seen.has(uuid)) continue
+    seen.add(uuid)
+    result.push(line)
+  }
+  return result
+}
+
+// A gap between two consecutive user prompts longer than this starts a new session segment.
+// Deliberately larger than summarizers/helpers.ts's IDLE_GAP_THRESHOLD_MS (10 min) — that one
+// answers "was this pause part of active work within one sitting," this one answers "is this
+// genuinely a different sitting." 30 minutes is a first-pass guess, not a calibrated value — same
+// honesty standard as every other threshold in this project. See the staged issue for the open
+// question on whether to also force a split at real calendar-day boundaries.
+export const SESSION_SPLIT_GAP_MS = 30 * 60_000
+
+/**
+ * Splits a Claude Code JSONL transcript's lines into segments, one per group of consecutive user
+ * prompts with no gap between them exceeding SESSION_SPLIT_GAP_MS. A split point always falls
+ * immediately before a `type: 'user'` line — a segment's tool calls and assistant responses
+ * always stay grouped with the prompt that triggered them, never split mid-turn.
+ *
+ * Pure and independently testable on purpose: this only needs the raw lines and produces raw
+ * line groups, so it can be verified against real transcript data without touching any of the
+ * token/tool/file accounting in _parseClaudeSegment.
+ */
+export function splitClaudeLinesOnPromptGaps(lines: string[]): string[][] {
+  if (lines.length === 0) return []
+
+  const boundaries: number[] = [0]
+  // Tracks the highest user-prompt timestamp seen so far, not just the most recently seen one —
+  // real transcripts can contain an isolated out-of-order timestamp (confirmed on real data: one
+  // entry mid-file stamped a full day earlier than its neighbors, apparently from Claude Code's
+  // own resume/continuation handling). Comparing against the max rather than the last value keeps
+  // a single such anomaly from corrupting the gap baseline for every comparison after it.
+  let maxUserTs: number | null = null
+  for (let i = 0; i < lines.length; i++) {
+    let entry: Record<string, unknown>
+    try { entry = JSON.parse(lines[i]) as Record<string, unknown> } catch { continue }
+    if (entry['type'] !== 'user') continue
+
+    const ts = entry['timestamp'] as string | undefined
+    const tsMs = ts ? Date.parse(ts) : NaN
+    if (!Number.isFinite(tsMs)) continue
+
+    if (maxUserTs !== null && tsMs - maxUserTs > SESSION_SPLIT_GAP_MS) {
+      boundaries.push(i)
+    }
+    maxUserTs = Math.max(maxUserTs ?? tsMs, tsMs)
+  }
+
+  const segments: string[][] = []
+  for (let b = 0; b < boundaries.length; b++) {
+    const start = boundaries[b]
+    const end = b + 1 < boundaries.length ? boundaries[b + 1] : lines.length
+    segments.push(lines.slice(start, end))
+  }
+  return segments
+}
+
+/** Segment 0 keeps the file's own session ID unchanged — the common case (a file that never
+ *  needs splitting) gets no ID churn at all. Later segments get a stable, deterministic suffix. */
+export function claudeSegmentSessionId(baseSessionId: string, segmentIndex: number): string {
+  return segmentIndex === 0 ? baseSessionId : `${baseSessionId}#${segmentIndex}`
 }
 
 function _buildCard(

--- a/src/test/logReader.claude.test.ts
+++ b/src/test/logReader.claude.test.ts
@@ -42,9 +42,9 @@ suite('LogReader — Claude Code edit details', () => {
     ])
 
     const reader = new LogReader()
-    const result = reader.parseFile(filePath, 'claude')
-    assert.ok(result, 'expected a parsed session')
-    const card = result!.card
+    const results = reader.parseFile(filePath, 'claude')
+    assert.strictEqual(results.length, 1, 'expected one parsed session')
+    const card = results[0].card
 
     const toolEntry = card.timeline.find(e => e.type === 'tool')
     assert.ok(toolEntry, 'expected a tool timeline entry')
@@ -88,12 +88,14 @@ suite('LogReader — Claude Code edit details', () => {
     ])
 
     const reader = new LogReader()
-    const result = reader.parseFile(filePath, 'claude')
-    const toolEntry = result!.card.timeline.find(e => e.type === 'tool')
+    const results = reader.parseFile(filePath, 'claude')
+    assert.strictEqual(results.length, 1)
+    const card = results[0].card
+    const toolEntry = card.timeline.find(e => e.type === 'tool')
     assert.strictEqual(toolEntry!.editDetails?.length, 2)
     assert.ok(toolEntry!.editDetails!.every(ed => ed.filePath === '/workspace/b.ts'))
 
-    const counts = getFileEditCounts(result!.card)
+    const counts = getFileEditCounts(card)
     assert.strictEqual(counts['/workspace/b.ts'].length, 2)
   })
 
@@ -115,11 +117,13 @@ suite('LogReader — Claude Code edit details', () => {
     ])
 
     const reader = new LogReader()
-    const result = reader.parseFile(filePath, 'claude')
-    const toolEntry = result!.card.timeline.find(e => e.type === 'tool')
+    const results = reader.parseFile(filePath, 'claude')
+    assert.strictEqual(results.length, 1)
+    const card = results[0].card
+    const toolEntry = card.timeline.find(e => e.type === 'tool')
     assert.strictEqual(toolEntry!.editDetails, undefined)
 
-    const stats = computeOneShotStats(result!.card)
+    const stats = computeOneShotStats(card)
     assert.strictEqual(stats.filesConsidered, 0)
   })
 })

--- a/src/test/logReader.claudeSplit.test.ts
+++ b/src/test/logReader.claudeSplit.test.ts
@@ -1,0 +1,248 @@
+import * as assert from 'assert'
+import * as path from 'path'
+import * as fs from 'fs'
+import * as os from 'os'
+import { LogReader, splitClaudeLinesOnPromptGaps, claudeSegmentSessionId, dedupeByUuid, SESSION_SPLIT_GAP_MS } from '../logReader'
+
+function writeJsonl(filePath: string, lines: Record<string, unknown>[]) {
+  fs.writeFileSync(filePath, lines.map(l => JSON.stringify(l)).join('\n') + '\n')
+}
+
+function userLine(ts: string, text = 'hi', extra: Record<string, unknown> = {}) {
+  return { type: 'user', cwd: '/workspace', timestamp: ts, message: { content: text }, ...extra }
+}
+
+function assistantLine(ts: string) {
+  return {
+    type: 'assistant', timestamp: ts,
+    message: { model: 'claude-sonnet-5', usage: { input_tokens: 10, output_tokens: 5 }, content: [{ type: 'text', text: 'ok' }] },
+  }
+}
+
+suite('splitClaudeLinesOnPromptGaps', () => {
+  test('empty input returns no segments', () => {
+    assert.deepStrictEqual(splitClaudeLinesOnPromptGaps([]), [])
+  })
+
+  test('a single prompt with no gap stays one segment', () => {
+    const lines = [userLine('2026-01-01T00:00:00.000Z'), assistantLine('2026-01-01T00:00:05.000Z')].map(l => JSON.stringify(l))
+    const segments = splitClaudeLinesOnPromptGaps(lines)
+    assert.strictEqual(segments.length, 1)
+    assert.strictEqual(segments[0].length, 2)
+  })
+
+  test('two prompts under the threshold stay one segment', () => {
+    const lines = [
+      userLine('2026-01-01T00:00:00.000Z'),
+      assistantLine('2026-01-01T00:00:05.000Z'),
+      userLine(new Date(Date.parse('2026-01-01T00:00:00.000Z') + SESSION_SPLIT_GAP_MS - 1000).toISOString()),
+    ].map(l => JSON.stringify(l))
+    const segments = splitClaudeLinesOnPromptGaps(lines)
+    assert.strictEqual(segments.length, 1)
+    assert.strictEqual(segments[0].length, 3)
+  })
+
+  test('two prompts over the threshold split into two segments, boundary right before the second prompt', () => {
+    const secondPromptTs = new Date(Date.parse('2026-01-01T00:00:00.000Z') + SESSION_SPLIT_GAP_MS + 1000).toISOString()
+    const lines = [
+      userLine('2026-01-01T00:00:00.000Z'),
+      assistantLine('2026-01-01T00:00:05.000Z'),
+      userLine(secondPromptTs),
+      assistantLine(secondPromptTs),
+    ].map(l => JSON.stringify(l))
+    const segments = splitClaudeLinesOnPromptGaps(lines)
+    assert.strictEqual(segments.length, 2)
+    assert.strictEqual(segments[0].length, 2)
+    assert.strictEqual(segments[1].length, 2)
+    assert.deepStrictEqual(JSON.parse(segments[1][0]).timestamp, secondPromptTs)
+  })
+
+  test('three prompts, one large gap, produces three segments only where gaps actually exceed the threshold', () => {
+    const t0 = Date.parse('2026-01-01T00:00:00.000Z')
+    const t1 = t0 + 5 * 60_000                       // 5 min later — no split
+    const t2 = t1 + SESSION_SPLIT_GAP_MS + 60_000     // well over the threshold — split
+    const lines = [
+      userLine(new Date(t0).toISOString()),
+      userLine(new Date(t1).toISOString()),
+      userLine(new Date(t2).toISOString()),
+    ].map(l => JSON.stringify(l))
+    const segments = splitClaudeLinesOnPromptGaps(lines)
+    assert.strictEqual(segments.length, 2)
+    assert.strictEqual(segments[0].length, 2)
+    assert.strictEqual(segments[1].length, 1)
+  })
+
+  test('malformed lines are skipped without breaking segmentation', () => {
+    const secondPromptTs = new Date(Date.parse('2026-01-01T00:00:00.000Z') + SESSION_SPLIT_GAP_MS + 1000).toISOString()
+    const lines = [
+      JSON.stringify(userLine('2026-01-01T00:00:00.000Z')),
+      'not valid json',
+      JSON.stringify(userLine(secondPromptTs)),
+    ]
+    const segments = splitClaudeLinesOnPromptGaps(lines)
+    assert.strictEqual(segments.length, 2)
+    assert.strictEqual(segments[0].length, 2)  // the good user line + the malformed line stay together
+    assert.strictEqual(segments[1].length, 1)
+  })
+
+  test('a single out-of-order timestamp does not corrupt the gap baseline for later comparisons', () => {
+    // Confirmed on real transcript data: an isolated user entry can be stamped noticeably earlier
+    // than its neighbors (observed from Claude Code's own resume/continuation handling). Using the
+    // last-seen timestamp as the gap baseline would let this one stray entry make every subsequent
+    // real prompt look like a huge gap; tracking the max-seen timestamp instead should not.
+    const t0 = Date.parse('2026-01-02T12:00:00.000Z')
+    const strayEarlier = t0 - 24 * 3600_000  // a full day earlier, out of order
+    const t1 = t0 + 5 * 60_000               // 5 min after t0 — should NOT read as a gap from t0
+    const lines = [
+      userLine(new Date(t0).toISOString()),
+      userLine(new Date(strayEarlier).toISOString()),
+      userLine(new Date(t1).toISOString()),
+    ].map(l => JSON.stringify(l))
+    const segments = splitClaudeLinesOnPromptGaps(lines)
+    assert.strictEqual(segments.length, 1, 'the stray earlier timestamp should not itself trigger a split, nor corrupt the next comparison')
+  })
+
+  test('a user entry with no parseable timestamp never triggers a split', () => {
+    const lines = [
+      JSON.stringify(userLine('2026-01-01T00:00:00.000Z')),
+      JSON.stringify({ type: 'user', message: { content: 'no timestamp' } }),
+      JSON.stringify(userLine('2026-01-01T00:00:01.000Z')),
+    ]
+    const segments = splitClaudeLinesOnPromptGaps(lines)
+    assert.strictEqual(segments.length, 1)
+  })
+})
+
+suite('claudeSegmentSessionId', () => {
+  test('segment 0 keeps the base session id unchanged', () => {
+    assert.strictEqual(claudeSegmentSessionId('abc-123', 0), 'abc-123')
+  })
+
+  test('later segments get a stable, distinct suffix', () => {
+    assert.strictEqual(claudeSegmentSessionId('abc-123', 1), 'abc-123#1')
+    assert.strictEqual(claudeSegmentSessionId('abc-123', 2), 'abc-123#2')
+  })
+})
+
+suite('dedupeByUuid', () => {
+  test('keeps the first occurrence of a uuid and drops later repeats', () => {
+    const lines = [
+      JSON.stringify(userLine('2026-01-01T00:00:00.000Z', 'first', { uuid: 'a' })),
+      JSON.stringify(userLine('2026-01-01T00:01:00.000Z', 'second', { uuid: 'b' })),
+      // Same uuid as the first line, but re-serialized much later with an extra field and an old
+      // timestamp — the exact real-world shape found in a live transcript (a replayed history
+      // block, same uuid/timestamp, one added field).
+      JSON.stringify(userLine('2026-01-01T00:00:00.000Z', 'first', { uuid: 'a', slug: 'added-later' })),
+    ]
+    const result = dedupeByUuid(lines)
+    assert.strictEqual(result.length, 2)
+    assert.strictEqual(JSON.parse(result[0]).message.content, 'first')
+    assert.strictEqual(JSON.parse(result[1]).message.content, 'second')
+  })
+
+  test('leaves lines with no uuid untouched — never deduplicated', () => {
+    const lines = [
+      JSON.stringify({ type: 'session_meta', timestamp: '2026-01-01T00:00:00.000Z' }),
+      JSON.stringify({ type: 'session_meta', timestamp: '2026-01-01T00:00:01.000Z' }),
+    ]
+    const result = dedupeByUuid(lines)
+    assert.strictEqual(result.length, 2)
+  })
+
+  test('a malformed line passes through unchanged rather than being dropped', () => {
+    const result = dedupeByUuid(['not valid json'])
+    assert.deepStrictEqual(result, ['not valid json'])
+  })
+})
+
+suite('LogReader — Claude Code session splitting (integration)', () => {
+  let tmpDir: string
+
+  setup(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agentlens-claude-split-'))
+  })
+
+  teardown(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  test('a normal short session (no large gap) produces exactly one result with the unsuffixed session id', () => {
+    const filePath = path.join(tmpDir, 'sess-normal.jsonl')
+    writeJsonl(filePath, [
+      userLine('2026-01-01T00:00:00.000Z', 'first thing'),
+      assistantLine('2026-01-01T00:00:05.000Z'),
+      userLine('2026-01-01T00:05:00.000Z', 'second thing'),
+      assistantLine('2026-01-01T00:05:05.000Z'),
+    ])
+
+    const results = new LogReader().parseFile(filePath, 'claude')
+    assert.strictEqual(results.length, 1)
+    assert.strictEqual(results[0].card.sessionId, 'sess-normal')
+    assert.strictEqual(results[0].card.userRequest, 'first thing')
+  })
+
+  test('a session with a real multi-hour gap between prompts splits into two sessions, each with its own prompt and totals', () => {
+    const filePath = path.join(tmpDir, 'sess-gapped.jsonl')
+    const t0 = '2026-01-01T00:00:00.000Z'
+    const t1 = '2026-01-01T00:00:05.000Z'
+    const t2 = new Date(Date.parse(t0) + 5 * 3600_000).toISOString()  // 5 hours later — the reported bug scenario
+    const t3 = new Date(Date.parse(t2) + 5000).toISOString()
+    writeJsonl(filePath, [
+      userLine(t0, 'work on the first task'),
+      assistantLine(t1),
+      userLine(t2, 'come back and work on something else'),
+      assistantLine(t3),
+    ])
+
+    const results = new LogReader().parseFile(filePath, 'claude')
+    assert.strictEqual(results.length, 2, 'expected the 5-hour gap to split into two sessions')
+
+    assert.strictEqual(results[0].card.sessionId, 'sess-gapped')
+    assert.strictEqual(results[0].card.userRequest, 'work on the first task')
+    assert.strictEqual(results[0].card.turns, 1)
+
+    assert.strictEqual(results[1].card.sessionId, 'sess-gapped#1')
+    assert.strictEqual(results[1].card.userRequest, 'come back and work on something else')
+    assert.strictEqual(results[1].card.turns, 1)
+
+    // Each segment's own wall-clock duration should be small — nowhere near the 5-hour gap that
+    // used to be baked into one session's durationMs before this fix.
+    assert.ok(results[0].card.durationMs < 60_000)
+    assert.ok(results[1].card.durationMs < 60_000)
+  })
+
+  test('re-scanning an unchanged split file returns no results (cache behavior preserved)', () => {
+    const filePath = path.join(tmpDir, 'sess-gapped-2.jsonl')
+    const t0 = '2026-01-01T00:00:00.000Z'
+    const t1 = new Date(Date.parse(t0) + SESSION_SPLIT_GAP_MS + 60_000).toISOString()
+    writeJsonl(filePath, [userLine(t0, 'first'), userLine(t1, 'second')])
+
+    const reader = new LogReader()
+    const first = reader.parseFile(filePath, 'claude')
+    assert.strictEqual(first.length, 2)
+
+    const second = reader.parseFile(filePath, 'claude')
+    assert.strictEqual(second.length, 0, 'unchanged file should produce no new results on rescan')
+  })
+
+  test('a replayed history block (duplicate uuids, real-world shape) does not inflate turns or corrupt segmentation', () => {
+    // Reproduces the exact shape found in a live transcript: a normal short session, followed
+    // much later in the file by a re-serialized copy of its own early entries — same uuid, same
+    // (old) timestamp, one added field — the way Claude Code appears to replay history on resume.
+    const filePath = path.join(tmpDir, 'sess-replayed.jsonl')
+    const t0 = '2026-01-01T00:00:00.000Z'
+    const t1 = '2026-01-01T00:00:05.000Z'
+    writeJsonl(filePath, [
+      userLine(t0, 'original prompt', { uuid: 'u1' }),
+      assistantLine(t1),
+      // Much later in the file, but stamped with the *original* early timestamp and uuid —
+      // exactly the anomaly found on real data.
+      userLine(t0, 'original prompt', { uuid: 'u1', slug: 'added-by-a-later-version' }),
+    ])
+
+    const results = new LogReader().parseFile(filePath, 'claude')
+    assert.strictEqual(results.length, 1, 'the replayed duplicate must not be read as a second real prompt')
+    assert.strictEqual(results[0].card.turns, 1, 'the duplicate entry must not double-count as a second turn')
+    assert.ok(results[0].card.durationMs < 60_000, 'duration must reflect only the real span, not the duplicate\'s stale timestamp')
+  })
+})

--- a/src/test/logReader.codexSplit.test.ts
+++ b/src/test/logReader.codexSplit.test.ts
@@ -1,0 +1,198 @@
+import * as assert from 'assert'
+import * as path from 'path'
+import * as fs from 'fs'
+import * as os from 'os'
+import { LogReader, splitCodexLinesOnPromptGaps, SESSION_SPLIT_GAP_MS } from '../logReader'
+
+function writeJsonl(filePath: string, lines: Record<string, unknown>[]) {
+  fs.writeFileSync(filePath, lines.map(l => JSON.stringify(l)).join('\n') + '\n')
+}
+
+function threadSettingsApplied(ts: string) {
+  return { timestamp: ts, type: 'event_msg', payload: { type: 'thread_settings_applied' } }
+}
+
+function taskStarted(ts: string) {
+  return { timestamp: ts, type: 'event_msg', payload: { type: 'task_started', turn_id: 't-' + ts } }
+}
+
+function userMessage(ts: string, message = 'hi') {
+  return { timestamp: ts, type: 'event_msg', payload: { type: 'user_message', message } }
+}
+
+/** A turn as Codex actually logs it (confirmed on real data, exhaustively across a whole file):
+ *  thread_settings_applied, then task_started <50ms later, then the turn's user_message — all
+ *  effectively the same turn timestamp. See splitCodexLinesOnPromptGaps's own comment for why the
+ *  split boundary is built on the bookkeeping pair rather than user_message itself. */
+function turn(ts: string, message = 'hi'): Record<string, unknown>[] {
+  return [threadSettingsApplied(ts), taskStarted(ts), userMessage(ts, message)]
+}
+
+function tokenCount(ts: string, cumulativeInput: number, cumulativeOutput: number, cumulativeCachedInput = 0) {
+  return {
+    timestamp: ts,
+    type: 'event_msg',
+    payload: {
+      type: 'token_count',
+      info: {
+        model: 'gpt-5.6-luna',
+        total_token_usage: { input_tokens: cumulativeInput, output_tokens: cumulativeOutput, cached_input_tokens: cumulativeCachedInput },
+        last_token_usage: { input_tokens: 1, output_tokens: 1 },
+      },
+    },
+  }
+}
+
+function sessionMeta(ts: string, cwd: string) {
+  return { timestamp: ts, type: 'session_meta', payload: { session_id: 'sess', cwd } }
+}
+
+suite('splitCodexLinesOnPromptGaps', () => {
+  test('a single turn with no gap stays one segment', () => {
+    const lines = [...turn('2026-01-01T00:00:00.000Z'), tokenCount('2026-01-01T00:00:05.000Z', 100, 50)].map(l => JSON.stringify(l))
+    const segments = splitCodexLinesOnPromptGaps(lines)
+    assert.strictEqual(segments.length, 1)
+  })
+
+  test('two turns over the threshold split into two segments', () => {
+    const t1 = new Date(Date.parse('2026-01-01T00:00:00.000Z') + SESSION_SPLIT_GAP_MS + 1000).toISOString()
+    const lines = [...turn('2026-01-01T00:00:00.000Z'), ...turn(t1)].map(l => JSON.stringify(l))
+    const segments = splitCodexLinesOnPromptGaps(lines)
+    assert.strictEqual(segments.length, 2)
+  })
+
+  test('the boundary walks back before thread_settings_applied, not before user_message — the fix for the real bookkeeping-bleed bug', () => {
+    // Reproduces the exact real-data shape: thread_settings_applied then task_started, both
+    // <50ms before their turn's user_message, all sharing the *new* turn's timestamp. Splitting
+    // on user_message alone (or on task_started alone — an earlier, incomplete version of this
+    // fix) would leave one or both bookkeeping lines attached to the end of the previous segment,
+    // pulling its measured span forward to the new turn's arrival.
+    const t1 = new Date(Date.parse('2026-01-01T00:00:00.000Z') + SESSION_SPLIT_GAP_MS + 1000).toISOString()
+    const lines = [...turn('2026-01-01T00:00:00.000Z'), ...turn(t1)].map(l => JSON.stringify(l))
+    const segments = splitCodexLinesOnPromptGaps(lines)
+    assert.strictEqual(segments.length, 2)
+    assert.strictEqual(segments[0].length, 3, 'segment 0 keeps only its own turn, not any of the next turn\'s bookkeeping lines')
+    assert.strictEqual(JSON.parse(segments[1][0]).payload.type, 'thread_settings_applied', 'segment 1 starts with the new turn\'s earliest bookkeeping event')
+  })
+
+  test('walkback groups an unrecognized near-simultaneous bookkeeping event type too, not just the two already known', () => {
+    // Proves the walkback is generic rather than accidentally still keyed to the specific names
+    // found so far — uses a synthetic type name that isn't thread_settings_applied/task_started
+    // at all, timestamped within WALKBACK_EPSILON_MS of the following task_started/user_message.
+    const t0 = '2026-01-01T00:00:00.000Z'
+    const t1raw = Date.parse('2026-01-01T00:00:00.000Z') + SESSION_SPLIT_GAP_MS + 1000
+    const t1 = new Date(t1raw).toISOString()
+    const t1plus1s = new Date(t1raw + 1000).toISOString()  // within WALKBACK_EPSILON_MS of t1
+    const lines = [
+      ...turn(t0),
+      { timestamp: t1, type: 'event_msg', payload: { type: 'some_future_bookkeeping_event_not_yet_seen' } },
+      taskStarted(t1plus1s),
+      userMessage(t1plus1s, 'resumed'),
+    ].map(l => JSON.stringify(l))
+    const segments = splitCodexLinesOnPromptGaps(lines)
+    assert.strictEqual(segments.length, 2)
+    assert.strictEqual(segments[0].length, 3, 'the unrecognized event type must not remain attached to segment 0')
+    assert.strictEqual(JSON.parse(segments[1][0]).payload.type, 'some_future_bookkeeping_event_not_yet_seen')
+  })
+
+  test('turn_aborted triggers its own split even when the following thread_settings_applied arrives well outside the walkback epsilon', () => {
+    // Reproduces the real-data shape found in a second real transcript: when a turn was left
+    // incomplete and the user comes back later, Codex logs turn_aborted stamped with the
+    // *resumption* time, but the following turn's own thread_settings_applied/task_started can
+    // arrive anywhere from ~0.1s to 31s later (measured across 7 real occurrences in one file) —
+    // too inconsistent for WALKBACK_EPSILON_MS (2s) to reliably bridge. turn_aborted has to
+    // trigger gap detection on its own rather than depend on being swept in by a later anchor.
+    const t0 = '2026-01-01T00:00:00.000Z'
+    const abortTs = new Date(Date.parse(t0) + SESSION_SPLIT_GAP_MS + 1000).toISOString()
+    const newTurnTs = new Date(Date.parse(abortTs) + 31_000).toISOString()  // 31s later — the real worst case found
+    const lines = [
+      ...turn(t0),
+      { timestamp: abortTs, type: 'event_msg', payload: { type: 'turn_aborted' } },
+      ...turn(newTurnTs, 'resumed after 3 days'),
+    ].map(l => JSON.stringify(l))
+    const segments = splitCodexLinesOnPromptGaps(lines)
+    assert.strictEqual(segments.length, 2, 'turn_aborted itself must trigger the split, not just the later thread_settings_applied')
+    assert.strictEqual(segments[0].length, 3, 'segment 0 keeps only its own turn')
+    assert.strictEqual(JSON.parse(segments[1][0]).payload.type, 'turn_aborted', 'segment 1 starts at turn_aborted, not 31s later at thread_settings_applied')
+  })
+
+  test('a token_count event does not itself count as a prompt boundary', () => {
+    const t1 = new Date(Date.parse('2026-01-01T00:00:00.000Z') + SESSION_SPLIT_GAP_MS + 1000).toISOString()
+    const lines = [...turn('2026-01-01T00:00:00.000Z'), tokenCount(t1, 100, 50)].map(l => JSON.stringify(l))
+    const segments = splitCodexLinesOnPromptGaps(lines)
+    assert.strictEqual(segments.length, 1, 'a token_count event, even after a large gap, must not itself trigger a split')
+  })
+})
+
+suite('LogReader — Codex session splitting (integration)', () => {
+  let tmpDir: string
+
+  setup(() => { tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agentlens-codex-split-')) })
+  teardown(() => { fs.rmSync(tmpDir, { recursive: true, force: true }) })
+
+  test('a normal short session produces exactly one result with the unsuffixed session id', () => {
+    const filePath = path.join(tmpDir, 'sess-normal.jsonl')
+    writeJsonl(filePath, [
+      sessionMeta('2026-01-01T00:00:00.000Z', '/workspace'),
+      ...turn('2026-01-01T00:00:01.000Z', 'first'),
+      tokenCount('2026-01-01T00:00:05.000Z', 1000, 200),
+    ])
+    const results = new LogReader().parseFile(filePath, 'codex')
+    assert.strictEqual(results.length, 1)
+    assert.strictEqual(results[0].card.sessionId, 'sess-normal')
+  })
+
+  test('a real multi-day gap splits into two sessions, each reporting only its own token delta', () => {
+    // Reproduces the real-world shape found in an actual Codex transcript: total_token_usage
+    // climbs monotonically across the whole file with no resets, even across a multi-day gap.
+    const filePath = path.join(tmpDir, 'sess-gapped.jsonl')
+    const t0 = '2026-01-01T00:00:00.000Z'
+    const t1 = '2026-01-01T00:00:05.000Z'
+    const t2 = new Date(Date.parse(t0) + 3 * 24 * 3600_000).toISOString()  // 3 days later
+    const t3 = new Date(Date.parse(t2) + 5000).toISOString()
+    writeJsonl(filePath, [
+      sessionMeta(t0, '/workspace'),
+      ...turn(t0, 'day one work'),
+      tokenCount(t1, 16000, 150, 0),          // cumulative after segment 1's own turn
+      ...turn(t2, 'day four work'),
+      tokenCount(t3, 33700, 2200, 500),       // cumulative after segment 2's own turn — includes segment 1's 16000/150
+    ])
+
+    const results = new LogReader().parseFile(filePath, 'codex')
+    assert.strictEqual(results.length, 2, 'expected the 3-day gap to split into two sessions')
+
+    // Segment 0: no baseline, so its totals equal the raw cumulative values at that point.
+    assert.strictEqual(results[0].card.sessionId, 'sess-gapped')
+    assert.strictEqual(results[0].card.inputTokens, 16000)
+    assert.strictEqual(results[0].card.outputTokens, 150)
+
+    // Segment 1: must report only its OWN delta (33700-16000 input, 2200-150 output, 500-0
+    // cached), not the full cumulative total that would double-count segment 0's tokens.
+    assert.strictEqual(results[1].card.sessionId, 'sess-gapped#1')
+    assert.strictEqual(results[1].card.inputTokens, 500 + (33700 - 500 - 16000), 'cacheReadTokens + raw input delta')
+    assert.strictEqual(results[1].card.cacheReadTokens, 500)
+    assert.strictEqual(results[1].card.outputTokens, 2200 - 150)
+  })
+
+  test('a segment with no token_count events of its own inherits (does not reset) the running baseline for the next segment', () => {
+    const filePath = path.join(tmpDir, 'sess-empty-middle.jsonl')
+    const t0 = '2026-01-01T00:00:00.000Z'
+    const t1 = new Date(Date.parse(t0) + SESSION_SPLIT_GAP_MS + 1000).toISOString()
+    const t2 = new Date(Date.parse(t1) + SESSION_SPLIT_GAP_MS + 1000).toISOString()
+    const t3 = new Date(Date.parse(t2) + 5000).toISOString()
+    writeJsonl(filePath, [
+      sessionMeta(t0, '/workspace'),
+      ...turn(t0, 'first'),
+      tokenCount(t0, 10000, 100),
+      ...turn(t1, 'second, no token_count event follows'),  // segment 1: no usage of its own
+      ...turn(t2, 'third'),
+      tokenCount(t3, 25000, 500),  // segment 2's cumulative — must diff against segment 0's 10000/100, not segment 1's (nonexistent) usage
+    ])
+
+    const results = new LogReader().parseFile(filePath, 'codex')
+    assert.strictEqual(results.length, 3)
+    assert.strictEqual(results[0].card.inputTokens, 10000)
+    assert.strictEqual(results[1].card.inputTokens, 0, 'segment with no token_count events reports zero tokens of its own')
+    assert.strictEqual(results[2].card.inputTokens, 25000 - 10000, 'segment 2 diffs against the last real baseline (segment 0), skipping over segment 1')
+  })
+})

--- a/src/test/logReader.copilotVSCodeSplit.test.ts
+++ b/src/test/logReader.copilotVSCodeSplit.test.ts
@@ -1,0 +1,154 @@
+import * as assert from 'assert'
+import * as path from 'path'
+import * as fs from 'fs'
+import * as os from 'os'
+import { LogReader, splitCopilotVSCodeLinesOnPromptGaps, SESSION_SPLIT_GAP_MS } from '../logReader'
+
+function writeJsonl(filePath: string, lines: Record<string, unknown>[]) {
+  fs.writeFileSync(filePath, lines.map(l => JSON.stringify(l)).join('\n') + '\n')
+}
+
+function snapshot(creationDateMs: number, model = 'copilot/gpt-5.6-luna') {
+  return {
+    kind: 0,
+    v: {
+      version: 3, creationDate: creationDateMs, sessionId: 'sess',
+      requests: [], inputState: { selectedModel: { id: model, metadata: { family: model.replace(/^copilot\//, '') } } },
+    },
+  }
+}
+
+/** One `kind: 2` push adding a single new turn — the format's own "new prompt" signal. */
+function requestsPush(ts: number, message = 'hi', completionTokens?: number) {
+  const req: Record<string, unknown> = { requestId: 'r-' + ts, timestamp: ts, message: { text: message } }
+  if (completionTokens !== undefined) req['completionTokens'] = completionTokens
+  return { kind: 2, k: ['requests'], v: [req] }
+}
+
+/** A late-arriving completionTokens update (Format A) — idx addresses the *global* position in
+ *  the whole session's requests array, which is what the startingTurnIndex plumbing exists for. */
+function completionTokensSet(idx: number, tokens: number) {
+  return { kind: 1, k: ['requests', idx, 'completionTokens'], v: tokens }
+}
+
+suite('splitCopilotVSCodeLinesOnPromptGaps', () => {
+  test('a single turn with no gap stays one segment', () => {
+    const lines = [snapshot(1000), requestsPush(1000, 'hi', 5)].map(l => JSON.stringify(l))
+    assert.strictEqual(splitCopilotVSCodeLinesOnPromptGaps(lines).length, 1)
+  })
+
+  test('two turns over the threshold split into two segments', () => {
+    const lines = [snapshot(1000), requestsPush(1000), requestsPush(1000 + SESSION_SPLIT_GAP_MS + 1000)].map(l => JSON.stringify(l))
+    assert.strictEqual(splitCopilotVSCodeLinesOnPromptGaps(lines).length, 2)
+  })
+
+  test('a kind=1 update alone (no timestamp) is never itself a prompt boundary', () => {
+    const lines = [snapshot(1000), requestsPush(1000), completionTokensSet(0, 42)].map(l => JSON.stringify(l))
+    assert.strictEqual(splitCopilotVSCodeLinesOnPromptGaps(lines).length, 1)
+  })
+
+  test('a batched push of two requests uses the first request\'s timestamp for gap detection', () => {
+    const t0 = 1000
+    const t1 = t0 + SESSION_SPLIT_GAP_MS + 1000
+    const batchPush = { kind: 2, k: ['requests'], v: [
+      { requestId: 'a', timestamp: t1, message: { text: 'first of the batch' } },
+      { requestId: 'b', timestamp: t1 + 500, message: { text: 'second of the batch' } },
+    ] }
+    const lines = [snapshot(t0), requestsPush(t0), batchPush].map(l => JSON.stringify(l))
+    const segments = splitCopilotVSCodeLinesOnPromptGaps(lines)
+    assert.strictEqual(segments.length, 2, 'the batch push as a whole must still trigger the split (gap from t0)')
+    assert.strictEqual(segments[1].length, 1, 'the whole batch line stays together — a line can\'t be split internally')
+  })
+})
+
+suite('LogReader — Copilot VS Code chat session splitting (integration)', () => {
+  let tmpDir: string
+
+  setup(() => { tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agentlens-copilot-vscode-split-')) })
+  teardown(() => { fs.rmSync(tmpDir, { recursive: true, force: true }) })
+
+  test('a normal short session produces exactly one result with the unsuffixed session id', () => {
+    const filePath = path.join(tmpDir, 'sess-normal.jsonl')
+    writeJsonl(filePath, [
+      snapshot(1000),
+      requestsPush(1000, 'first', 10),
+    ])
+    const results = new LogReader().parseFile(filePath, 'copilot_vscode')
+    assert.strictEqual(results.length, 1)
+    assert.strictEqual(results[0].card.sessionId, 'sess-normal')
+  })
+
+  test('a real multi-hour gap splits into two sessions, each with its own prompt', () => {
+    const filePath = path.join(tmpDir, 'sess-gapped.jsonl')
+    const t0 = 1_700_000_000_000
+    const t1 = t0 + SESSION_SPLIT_GAP_MS + 3600_000  // over an hour past the threshold
+    writeJsonl(filePath, [
+      snapshot(t0),
+      requestsPush(t0, 'day one work', 10),
+      requestsPush(t1, 'day two work', 20),
+    ])
+
+    const results = new LogReader().parseFile(filePath, 'copilot_vscode')
+    assert.strictEqual(results.length, 2, 'expected the gap to split into two sessions')
+    assert.strictEqual(results[0].card.sessionId, 'sess-gapped')
+    assert.strictEqual(results[0].card.userRequest, 'day one work')
+    assert.strictEqual(results[1].card.sessionId, 'sess-gapped#1')
+    assert.strictEqual(results[1].card.userRequest, 'day two work')
+  })
+
+  test('segment 0 uses its own first turn\'s timestamp, not the chat panel\'s creation time, as its start', () => {
+    // Reproduces the real-data finding: a chat panel can sit open for hours before its first real
+    // message, which made sessionCreatedMs alone show a 66-73 hour "duration" on real files whose
+    // actual turns spanned well under 90 minutes. creationDate here is 5 hours before the first
+    // real turn — startTime/durationMs must reflect the turn, not the panel's creation.
+    const filePath = path.join(tmpDir, 'sess-stale-creation-date.jsonl')
+    const panelCreatedMs = 1_700_000_000_000
+    const firstTurnMs = panelCreatedMs + 5 * 3600_000
+    const secondTurnMs = firstTurnMs + 5 * 60_000
+    writeJsonl(filePath, [
+      snapshot(panelCreatedMs),
+      requestsPush(firstTurnMs, 'finally typed something', 10),
+      requestsPush(secondTurnMs, 'a follow-up', 5),
+    ])
+    const results = new LogReader().parseFile(filePath, 'copilot_vscode')
+    assert.strictEqual(results.length, 1)
+    assert.strictEqual(results[0].card.startTime, new Date(firstTurnMs).toISOString())
+    assert.ok(results[0].card.durationMs < 60 * 60_000, 'duration should reflect the ~5min between turns, not the 5+ hours since panel creation')
+  })
+
+  test('a segment after the first still has a usable start time despite no kind=0 snapshot of its own', () => {
+    // sessionCreatedMs (the kind=0 snapshot) only appears once, in segment 0 — segment 1 must
+    // fall back to its own earliest turn timestamp rather than being dropped for lack of one.
+    const filePath = path.join(tmpDir, 'sess-no-snapshot-in-later-segment.jsonl')
+    const t0 = 1_700_000_000_000
+    const t1 = t0 + SESSION_SPLIT_GAP_MS + 3600_000
+    writeJsonl(filePath, [
+      snapshot(t0),
+      requestsPush(t0, 'first', 10),
+      requestsPush(t1, 'second', 20),
+    ])
+    const results = new LogReader().parseFile(filePath, 'copilot_vscode')
+    assert.strictEqual(results.length, 2)
+    assert.strictEqual(results[1].card.startTime, new Date(t1).toISOString())
+  })
+
+  test('a late-arriving completionTokens update in a later segment addresses the correct turn via startingTurnIndex', () => {
+    // Reproduces the format's real correctness wrinkle: kind=1 updates address a request by its
+    // position in the *whole session's* requests array, not a position relative to whichever
+    // segment it falls in. Segment 1 here is the file's 2nd turn overall (global index 1) — its
+    // own completionTokens update must land on that global index, not reset to a local index 0.
+    const filePath = path.join(tmpDir, 'sess-global-index.jsonl')
+    const t0 = 1_700_000_000_000
+    const t1 = t0 + SESSION_SPLIT_GAP_MS + 3600_000
+    writeJsonl(filePath, [
+      snapshot(t0),
+      requestsPush(t0, 'first', 10),          // global index 0
+      requestsPush(t1, 'second'),             // global index 1 — no completionTokens in the push itself
+      completionTokensSet(1, 25),             // late-arriving update, addresses global index 1
+    ])
+    const results = new LogReader().parseFile(filePath, 'copilot_vscode')
+    assert.strictEqual(results.length, 2)
+    assert.strictEqual(results[0].card.outputTokens, 10)
+    assert.strictEqual(results[1].card.outputTokens, 25, 'the late completionTokens update must land on segment 1\'s own turn, not be lost or miscounted')
+  })
+})

--- a/standalone/server.ts
+++ b/standalone/server.ts
@@ -270,8 +270,10 @@ async function startLogIngestion() {
   for (const file of files) {
     if (file.agentKey === 'opencode') continue  // already handled above
     try {
-      const result = logReader.parseFile(file.filePath, file.agentKey)
-      if (result) {
+      // Usually one result; a Claude Code transcript split by a large gap between prompts
+      // (see splitClaudeLinesOnPromptGaps) can yield more than one.
+      const results = logReader.parseFile(file.filePath, file.agentKey)
+      for (const result of results) {
         result.card.oneShotStats = computeOneShotStats(result.card)
         logSessions.set(result.card.sessionId, result.card)
         countByKey.set(file.agentKey, (countByKey.get(file.agentKey) ?? 0) + 1)


### PR DESCRIPTION
## Summary

Sessions read from log files (as opposed to OTEL telemetry) were treated as one session per file, unconditionally — `sessionId = path.basename(filePath, '.jsonl')`. For a long-running CLI terminal or an idle VS Code chat panel, one file can span real days or weeks, so "session duration" read as wildly, sometimes absurdly, inflated (333.6h, 169h, and more, observed directly in a real Sessions list sorted by duration).

An earlier, smaller fix (idle-gap-capping active time, branch `session-duration-idle-gaps`, not in this PR) turned out insufficient — checked against a real 53-hour, 3-day transcript, it only got the number down to 11.46 hours, still nowhere near accurate for any single prompt within it. The real fix is this one: split a file into multiple session cards at a genuinely large gap (>30 min) between consecutive prompts, never mid-turn, so each result is a complete, coherent chunk of work.

Every fix in this PR came from checking real transcript data on this machine, not from reasoning about a format in the abstract — several non-obvious bugs were only found this way (see below).

## What's covered

**Claude Code CLI** — split on `type: 'user'` entries, plus:
- `dedupeByUuid()`: found and fixed a real, distinct bug during validation — 466 duplicate message uuids in one real transcript (Claude Code re-serializing and re-appending a block of earlier history on some resume path). Left uncorrected, this both corrupted gap detection and would double-count turns/tokens.
- Hardened gap detection against a single isolated out-of-order timestamp (also found on real data) corrupting the baseline for every comparison after it.

**Codex CLI** — split on `event_msg` events (`user_message`, `turn_aborted`), plus three real-data-driven fixes:
1. Codex's `token_count` events report a *cumulative* total for the whole file, not per-turn — naive slicing would give every segment after the first the whole session's running total. Fixed by threading each segment's ending cumulative usage forward as the next segment's baseline.
2. A `thread_settings_applied`+`task_started` bookkeeping pair, logged milliseconds before every turn's `user_message`, kept bleeding into the end of the *previous* segment. Fixed generally with a walkback that groups any near-simultaneous preceding lines regardless of type, rather than naming specific event types (a losing game — confirmed by a second real file needing a third event type, `turn_aborted`, handled separately since its timing relative to the next turn was too inconsistent for the walkback to bridge).

**Copilot VS Code chat** — split on `kind: 2` requests-array pushes, plus two more real-data-driven fixes:
1. This format's updates address a turn by its position in the *whole session's* requests array, not relative to whichever segment it falls in — re-parsing each segment from a local counter would misalign every such update after the first (and broke `userRequest` capture, which had the same implicit "turn 0" assumption). Fixed by threading a running turn-index offset across segments.
2. The chat panel's creation timestamp isn't "when the first real message was sent" — two of four real files checked showed 66–73 hour segment-0 durations purely from an idle panel sitting open before its first prompt. Fixed by always preferring the segment's own earliest real turn timestamp.

**Not covered**: Copilot CLI has the identical structural flaw but isn't touched — this machine has never run it (no real data to validate against, and every other fix here came specifically from checking real data rather than guessing).

## Verified on real data, not just synthetic tests

- This repo's own 53-hour, 7,619-line Claude Code transcript: 1 → 10 segments, largest 41.3 min.
- Two real Codex files from an actual Sessions list (333.6h and 169.0h as originally reported): 12 segments (largest 41.3 min) and 33 segments (largest 218.7 min, checked directly and confirmed genuinely continuous work, not a bug) respectively.
- Four real Copilot VS Code chat files (2h/28.6h/44.7h/121.7h spans): largest resulting session duration 22.8/40.4/92.9/79.0 minutes respectively.

## Test plan

- [x] `tsc --noEmit` (both configs) clean
- [x] `eslint src media/src` — 0 errors (pre-existing warnings only)
- [x] Full `mocha` suite — 375/375 passing (35 new tests across the three formats)
- [x] Production build clean
- [x] Manually validated against 7 real session files across all three formats (see above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)