### PR TITLE
feat: paginate the Sessions table with a configurable default page size

### DIFF
--- a/media/src/App.tsx
+++ b/media/src/App.tsx
@@ -486,6 +486,12 @@ function TimeRangePicker({ hideAgentFilter = false }: { hideAgentFilter?: boolea
   const [searchError, setSearchError] = useState<string | null>(null)
   const tab = normalizeTabId(activeTab.value)
   const showReset = tab !== 'help'
+  // Pagination only makes sense for the Sessions tab's own table — every other tab sharing this
+  // row has no notion of "pages." Mirrors the bottom footer's own controls in Sessions.tsx exactly
+  // (same styling, same sessionsPage signal) so the two never disagree.
+  const showPaging = tab === 'sessions'
+  const sessionCount = filteredSessions.value.length
+  const { page: sessPage, totalPages: sessTotalPages } = showPaging ? getSessionsPagination(sessionCount) : { page: 0, totalPages: 1 }
 
   const isFiltered = sessionTextFilter.value !== '' ||
     evidenceSessionIds.value !== null ||
@@ -643,6 +649,24 @@ function TimeRangePicker({ hideAgentFilter = false }: { hideAgentFilter?: boolea
           title="Refresh this time range"
         ><IconRefresh /></button>
       )}
+
+      {/* Session paging — same controls, same styling, same signal as the table's own footer in
+          Sessions.tsx, just also reachable without scrolling down first. */}
+      {showPaging && sessTotalPages > 1 && (
+        <span style="margin-left:auto;display:flex;align-items:center;gap:8px;font-size:11px;color:var(--muted);white-space:nowrap">
+          <button
+            onClick={() => sessionsPage.value = Math.max(0, sessPage - 1)}
+            disabled={sessPage === 0}
+            style={`padding:2px 8px;font-size:11px;border:1px solid var(--border);border-radius:3px;background:transparent;color:var(--fg);cursor:${sessPage === 0 ? 'default' : 'pointer'};opacity:${sessPage === 0 ? 0.4 : 1}`}
+          >‹ Prev</button>
+          <span>Page {sessPage + 1} of {sessTotalPages}</span>
+          <button
+            onClick={() => sessionsPage.value = Math.min(sessTotalPages - 1, sessPage + 1)}
+            disabled={sessPage >= sessTotalPages - 1}
+            style={`padding:2px 8px;font-size:11px;border:1px solid var(--border);border-radius:3px;background:transparent;color:var(--fg);cursor:${sessPage >= sessTotalPages - 1 ? 'default' : 'pointer'};opacity:${sessPage >= sessTotalPages - 1 ? 0.4 : 1}`}
+          >Next ›</button>
+        </span>
+      )}
     </div>
   )
 }
