### PR TITLE
fix: resolve model rates when ID differs from the key only by . vs -

### DIFF
--- a/PRICING_SOURCES.md
+++ b/PRICING_SOURCES.md
@@ -389,8 +389,18 @@ OpenCode uses token-based pricing for third-party models (routed through its pro
 ## Notes for maintainers
 
 - The `PRICING_LAST_UPDATED` constant in `media/src/pricing.ts` surfaces in the UI. Update it whenever rates change.
-- Model IDs in telemetry often include date suffixes (e.g. `claude-sonnet-4-6-20260501`).
-  `normalizeModelId()` in `pricing.ts` strips these before table lookup.
+- **Model-ID normalization for lookup (`normalizeCostKey()` in both `pricing.ts` files, kept in sync):**
+  a lookup key is derived by lowercasing, stripping a trailing date suffix (e.g.
+  `claude-sonnet-4-6-20260501`), then collapsing `.`, whitespace, and `_` to `-`. **Every `RATES`
+  key is run through the same function**, so it does not matter whether you write a new key with a
+  dot or a hyphen (`claude-opus-4-8` and `claude-opus-4.8` resolve identically) — pick whatever
+  matches the vendor's own spelling. This is why the old `'gpt-5 mini'` space-variant alias key
+  could be deleted. Normalization is lookup-only; the raw model ID from telemetry is what gets
+  stored and shown. (Fixes GH #231, where dotted Copilot IDs missed the hyphenated Claude keys.)
+- **Collision guard:** `RATES_BY_COST_KEY` is built at module load and *throws* if two distinct
+  `RATES` keys collapse to the same normalized key with different rate objects. If you add a key
+  that trips this, the tests (`src/test/pricing.test.ts`) and `tsc`/`mocha` will fail loudly —
+  rename one of the two so they don't collide.
 - If a model appears in telemetry but is missing from the rate table, the UI shows `~$?` rather than $0
   to avoid silently under-reporting cost. Add the model to `RATES` in `pricing.ts` to resolve.
 - Pricing corrections that change displayed cost for real sessions (not just new-model additions)

--- a/media/src/pricing.ts
+++ b/media/src/pricing.ts
@@ -44,8 +44,8 @@ export const RATES: Record<string, ModelRates> = {
   // model list or the annual multiplier page yet — multiplierAnnualPostJun1 set to 0 until published.
   'gpt-4.1-mini':        { inputPerMTok: 0.40,  cacheReadPerMTok: 0.10,   cacheWritePerMTok: 0, outputPerMTok: 1.60,  multiplier: 0,    multiplierAnnualPostJun1: 0 },
   // gpt-5-mini: no longer included/$0 as of 2026-07-19 — now billed at standard token rates.
+  // (The old `'gpt-5 mini'` space-variant alias key is gone — normalizeCostKey collapses the space to a hyphen.)
   'gpt-5-mini':          { inputPerMTok: 0.25,  cacheReadPerMTok: 0.025,  cacheWritePerMTok: 0, outputPerMTok: 2.00,  multiplier: 0,    multiplierAnnualPostJun1: 0.33 },
-  'gpt-5 mini':          { inputPerMTok: 0.25,  cacheReadPerMTok: 0.025,  cacheWritePerMTok: 0, outputPerMTok: 2.00,  multiplier: 0,    multiplierAnnualPostJun1: 0.33 },
   // older included models kept for historical sessions
   'gpt-4o':              { inputPerMTok: 2.50,  cacheReadPerMTok: 1.25,   cacheWritePerMTok: 0, outputPerMTok: 10.00, multiplier: 0,    multiplierAnnualPostJun1: 0.33 },
   'gpt-4o-mini':         { inputPerMTok: 0.15,  cacheReadPerMTok: 0.075,  cacheWritePerMTok: 0, outputPerMTok: 0.60,  multiplier: 0,    multiplierAnnualPostJun1: 0.33 },
@@ -197,7 +197,7 @@ export const PRICING_SECTIONS: PricingSection[] = [
       { label: 'Codex CLI pricing', url: 'https://learn.chatgpt.com/docs/pricing' },
     ],
     modelKeys: [
-      'gpt-4.1', 'gpt-4.1-mini', 'gpt-4.1-nano', 'gpt-5', 'gpt-5-nano', 'gpt-5-mini', 'gpt-5 mini', 'gpt-4o', 'gpt-4o-mini',
+      'gpt-4.1', 'gpt-4.1-mini', 'gpt-4.1-nano', 'gpt-5', 'gpt-5-nano', 'gpt-5-mini', 'gpt-4o', 'gpt-4o-mini',
       'gpt-5.1', 'gpt-5.1-codex', 'gpt-5.1-codex-mini', 'gpt-5.1-codex-max',
       'gpt-5.2', 'gpt-5.2-codex', 'gpt-5.3-codex', 'gpt-5.4', 'gpt-5.4-mini', 'gpt-5.4-nano',
       'gpt-5.5', 'gpt-5.6-luna', 'gpt-5.6-terra', 'gpt-5.6-sol', 'gpt-5.6-cyber', 'codex-mini-latest',
@@ -255,13 +255,39 @@ export const REQUEST_BILLING_SOURCES = [
   { label: 'Legacy request multipliers (pre-Jun 1, 2026, historical)', url: 'https://docs.github.com/en/copilot/concepts/billing/copilot-requests' },
 ]
 
-function normalizeModelId(modelId: string): string {
+// Normalizes a model ID to the key used for rate lookup. Vendors and telemetry sources disagree on
+// whether a minor version is punctuated with a dot or a hyphen: Copilot VS Code emits
+// `claude-opus-4.8` while this table keys that model `claude-opus-4-8`; OpenAI IDs like `gpt-5.4`
+// run the other way. Collapsing `.`, whitespace, and `_` to `-` — applied to BOTH the incoming ID
+// and every RATES key (see RATES_BY_COST_KEY) — makes the two representations meet. Lookup only;
+// the raw model ID is still what gets stored and displayed. Kept in sync with src/pricing.ts. See GH #231.
+export function normalizeCostKey(modelId: string): string {
   return modelId
     .toLowerCase()
     .replace(/-\d{4}-\d{2}-\d{2}$/, '')  // strip date suffix e.g. -2025-04-14
     .replace(/-\d{8}$/, '')               // strip YYYYMMDD suffix e.g. -20260501
     .trim()
+    .replace(/[.\s_]+/g, '-')
 }
+
+// RATES re-keyed by normalizeCostKey, built once at module load. If two distinct RATES keys
+// collapse to the same cost key with *different* rates, that's a table-authoring mistake that would
+// otherwise let one silently shadow the other — fail loudly instead.
+const RATES_BY_COST_KEY: Map<string, ModelRates> = (() => {
+  const map = new Map<string, ModelRates>()
+  for (const [modelId, rates] of Object.entries(RATES)) {
+    const key = normalizeCostKey(modelId)
+    const existing = map.get(key)
+    if (existing && JSON.stringify(existing) !== JSON.stringify(rates)) {
+      throw new Error(
+        `pricing: RATES key "${modelId}" collapses to cost key "${key}", which another key ` +
+        `already maps to with different rates — rename one so they don't collide under normalizeCostKey`,
+      )
+    }
+    map.set(key, rates)
+  }
+  return map
+})()
 
 // Exact match only, after normalization — no prefix-matching fallback. A previous
 // version fell back to substring-prefix matching ("versioned or aliased model IDs"),
@@ -274,8 +300,7 @@ function normalizeModelId(modelId: string): string {
 // visible gap. Kept in sync with the same fix in src/pricing.ts.
 export function lookupRates(modelId: string): ModelRates | null {
   if (!modelId) return null
-  const normalized = normalizeModelId(modelId)
-  return RATES[normalized] ?? null
+  return RATES_BY_COST_KEY.get(normalizeCostKey(modelId)) ?? null
 }
 
 // Token-based cost: the new Copilot AI Credits model (Jun 2026+).

--- a/src/pricing.ts
+++ b/src/pricing.ts
@@ -27,8 +27,8 @@ const RATES: Record<string, ModelRates> = {
   // gpt-4.1-mini: added 2026-08-12 — confirmed on OpenAI's general API pricing page.
   'gpt-4.1-mini':       { inputPerMTok: 0.40,  cacheReadPerMTok: 0.10,   cacheWritePerMTok: 0, outputPerMTok: 1.60,  contextWindowTokens: 0 },
   // gpt-5-mini: no longer an included/$0 model as of the 2026-07-19 pricing page — now billed at standard rates.
+  // (The old `'gpt-5 mini'` space-variant alias key is gone — normalizeCostKey collapses the space to a hyphen.)
   'gpt-5-mini':         { inputPerMTok: 0.25,  cacheReadPerMTok: 0.025,  cacheWritePerMTok: 0, outputPerMTok: 2.00,  contextWindowTokens: 200_000 },
-  'gpt-5 mini':         { inputPerMTok: 0.25,  cacheReadPerMTok: 0.025,  cacheWritePerMTok: 0, outputPerMTok: 2.00,  contextWindowTokens: 200_000 },
   'gpt-4o':             { inputPerMTok: 2.50,  cacheReadPerMTok: 1.25,   cacheWritePerMTok: 0, outputPerMTok: 10.00, contextWindowTokens: 128_000 },
   'gpt-4o-mini':        { inputPerMTok: 0.15,  cacheReadPerMTok: 0.075,  cacheWritePerMTok: 0, outputPerMTok: 0.60,  contextWindowTokens: 128_000 },
   // gpt-5.1: corrected 2026-08-07 — was $1.75/$14.00, live API pricing page now shows $1.25/$10.00 (older-gen
@@ -170,16 +170,43 @@ const RATES: Record<string, ModelRates> = {
 // logReader.ts's fast-mode `-fast` marker) can strip a trailing date first — a raw
 // model string can be date-suffixed (e.g. claude-opus-4-7-20260315), and appending
 // another suffix afterward moves the date off the end, out of reach of the
-// date-stripping regex normalizeModelId() applies below.
+// date-stripping regex normalizeCostKey() applies below.
 export function stripDateSuffix(modelId: string): string {
   return modelId
     .replace(/-\d{4}-\d{2}-\d{2}$/, '')  // strip date suffix e.g. -2025-04-14
     .replace(/-\d{8}$/, '')               // strip YYYYMMDD suffix e.g. -20260501
 }
 
-function normalizeModelId(modelId: string): string {
-  return stripDateSuffix(modelId.toLowerCase()).trim()
+// Normalizes a model ID to the key used for rate lookup. Vendors and telemetry sources disagree on
+// whether a minor version is punctuated with a dot or a hyphen: Copilot VS Code emits
+// `claude-opus-4.8` while this table keys that model `claude-opus-4-8`; OpenAI IDs like `gpt-5.4`
+// run the other way. Collapsing `.`, whitespace, and `_` to `-` — applied to BOTH the incoming ID
+// and every RATES key (see RATES_BY_COST_KEY) — makes the two representations meet. Lookup only;
+// the raw model ID is still what gets stored and displayed. See GH #231.
+export function normalizeCostKey(modelId: string): string {
+  return stripDateSuffix(modelId.toLowerCase())
+    .trim()
+    .replace(/[.\s_]+/g, '-')
 }
+
+// RATES re-keyed by normalizeCostKey, built once at module load. If two distinct RATES keys
+// collapse to the same cost key with *different* rates, that's a table-authoring mistake that would
+// otherwise let one silently shadow the other — fail loudly instead.
+const RATES_BY_COST_KEY: Map<string, ModelRates> = (() => {
+  const map = new Map<string, ModelRates>()
+  for (const [modelId, rates] of Object.entries(RATES)) {
+    const key = normalizeCostKey(modelId)
+    const existing = map.get(key)
+    if (existing && JSON.stringify(existing) !== JSON.stringify(rates)) {
+      throw new Error(
+        `pricing: RATES key "${modelId}" collapses to cost key "${key}", which another key ` +
+        `already maps to with different rates — rename one so they don't collide under normalizeCostKey`,
+      )
+    }
+    map.set(key, rates)
+  }
+  return map
+})()
 
 // Exact match only, after normalization — no prefix-matching fallback. A previous
 // version fell back to substring-prefix matching ("versioned or aliased model IDs"),
@@ -192,8 +219,7 @@ function normalizeModelId(modelId: string): string {
 // visible gap.
 export function lookupRates(modelId: string): ModelRates | null {
   if (!modelId) return null
-  const normalized = normalizeModelId(modelId)
-  return RATES[normalized] ?? null
+  return RATES_BY_COST_KEY.get(normalizeCostKey(modelId)) ?? null
 }
 
 // Applies two-tier pricing: tokens up to the threshold at baseRate, remainder at aboveRate.

--- a/src/test/pricing.test.ts
+++ b/src/test/pricing.test.ts
@@ -1,5 +1,5 @@
 import * as assert from 'assert'
-import { lookupRates, calcTokenCostUsd, stripDateSuffix } from '../pricing'
+import { lookupRates, calcTokenCostUsd, stripDateSuffix, normalizeCostKey } from '../pricing'
 
 suite('pricing', () => {
   test('lookupRates returns rates for known model', () => {
@@ -143,5 +143,70 @@ suite('pricing', () => {
     const cost = calcTokenCostUsd(0, 300_000, 50_000, 0, 'grok-4.5')
     const expectedCacheRead = (200_000 / 1_000_000) * 0.50 + (100_000 / 1_000_000) * 1.00
     assert.ok(Math.abs(cost - expectedCacheRead) < 0.0001, `Expected $${expectedCacheRead}, got $${cost}`)
+  })
+
+  // ── dot-vs-hyphen model IDs (GH #231) ──────────────────────────────────────
+
+  test('lookupRates resolves a dotted Claude model ID onto its hyphenated rate key', () => {
+    // Copilot VS Code imports these with dotted minor versions; RATES keys them with hyphens.
+    for (const dotted of ['claude-opus-4.8', 'claude-opus-4.6', 'claude-sonnet-4.6']) {
+      const rates = lookupRates(dotted)
+      assert.ok(rates !== null, `${dotted} should resolve`)
+      assert.strictEqual(rates, lookupRates(dotted.replace(/\./g, '-')), `${dotted} should match its hyphenated key`)
+    }
+  })
+
+  test('calcTokenCostUsd returns a non-zero cost for a dotted Claude model ID with real tokens', () => {
+    // The exact #231 symptom: non-zero output tokens on a known model, but cost_usd = 0.
+    const cost = calcTokenCostUsd(0, 0, 0, 1_000_000, 'claude-opus-4.8')
+    assert.ok(cost > 0, `Expected non-zero cost, got $${cost}`)
+    assert.strictEqual(cost, calcTokenCostUsd(0, 0, 0, 1_000_000, 'claude-opus-4-8'))
+  })
+
+  test('lookupRates resolves a hyphenated GPT model ID onto its dotted rate key', () => {
+    // The reverse direction: RATES keys GPT models with dots, so a hyphenated telemetry ID must
+    // still resolve (and a naive input-only `.`→`-` replace would have broken this).
+    assert.strictEqual(lookupRates('gpt-5-4'), lookupRates('gpt-5.4'))
+    assert.ok(lookupRates('gpt-5-4') !== null)
+  })
+
+  test('lookupRates resolves a dotted ID that is also date-suffixed', () => {
+    assert.strictEqual(lookupRates('claude-opus-4.8-20260101'), lookupRates('claude-opus-4-8'))
+    assert.strictEqual(lookupRates('claude-opus-4.8-2026-01-01'), lookupRates('claude-opus-4-8'))
+  })
+
+  test('lookupRates resolves a dotted fast-mode ID (logReader base + "-fast" pattern)', () => {
+    const rates = lookupRates('claude-opus-4.8-fast')
+    assert.ok(rates !== null)
+    assert.strictEqual(rates, lookupRates('claude-opus-4-8-fast'))
+  })
+
+  test('lookupRates resolves the retired "gpt-5 mini" space-variant onto gpt-5-mini', () => {
+    assert.strictEqual(lookupRates('gpt-5 mini'), lookupRates('gpt-5-mini'))
+    assert.ok(lookupRates('gpt-5 mini') !== null)
+  })
+
+  test('normalization does not resurrect prefix-matching: unknown newer/aliased models stay null', () => {
+    assert.strictEqual(lookupRates('claude-opus-4-9'), null)
+    assert.strictEqual(lookupRates('claude-opus-4.9'), null)
+    assert.strictEqual(lookupRates('gpt-4.1-turbo'), null)
+  })
+
+  test('normalizeCostKey collapses dots, spaces, and underscores to hyphens after date-stripping', () => {
+    assert.strictEqual(normalizeCostKey('Claude-Opus-4.8'), 'claude-opus-4-8')
+    assert.strictEqual(normalizeCostKey('gpt-5.4'), 'gpt-5-4')
+    assert.strictEqual(normalizeCostKey('gpt-5 mini'), 'gpt-5-mini')
+    assert.strictEqual(normalizeCostKey('gpt_5_mini'), 'gpt-5-mini')
+    assert.strictEqual(normalizeCostKey('claude-opus-4.8-20260101'), 'claude-opus-4-8')
+  })
+
+  test('the RATES cost-key index builds without a collision (guard in pricing.ts did not throw on import)', () => {
+    // If two RATES keys collapsed to one cost key with different rates, importing ../pricing above
+    // would already have thrown. This asserts the observable consequence: every known model still
+    // resolves to a rate, and a couple of near-miss pairs resolve independently.
+    assert.ok(lookupRates('gpt-5.4') !== null && lookupRates('gpt-5.4-mini') !== null)
+    assert.notStrictEqual(lookupRates('gpt-5.4'), lookupRates('gpt-5.4-mini'))
+    assert.ok(lookupRates('mai-code-1-flash') !== null && lookupRates('mai-code-1.1-flash') !== null)
+    assert.notStrictEqual(lookupRates('mai-code-1-flash'), lookupRates('mai-code-1.1-flash'))
   })
 })


### PR DESCRIPTION
Fixes #231

## Problem

Copilot VS Code imports Claude sessions with dotted model IDs (`claude-opus-4.8`, `claude-opus-4.6`, `claude-sonnet-4.6`). `RATES` keys those models with hyphens (`claude-opus-4-8`, …). `normalizeModelId` only lowercased, trimmed, and stripped a trailing date suffix, then did an **exact** `RATES[...]` lookup — so the dotted ID missed, `lookupRates` returned `null`, and `calcTokenCostUsd` returned `0`. Sessions with real output tokens on a known, priced model were silently reported at `cost_usd = 0`.

The mismatch is bidirectional: Claude keys are hyphenated but telemetry emits dots; OpenAI/Google/xAI keys are dotted and a hyphenated telemetry ID would miss the other way. A naive input-only `replaceAll('.', '-')` would break every dotted GPT/Gemini/Grok key.

## Fix

- **`normalizeCostKey`** replaces `normalizeModelId` in both `src/pricing.ts` and `media/src/pricing.ts` (kept hand-synced). Same steps, then collapses `.`, whitespace, and `_` to `-`.
- **`RATES_BY_COST_KEY`** — a `Map` built once at module load, running every `RATES` key through `normalizeCostKey`. `lookupRates` is now a lookup into it, so both `.`↔`-` directions resolve because the table keys and the incoming ID meet in the middle.
- **Collision guard** — the map builder `throw`s if two distinct `RATES` keys collapse to one cost key with different rates.
- Retired the `'gpt-5 mini'` space-variant alias key (and its `PRICING_SECTIONS` entry) — `normalizeCostKey` now covers it.
- Normalization is **lookup-only**; the raw model ID is still stored and displayed everywhere.
- `PRICING_SOURCES.md` "Notes for maintainers" documents the normalization and the collision guard.

## Historical rows

Persisted `cost_usd` is recomputed on the next full log rescan — the scan dedup map is in-memory per activation with no persisted cursor for any of the four log formats — so affected Copilot sessions self-heal on the next extension restart. No migration needed.

## Verification

31 pricing tests pass (9 new: dotted Claude repro + cost non-zero, hyphenated GPT, dotted + date-suffixed, dotted `-fast`, retired space-variant, `normalizeCostKey` units, collision guard, and the existing "no prefix match" cases still `null`). `check-types` clean (incl. `media`), `lint` 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
