### PR TITLE
Color-code Sessions rows that are segments of the same split conversation

### DIFF
--- a/media/src/tabs/Help.tsx
+++ b/media/src/tabs/Help.tsx
@@ -462,6 +462,7 @@ function SessionsSection() {
       <h3 class="help-heading">{HELP_SECTIONS.sessions.heading}</h3>
       <div class="help-overview-body">
         <p>The Sessions tab shows all recorded sessions as a sortable table — timestamp, prompt, model, tokens, duration, and estimated cost per row. Use the filter bar to search by text, filter by agent, data source (OTEL / Log), or initiator (User / Agent / API), set a time range, or cap the number of rows shown. The Reset button clears all active filters back to defaults.</p>
+        <p>Claude Code, Codex, and Copilot Chat (VS Code) each write one log file per work session on disk — but a single file can span multiple genuinely separate conversations if a long idle gap (30+ minutes) separates them, so AgentLens splits it into one session card per conversation rather than showing one entry with a misleading multi-hour (or multi-day) duration. A colored bar on the left edge of a row marks sessions that came from the same original file — same color means same conversation, split apart by time. Hover the bar for its position (e.g. "Part 2 of 5"). Only sessions still visible under the active filters are colored; if a filter hides a sibling, the remaining row isn't colored — nothing implies a hidden sibling exists.</p>
         <p>Click any row to expand it in-place. Five sub-tabs appear beneath the row:</p>
 
         <h4 style={subHeadStyle}>Sub-tabs</h4>

--- a/media/src/tabs/Sessions.tsx
+++ b/media/src/tabs/Sessions.tsx
@@ -8,7 +8,7 @@ import {
 } from '../state'
 import {
   getAgentColor, getAgentSourceLabel, formatMs, formatCompact, formatSessionTime,
-  getDataSourceBadgeHtml, getInitiatorBadgeHtml,
+  getDataSourceBadgeHtml, getInitiatorBadgeHtml, getConversationColor,
 } from '../utils'
 import { calcSessionCost, oneShotRate, avgEditsPerFile } from '../sessionMetrics'
 import { fmtUsd } from './Cost'
@@ -322,9 +322,38 @@ function SessionDetail({ sess }: { sess: SessionSummaryCard }) {
   )
 }
 
+// A log file can now split into several session cards when a large idle gap separates two real
+// conversations within it (see splitLinesOnPromptGaps in logReader.ts) — those cards share a
+// conversationId. Builds a per-sessionId lookup (color + "part X of Y") for every session that
+// still has 2+ siblings visible in the given list, so the Sessions table can color-code and label
+// rows that are really one conversation split across multiple cards. Computed over the full
+// filtered list (not just the current page) so a group's color/labels stay consistent regardless
+// of which page a sibling happens to land on; a sibling hidden by an active filter just means that
+// group won't be colored at all here (nothing misleading — no "phantom" sibling implied).
+function buildConversationInfo(sessions: SessionSummaryCard[]): Map<string, { color: string; index: number; total: number }> {
+  const byConversation = new Map<string, SessionSummaryCard[]>()
+  for (const s of sessions) {
+    if (!s.conversationId) continue
+    const group = byConversation.get(s.conversationId)
+    if (group) group.push(s)
+    else byConversation.set(s.conversationId, [s])
+  }
+  const info = new Map<string, { color: string; index: number; total: number }>()
+  for (const [conversationId, members] of byConversation) {
+    if (members.length < 2) continue
+    const color = getConversationColor(conversationId)
+    const ordered = [...members].sort((a, b) => new Date(a.startTime).getTime() - new Date(b.startTime).getTime())
+    ordered.forEach((m, i) => info.set(m.sessionId, { color, index: i + 1, total: ordered.length }))
+  }
+  return info
+}
+
 // ── Table row ─────────────────────────────────────────────────────────────────
 