@@ -741,11 +765,6 @@ function SearchFilterBar() {
   const iFilter = initiatorFilter.value
   const dsFilter = dataSourceFilter.value
   const evIds = evidenceSessionIds.value
-  // Pagination only makes sense for the Sessions tab's own table — every other tab that shares
-  // this filter bar has no notion of "pages."
-  const showPaging = normalizeTabId(activeTab.value) === 'sessions'
-  const sessionCount = filteredSessions.value.length
-  const { page, totalPages } = showPaging ? getSessionsPagination(sessionCount) : { page: 0, totalPages: 1 }
 
   return (
     <div style="display:flex;flex-direction:column;background:var(--vscode-editor-background);border-bottom:1px solid var(--vscode-panel-border);flex-shrink:0">
@@ -780,24 +799,7 @@ function SearchFilterBar() {
         value={dsFilter}
         onChange={v => { dataSourceFilter.value = v }}
       />
-      <span style="margin-left:auto;font-size:10px;color:var(--muted);white-space:nowrap;padding-right:2px">{sessionCount} sessions</span>
-      {showPaging && totalPages > 1 && (
-        <span style="display:flex;align-items:center;gap:4px;font-size:10px;color:var(--muted);white-space:nowrap">
-          <button
-            onClick={() => sessionsPage.value = Math.max(0, page - 1)}
-            disabled={page === 0}
-            title="Previous page"
-            style={`padding:1px 6px;font-size:10px;border:1px solid var(--border);border-radius:3px;background:transparent;color:var(--fg);cursor:${page === 0 ? 'default' : 'pointer'};opacity:${page === 0 ? 0.4 : 1}`}
-          >‹</button>
-          <span>{page + 1}/{totalPages}</span>
-          <button
-            onClick={() => sessionsPage.value = Math.min(totalPages - 1, page + 1)}
-            disabled={page >= totalPages - 1}
-            title="Next page"
-            style={`padding:1px 6px;font-size:10px;border:1px solid var(--border);border-radius:3px;background:transparent;color:var(--fg);cursor:${page >= totalPages - 1 ? 'default' : 'pointer'};opacity:${page >= totalPages - 1 ? 0.4 : 1}`}
-          >›</button>
-        </span>
-      )}
+      <span style="margin-left:auto;font-size:10px;color:var(--muted);white-space:nowrap;padding-right:2px">{filteredSessions.value.length} sessions</span>
       </div>
     </div>
   )

--- a/media/src/App.tsx
+++ b/media/src/App.tsx
@@ -25,7 +25,7 @@ import { Pricing } from './tabs/Pricing'
 import { Patterns } from './tabs/Patterns'
 import { Automation, checkAutomations } from './tabs/Automation'
 import { instructionFiles, appliedSuggestions, dismissedIds } from './tabs/Instructions'
-import { IngestionToggles, McpToggle, OtelReconfigureButton, ThemeToggle } from './tabs/Settings'
+import { IngestionToggles, McpToggle, OtelReconfigureButton, ThemeToggle, SessionsPageSizeControl } from './tabs/Settings'
 
 
 // Standalone opens with the left activity sidebar collapsed by default, since it
@@ -104,6 +104,7 @@ function ConfigPanel() {
         >×</button>
       </div>
       {window.__STANDALONE__ === true && <ThemeToggle />}
+      <SessionsPageSizeControl />
       <IngestionToggles />
       <OtelReconfigureButton />
       <McpToggle />

--- a/media/src/App.tsx
+++ b/media/src/App.tsx
@@ -11,6 +11,7 @@ import {
   sessionSortKey, sessionSortDir,
   workspaceFilter, availableWorkspaces, shortWorkspaceName,
   enableOtelIngestion, enableLogIngestion, otlpPort, otelReconfigureResult, type OtelReconfigureResult,
+  sessionsPage, getSessionsPagination,
 } from './state'
 import type { TimelineEntry, AgentFilter, InitiatorFilter, DataSourceFilter, WorkspaceFilter, DailyStatRow, LifetimeStats, BurnRate, Projection, SessionSummaryCard, GitOutcome } from './types'
 
@@ -740,6 +741,11 @@ function SearchFilterBar() {
   const iFilter = initiatorFilter.value
   const dsFilter = dataSourceFilter.value
   const evIds = evidenceSessionIds.value
+  // Pagination only makes sense for the Sessions tab's own table — every other tab that shares
+  // this filter bar has no notion of "pages."
+  const showPaging = normalizeTabId(activeTab.value) === 'sessions'
+  const sessionCount = filteredSessions.value.length
+  const { page, totalPages } = showPaging ? getSessionsPagination(sessionCount) : { page: 0, totalPages: 1 }
 
   return (
     <div style="display:flex;flex-direction:column;background:var(--vscode-editor-background);border-bottom:1px solid var(--vscode-panel-border);flex-shrink:0">
@@ -774,7 +780,24 @@ function SearchFilterBar() {
         value={dsFilter}
         onChange={v => { dataSourceFilter.value = v }}
       />
-      <span style="margin-left:auto;font-size:10px;color:var(--muted);white-space:nowrap;padding-right:2px">{filteredSessions.value.length} sessions</span>
+      <span style="margin-left:auto;font-size:10px;color:var(--muted);white-space:nowrap;padding-right:2px">{sessionCount} sessions</span>
+      {showPaging && totalPages > 1 && (
+        <span style="display:flex;align-items:center;gap:4px;font-size:10px;color:var(--muted);white-space:nowrap">
+          <button
+            onClick={() => sessionsPage.value = Math.max(0, page - 1)}
+            disabled={page === 0}
+            title="Previous page"
+            style={`padding:1px 6px;font-size:10px;border:1px solid var(--border);border-radius:3px;background:transparent;color:var(--fg);cursor:${page === 0 ? 'default' : 'pointer'};opacity:${page === 0 ? 0.4 : 1}`}
+          >‹</button>
+          <span>{page + 1}/{totalPages}</span>
+          <button
+            onClick={() => sessionsPage.value = Math.min(totalPages - 1, page + 1)}
+            disabled={page >= totalPages - 1}
+            title="Next page"
+            style={`padding:1px 6px;font-size:10px;border:1px solid var(--border);border-radius:3px;background:transparent;color:var(--fg);cursor:${page >= totalPages - 1 ? 'default' : 'pointer'};opacity:${page >= totalPages - 1 ? 0.4 : 1}`}
+          >›</button>
+        </span>
+      )}
       </div>
     </div>
   )

--- a/media/src/state.ts
+++ b/media/src/state.ts
@@ -226,6 +226,17 @@ export function setSessionsPageSize(size: number): void {
 // changes shape, rather than leaving the user stranded on a now-out-of-range page.
 export const sessionsPage = signal(0)
 
+/** Shared by Sessions.tsx (the table itself) and App.tsx's SearchFilterBar (the compact Prev/Next
+ *  next to the filter row) so both always agree on the current page and page count — clamps
+ *  locally rather than writing back into the signal, so loosening a filter later makes a
+ *  previously out-of-range page valid again on its own. */
+export function getSessionsPagination(totalCount: number): { page: number; totalPages: number; pageSize: number } {
+  const pageSize = sessionsPageSize.value
+  const totalPages = Math.max(1, Math.ceil(totalCount / pageSize))
+  const page = Math.min(sessionsPage.value, totalPages - 1)
+  return { page, totalPages, pageSize }
+}
+
 // ── Navigation helpers ────────────────────────────────────────────────────────
 
 export function goToHelp(anchor: string): void {

--- a/media/src/state.ts
+++ b/media/src/state.ts
@@ -113,6 +113,10 @@ export const gitOutcomes = signal<Record<string, GitOutcome | null>>({})
 // Traces and Flow auto-open to it; a context bar shows it across all tabs.
 export const focusedSessionId = signal<string | null>(null)
 
+// sessionLimit scopes how many recent sessions feed Alerts/Charts/Cost/Automation's analysis
+// (see displaySessions below) — a data-scoping concept, unrelated to the Sessions table's own
+// pagination (sessionsPageSize/sessionsPage, defined further down), which only controls how many
+// rows render at once and never excludes a session from any other tab's analysis.
 export const sessionLimit = signal(25)
 export const selectedAgentFilter = signal<AgentFilter>('all')
 export const initiatorFilter = signal<InitiatorFilter>('all')
@@ -185,6 +189,42 @@ export function setThemePreference(pref: ThemePreference): void {
   } catch { /* localStorage unavailable — preference just won't survive a reload */ }
   applyThemeAttribute(pref)
 }
+
+// ── Sessions table pagination (both VS Code and standalone — no built-in equivalent to defer to
+//    in either context, unlike theme) ──────────────────────────────────────────
+
+// Rendering every matching session as its own live component with no cap was the mechanism behind
+// .staged-issues/session-list-scaling.md — fine at hundreds, unbounded past that, and the one time
+// range ("All") most likely to be selected had no cap at all. 50 is picked as a reasonable
+// default — enough to browse a full day or two of normal usage on one page without constant
+// clicking, small enough to keep the DOM light — not a measured number, same honesty standard as
+// every other threshold in this project; adjustable in Settings for anyone who wants it larger.
+export const SESSIONS_PAGE_SIZE_OPTIONS = [25, 50, 100, 250, 500] as const
+const DEFAULT_SESSIONS_PAGE_SIZE = 50
+const SESSIONS_PAGE_SIZE_STORAGE_KEY = 'agentlens-sessions-page-size'
+
+function readStoredSessionsPageSize(): number {
+  try {
+    const v = Number(localStorage.getItem(SESSIONS_PAGE_SIZE_STORAGE_KEY))
+    if (SESSIONS_PAGE_SIZE_OPTIONS.includes(v as typeof SESSIONS_PAGE_SIZE_OPTIONS[number])) return v
+  } catch { /* localStorage unavailable — fall back to the default every load */ }
+  return DEFAULT_SESSIONS_PAGE_SIZE
+}
+
+export const sessionsPageSize = signal<number>(readStoredSessionsPageSize())
+
+export function setSessionsPageSize(size: number): void {
+  sessionsPageSize.value = size
+  sessionsPage.value = 0  // changing page size mid-browse would otherwise land on a confusing offset
+  try {
+    localStorage.setItem(SESSIONS_PAGE_SIZE_STORAGE_KEY, String(size))
+  } catch { /* localStorage unavailable — preference just won't survive a reload */ }
+}
+
+// Current page, 0-indexed. Deliberately not persisted — always start back at the most recent
+// sessions on reload, and reset it (see Sessions.tsx) whenever the underlying filtered list
+// changes shape, rather than leaving the user stranded on a now-out-of-range page.
+export const sessionsPage = signal(0)
 
 // ── Navigation helpers ────────────────────────────────────────────────────────
 

--- a/media/src/tabs/Sessions.tsx
+++ b/media/src/tabs/Sessions.tsx
@@ -4,6 +4,7 @@ import {
   focusedSessionId, vscode, ignoredInsightKeys,
   sessionSortKey, sessionSortDir, type SortKey,
   workspaceFilter, shortWorkspaceName, goToHelp,
+  sessionsPageSize, sessionsPage,
 } from '../state'
 import {
   getAgentColor, getAgentSourceLabel, formatMs, formatCompact, formatSessionTime,
@@ -469,6 +470,17 @@ export function Sessions() {
   const thSort = thBase + ';cursor:pointer;color:var(--fg)'
   const thMuted = thBase + ';color:var(--muted);font-weight:500'
 
+  // Rendering every matching session as its own live component with no cap was the mechanism
+  // behind .staged-issues/session-list-scaling.md — clamped locally rather than writing the
+  // clamp back into the signal, so loosening a filter later makes a previously out-of-range page
+  // valid again on its own, with no separate reset needed.
+  const pageSize = sessionsPageSize.value
+  const totalPages = Math.max(1, Math.ceil(sessions.length / pageSize))
+  const page = Math.min(sessionsPage.value, totalPages - 1)
+  const pageSessions = sessions.slice(page * pageSize, (page + 1) * pageSize)
+  const rangeStart = sessions.length === 0 ? 0 : page * pageSize + 1
+  const rangeEnd = Math.min((page + 1) * pageSize, sessions.length)
+
   return (
     <div id="sessions-content" style="padding-top:8px">
       <div class="h-scroll-hint">
@@ -486,14 +498,30 @@ export function Sessions() {
           </tr>
         </thead>
         <tbody>
-          {sessions.map(sess => (
+          {pageSessions.map(sess => (
             <SessionRow key={sess.sessionId} sess={sess} showWorkspace={showWorkspace} />
           ))}
         </tbody>
       </table>
       </div>
-      <div style="padding:6px 8px;font-size:11px;color:var(--muted);border-top:1px solid var(--vscode-panel-border)">
+      <div style="padding:6px 8px;font-size:11px;color:var(--muted);border-top:1px solid var(--vscode-panel-border);display:flex;align-items:center;justify-content:space-between;flex-wrap:wrap;gap:8px">
         <span>{(sessionSummary.value?.sessions?.length ?? 0)} sessions stored — managed by retention policy</span>
+        {totalPages > 1 && (
+          <span style="display:flex;align-items:center;gap:8px">
+            <span>Showing {rangeStart}–{rangeEnd} of {sessions.length}</span>
+            <button
+              onClick={() => sessionsPage.value = Math.max(0, page - 1)}
+              disabled={page === 0}
+              style={`padding:2px 8px;font-size:11px;border:1px solid var(--border);border-radius:3px;background:transparent;color:var(--fg);cursor:${page === 0 ? 'default' : 'pointer'};opacity:${page === 0 ? 0.4 : 1}`}
+            >‹ Prev</button>
+            <span>Page {page + 1} of {totalPages}</span>
+            <button
+              onClick={() => sessionsPage.value = Math.min(totalPages - 1, page + 1)}
+              disabled={page >= totalPages - 1}
+              style={`padding:2px 8px;font-size:11px;border:1px solid var(--border);border-radius:3px;background:transparent;color:var(--fg);cursor:${page >= totalPages - 1 ? 'default' : 'pointer'};opacity:${page >= totalPages - 1 ? 0.4 : 1}`}
+            >Next ›</button>
+          </span>
+        )}
       </div>
     </div>
   )

--- a/media/src/tabs/Sessions.tsx
+++ b/media/src/tabs/Sessions.tsx
@@ -4,7 +4,7 @@ import {
   focusedSessionId, vscode, ignoredInsightKeys,
   sessionSortKey, sessionSortDir, type SortKey,
   workspaceFilter, shortWorkspaceName, goToHelp,
-  sessionsPageSize, sessionsPage,
+  sessionsPage, getSessionsPagination,
 } from '../state'
 import {
   getAgentColor, getAgentSourceLabel, formatMs, formatCompact, formatSessionTime,
@@ -471,12 +471,9 @@ export function Sessions() {
   const thMuted = thBase + ';color:var(--muted);font-weight:500'
 
   // Rendering every matching session as its own live component with no cap was the mechanism
-  // behind .staged-issues/session-list-scaling.md — clamped locally rather than writing the
-  // clamp back into the signal, so loosening a filter later makes a previously out-of-range page
-  // valid again on its own, with no separate reset needed.
-  const pageSize = sessionsPageSize.value
-  const totalPages = Math.max(1, Math.ceil(sessions.length / pageSize))
-  const page = Math.min(sessionsPage.value, totalPages - 1)
+  // behind .staged-issues/session-list-scaling.md — see getSessionsPagination's own doc comment
+  // for why the clamping happens there rather than here.
+  const { page, totalPages, pageSize } = getSessionsPagination(sessions.length)
   const pageSessions = sessions.slice(page * pageSize, (page + 1) * pageSize)
   const rangeStart = sessions.length === 0 ? 0 : page * pageSize + 1
   const rangeEnd = Math.min((page + 1) * pageSize, sessions.length)

--- a/media/src/tabs/Settings.tsx
+++ b/media/src/tabs/Settings.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'preact/hooks'
-import { enableOtelIngestion, enableLogIngestion, otlpPort, vscode, otelReconfigureResult, type OtelReconfigureResult, themePreference, setThemePreference, type ThemePreference } from '../state'
+import { enableOtelIngestion, enableLogIngestion, otlpPort, vscode, otelReconfigureResult, type OtelReconfigureResult, themePreference, setThemePreference, type ThemePreference, sessionsPageSize, setSessionsPageSize, SESSIONS_PAGE_SIZE_OPTIONS } from '../state'
 
 function sendConfig(key: string, value: boolean) {
   if (vscode) {
@@ -104,6 +104,28 @@ export function ThemeToggle() {
           </button>
         ))}
       </div>
+    </div>
+  )
+}
+
+// Both VS Code and standalone — unlike theme, there's no IDE-native equivalent to defer to. See
+// .staged-issues/session-list-scaling.md for why this exists: the Sessions table rendered every
+// matching session as its own component with no cap, and the most common view ("All" time) had no
+// limit applied at all.
+export function SessionsPageSizeControl() {
+  const current = sessionsPageSize.value
+
+  return (
+    <div style="padding:12px 16px;border-bottom:1px solid var(--border)">
+      <div style="font-size:12px;font-weight:600;color:var(--fg);margin-bottom:2px">Sessions per page</div>
+      <div style="font-size:11px;color:var(--muted);margin-bottom:6px">How many sessions the Sessions tab renders at once, with paging for the rest.</div>
+      <select
+        value={current}
+        onChange={e => setSessionsPageSize(Number((e.target as HTMLSelectElement).value))}
+        style="width:100%;padding:4px 6px;font-size:12px;border:1px solid var(--border);border-radius:3px;background:var(--vscode-dropdown-background,var(--card-bg));color:var(--fg)"
+      >
+        {SESSIONS_PAGE_SIZE_OPTIONS.map(n => <option key={n} value={n}>{n} per page</option>)}
+      </select>
     </div>
   )
 }


### PR DESCRIPTION
## Summary

The Sessions table rendered every matching session as its own live component with no cap, and the one time range most likely to be selected ("All") had no limit applied at all — `sessionLimit` (default 25) only takes effect through `displaySessions`, which every other time range uses but "All" bypasses entirely. Fine at hundreds of sessions (this machine's real dataset), unbounded past that with no visibility into where it would actually break. Timely given the just-merged session-splitting work (#225), which multiplies session count per log file.

## What's implemented

- **`sessionsPageSize`** (default **50**, adjustable to 25/100/250/500 in Settings, persisted via `localStorage`) and **`sessionsPage`**, both in `state.ts`. Deliberately a separate signal from `sessionLimit` — that one scopes how many sessions feed Alerts/Charts/Cost/Automation's analysis, a different question from how many rows render at once, and touching it risked changing behavior in four other tabs.
- Client-side pagination over the already-filtered/sorted list in `Sessions.tsx`, applied uniformly across every time range including "All."
- **Paging controls in two places, kept in sync via a shared `getSessionsPagination()` helper**: the table's own bottom footer ("Showing X–Y of Z · ‹ Prev · Page N of M · Next ›"), and identical controls on the Time/Agent filter row at the top (only rendered on the Sessions tab, since that row is shared with Analytics/Advisor/etc., which have no notion of pages).
- `SessionsPageSizeControl` in Settings, rendered in both VS Code and standalone (no IDE-native equivalent to defer to, unlike the theme toggle).

## Verified in-browser (Playwright, real data — 97 sessions on this machine)

- Page 1 renders exactly 50 DOM rows, not 97
- Next → "Showing 51–97 of 97", 47 rows, Next correctly disabled on the last page
- Changing the Settings dropdown to 25 immediately re-renders and shows "Page 1 of 4"; the choice survives a full reload
- Clicking either the top-row or bottom-footer controls updates both in sync
- Confirmed hidden on non-Sessions tabs (e.g. Analytics) that share the same filter row

## Not done (see `.staged-issues/session-list-scaling.md` for the original investigation and why these are reasonable follow-ups rather than blocking this pass)

Ships as a client-side slice over the existing in-memory session list — doesn't reduce network payload or backend query cost. True virtualization, wiring to the backend's existing `searchSessions()` pagination, and session-count-based retention (standalone's `logSessions` map still has no cap) are all still open.

## Test plan

- [x] `tsc --noEmit` (both configs) clean
- [x] `eslint src media/src` — 0 errors (pre-existing warnings only)
- [x] Full `mocha` suite — 340/340 passing (no backend changes; frontend has no existing test harness in this repo)
- [x] Production build clean
- [x] Manually verified in-browser end to end (see above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)