### PR TITLE
Show version in Sessions footer, drop redundant retention line and Help page version

### DIFF
--- a/media/src/tabs/Help.tsx
+++ b/media/src/tabs/Help.tsx
@@ -142,9 +142,6 @@ function Toc() {
         <div style="display:flex;gap:4px;flex-wrap:nowrap;overflow-x:auto;scrollbar-width:none;flex:1;min-width:0;padding-left:12px">
           {TOC_SECTIONS.map(s => <a href={s.href}>{s.heading}</a>)}
         </div>
-        {window.__VERSION__ && (
-          <span style="font-size:10px;color:var(--muted);white-space:nowrap;flex-shrink:0">v{window.__VERSION__}</span>
-        )}
       </nav>
     </>
   )

--- a/media/src/tabs/Sessions.tsx
+++ b/media/src/tabs/Sessions.tsx
@@ -502,7 +502,7 @@ export function Sessions() {
       </table>
       </div>
       <div style="padding:6px 8px;font-size:11px;color:var(--muted);border-top:1px solid var(--vscode-panel-border);display:flex;align-items:center;justify-content:space-between;flex-wrap:wrap;gap:8px">
-        <span>{(sessionSummary.value?.sessions?.length ?? 0)} sessions stored — managed by retention policy</span>
+        {window.__VERSION__ && <span>AgentLens v{window.__VERSION__}</span>}
         {totalPages > 1 && (
           <span style="display:flex;align-items:center;gap:8px">
             <span>Showing {rangeStart}–{rangeEnd} of {sessions.length}</span>


### PR DESCRIPTION
## Summary
- Sessions table footer's "N sessions stored — managed by retention policy" line was redundant with the filter row's own session count and, when paginated, the footer's adjacent "Showing X-Y of Z" text — removed it.
- Removed the version display from the Help page's `Toc()` nav bar.
- The footer now shows `AgentLens vX.X.X` in the slot the retention line used to occupy, reusing the existing `window.__VERSION__` global already injected in both the VS Code webview and standalone contexts — no new version plumbing.

## Verification
- `tsc --noEmit` clean on both `media/tsconfig.json` and `tsconfig.json`
- `eslint src media/src` — 0 errors (same pre-existing warnings)
- Full mocha suite passing (375/375)
- `node esbuild.js --production` clean
- Verified visually against real local data via Playwright: Sessions footer reads "AgentLens v0.13.0"; Help page TOC has 0 occurrences of the version string

🤖 Generated with [Claude Code](https://claude.com/claude-code)