-function SessionRow({ sess, showWorkspace }: { sess: SessionSummaryCard; showWorkspace: boolean }) {
+function SessionRow({ sess, showWorkspace, conversation }: {
+  sess: SessionSummaryCard; showWorkspace: boolean
+  conversation?: { color: string; index: number; total: number }
+}) {
   const [expanded, setExpanded] = useState(false)
   const isFocused = focusedSessionId.value === sess.sessionId
   const rowRef = useRef<HTMLTableRowElement>(null)
@@ -354,6 +383,17 @@ function SessionRow({ sess, showWorkspace }: { sess: SessionSummaryCard; showWor
         onClick={toggle}
         style={`cursor:pointer;background:${rowBg};border-bottom:1px solid var(--vscode-panel-border)`}
       >
+        {/* Conversation-group marker — colored bar for sessions that are really one conversation
+            split into multiple cards by a long gap (see buildConversationInfo above). An empty
+            <td> collapses to zero width under table-layout:auto regardless of the width style, so
+            the bar is a real child element instead of a background painted on the cell itself. */}
+        <td
+          style="padding:0;width:4px"
+          title={conversation ? `Part ${conversation.index} of ${conversation.total} of the same conversation — split into separate sessions by a long gap` : undefined}
+        >
+          <div style={`width:4px;height:100%;min-height:20px;background:${conversation ? conversation.color : 'transparent'}`} />
+        </td>
+
         {/* Chevron */}
         <td style="padding:4px 4px 4px 8px;width:16px;color:var(--muted);font-size:9px;white-space:nowrap">
           {expanded ? '▼' : '▶'}
@@ -423,7 +463,7 @@ function SessionRow({ sess, showWorkspace }: { sess: SessionSummaryCard; showWor
 
       {expanded && (
         <tr style="border-bottom:1px solid var(--vscode-panel-border)">
-          <td colspan={8} style="padding:0">
+          <td colspan={9} style="padding:0">
             <SessionDetail sess={sess} />
           </td>
         </tr>
@@ -477,6 +517,7 @@ export function Sessions() {
   const pageSessions = sessions.slice(page * pageSize, (page + 1) * pageSize)
   const rangeStart = sessions.length === 0 ? 0 : page * pageSize + 1
   const rangeEnd = Math.min((page + 1) * pageSize, sessions.length)
+  const conversationInfo = buildConversationInfo(sessions)
 
   return (
     <div id="sessions-content" style="padding-top:8px">
@@ -484,6 +525,7 @@ export function Sessions() {
       <table style="width:100%;border-collapse:collapse;font-size:11px">
         <thead>
           <tr style="border-bottom:2px solid var(--vscode-panel-border)">
+            <th style="width:4px;padding:0" title="A colored bar marks sessions that are really one conversation split into multiple cards by a long gap between them." />
             <th style="width:16px;padding:3px 4px 3px 8px" />
             <th style={'width:10px;padding:3px 4px;' + thSort} onClick={() => onSortClick('source')} title="Sort by agent">{sortArrow('source')}</th>
             <th style={'text-align:left;' + thSort} onClick={() => onSortClick('start_time')}>Time{sortArrow('start_time')}</th>
@@ -496,7 +538,7 @@ export function Sessions() {
         </thead>
         <tbody>
           {pageSessions.map(sess => (
-            <SessionRow key={sess.sessionId} sess={sess} showWorkspace={showWorkspace} />
+            <SessionRow key={sess.sessionId} sess={sess} showWorkspace={showWorkspace} conversation={conversationInfo.get(sess.sessionId)} />
           ))}
         </tbody>
       </table>

--- a/media/src/utils.ts
+++ b/media/src/utils.ts
@@ -407,6 +407,25 @@ export function getAgentColor(source: string | null | undefined): string {
   return '#90a4ae'
 }
 
+// Fixed, visually distinct palette for coloring conversation groups (see getConversationColor) —
+// deliberately disjoint from the agent-source colors above so the two don't read as related.
+const CONVERSATION_COLORS = [
+  '#4dd0e1', '#ba68c8', '#81c784', '#ffb74d', '#e57373',
+  '#7986cb', '#a1887f', '#4db6ac', '#f06292', '#9575cd',
+] as const
+
+/** Deterministically maps a conversationId to one of a fixed set of colors, so a given split
+ *  conversation always gets the same color across reloads with nothing persisted — same idea as
+ *  hashing to a palette index. Used to color-code Sessions rows that are really one conversation
+ *  split across multiple session cards (see .staged-issues/color-code-multi-segment-conversations.md). */
+export function getConversationColor(conversationId: string): string {
+  let hash = 0
+  for (let i = 0; i < conversationId.length; i++) {
+    hash = (hash * 31 + conversationId.charCodeAt(i)) | 0
+  }
+  return CONVERSATION_COLORS[Math.abs(hash) % CONVERSATION_COLORS.length]
+}
+
 export function getAgentShortLabel(source: string | null | undefined): string {
   if (source === 'claude_code') return 'CL'
   if (source === 'codex') return 'CX'

--- a/src/logReader.ts
+++ b/src/logReader.ts
@@ -335,6 +335,13 @@ export class LogReader {
       const result = this._parseClaudeSegment(segmentLines, claudeSegmentSessionId(baseSessionId, segmentIndex))
       if (result) results.push(result)
     })
+    // Tag every segment with the file they came from, but only when the file actually split into
+    // more than one — a lone segment's conversationId equal to its own sessionId is meaningless.
+    // The frontend uses this to group and color-code rows that are really one conversation split
+    // across multiple session cards.
+    if (results.length > 1) {
+      for (const r of results) r.card.conversationId = baseSessionId
+    }
     return results
   }
 
@@ -533,6 +540,10 @@ export class LogReader {
       if (parsed.result) results.push(parsed.result)
       if (parsed.cumulativeUsage) runningTotalTokenUsage = parsed.cumulativeUsage
     })
+    // See the matching comment in _parseClaudeFile — same conversationId tagging, same reason.
+    if (results.length > 1) {
+      for (const r of results) r.card.conversationId = baseSessionId
+    }
     return results
   }
 
@@ -845,6 +856,10 @@ export class LogReader {
       if (parsed.result) results.push(parsed.result)
       startingTurnIndex += parsed.turnsPushed
     })
+    // See the matching comment in _parseClaudeFile — same conversationId tagging, same reason.
+    if (results.length > 1) {
+      for (const r of results) r.card.conversationId = baseSessionId
+    }
     return results
   }
 

--- a/src/test/logReader.claudeSplit.test.ts
+++ b/src/test/logReader.claudeSplit.test.ts
@@ -179,6 +179,7 @@ suite('LogReader — Claude Code session splitting (integration)', () => {
     assert.strictEqual(results.length, 1)
     assert.strictEqual(results[0].card.sessionId, 'sess-normal')
     assert.strictEqual(results[0].card.userRequest, 'first thing')
+    assert.strictEqual(results[0].card.conversationId, undefined, 'a file that never split has no group to color-code')
   })
 
   test('a session with a real multi-hour gap between prompts splits into two sessions, each with its own prompt and totals', () => {
@@ -209,6 +210,11 @@ suite('LogReader — Claude Code session splitting (integration)', () => {
     // used to be baked into one session's durationMs before this fix.
     assert.ok(results[0].card.durationMs < 60_000)
     assert.ok(results[1].card.durationMs < 60_000)
+
+    // Both segments came from the same file, so the Sessions table can color-code them as one
+    // conversation split apart — see .staged-issues/color-code-multi-segment-conversations.md.
+    assert.strictEqual(results[0].card.conversationId, 'sess-gapped')
+    assert.strictEqual(results[1].card.conversationId, 'sess-gapped')
   })
 
   test('re-scanning an unchanged split file returns no results (cache behavior preserved)', () => {

--- a/src/test/logReader.codexSplit.test.ts
+++ b/src/test/logReader.codexSplit.test.ts
@@ -140,6 +140,7 @@ suite('LogReader — Codex session splitting (integration)', () => {
     const results = new LogReader().parseFile(filePath, 'codex')
     assert.strictEqual(results.length, 1)
     assert.strictEqual(results[0].card.sessionId, 'sess-normal')
+    assert.strictEqual(results[0].card.conversationId, undefined, 'a file that never split has no group to color-code')
   })
 
   test('a real multi-day gap splits into two sessions, each reporting only its own token delta', () => {
@@ -172,6 +173,11 @@ suite('LogReader — Codex session splitting (integration)', () => {
     assert.strictEqual(results[1].card.inputTokens, 500 + (33700 - 500 - 16000), 'cacheReadTokens + raw input delta')
     assert.strictEqual(results[1].card.cacheReadTokens, 500)
     assert.strictEqual(results[1].card.outputTokens, 2200 - 150)
+
+    // Both segments came from the same file, so the Sessions table can color-code them as one
+    // conversation split apart — see .staged-issues/color-code-multi-segment-conversations.md.
+    assert.strictEqual(results[0].card.conversationId, 'sess-gapped')
+    assert.strictEqual(results[1].card.conversationId, 'sess-gapped')
   })
 
   test('a segment with no token_count events of its own inherits (does not reset) the running baseline for the next segment', () => {

--- a/src/test/logReader.copilotVSCodeSplit.test.ts
+++ b/src/test/logReader.copilotVSCodeSplit.test.ts
@@ -76,6 +76,7 @@ suite('LogReader — Copilot VS Code chat session splitting (integration)', () =
     const results = new LogReader().parseFile(filePath, 'copilot_vscode')
     assert.strictEqual(results.length, 1)
     assert.strictEqual(results[0].card.sessionId, 'sess-normal')
+    assert.strictEqual(results[0].card.conversationId, undefined, 'a file that never split has no group to color-code')
   })
 
   test('a real multi-hour gap splits into two sessions, each with its own prompt', () => {
@@ -94,6 +95,11 @@ suite('LogReader — Copilot VS Code chat session splitting (integration)', () =
     assert.strictEqual(results[0].card.userRequest, 'day one work')
     assert.strictEqual(results[1].card.sessionId, 'sess-gapped#1')
     assert.strictEqual(results[1].card.userRequest, 'day two work')
+
+    // Both segments came from the same file, so the Sessions table can color-code them as one
+    // conversation split apart — see .staged-issues/color-code-multi-segment-conversations.md.
+    assert.strictEqual(results[0].card.conversationId, 'sess-gapped')
+    assert.strictEqual(results[1].card.conversationId, 'sess-gapped')
   })
 
   test('segment 0 uses its own first turn\'s timestamp, not the chat panel\'s creation time, as its start', () => {


### PR DESCRIPTION
## Summary
- Splitting log-sourced sessions on prompt gaps (#225) means one real conversation can now show up as several separate rows in the Sessions list, often far apart since the list is time-sorted and unrelated sessions land between them — with nothing indicating they're related.
- `src/logReader.ts`: the three split-aware parsers (Claude Code, Codex, Copilot VS Code) tag every segment of a file that actually split with a shared `conversationId` (the file's base session id). No schema/DB changes — log-sourced cards are re-derived from disk and never persisted.
- `media/src/utils.ts`: `getConversationColor()` deterministically hashes a `conversationId` into a fixed palette, so a given conversation is always the same color with nothing to persist.
- `media/src/tabs/Sessions.tsx`: a new slim leftmost column renders a colored vertical bar for rows belonging to a group with 2+ members still visible in the current filter, with a "Part X of Y" hover tooltip. Ungrouped sessions render no bar.
- Documented the feature on the Help page's Sessions section.

## Verification
- `tsc --noEmit` clean on both `media/tsconfig.json` and `tsconfig.json`
- `eslint src media/src` — 0 errors (same pre-existing warnings)
- Full mocha suite passing (375/375) — extended the existing Claude/Codex/Copilot-VS-Code split integration tests with `conversationId` assertions
- `node esbuild.js --production` clean
- Verified against the real standalone dashboard with real local session data via Playwright: 42 of 50 default-view rows colored across 6 distinct conversation groups, tooltips correct, row-expand still spans the new column count correctly, ungrouped sessions show no bar
- Caught and fixed one real bug along the way: an empty `<td>` with only a background color collapsed to zero width under `table-layout:auto` regardless of its `width` style — fixed by giving the bar a real child element instead of relying on the cell's own background

🤖 Generated with [Claude Code](https://claude.com/claude-code)