### PR TITLE
feat: service install fetches @latest and warns if it can't

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,7 +310,7 @@ OTLP_PORT=4319 UI_PORT=3001 bunx agentlens-dashboard
 
 ```bash
 # One command — works whether or not agentlens-dashboard is already installed globally
-npx agentlens-dashboard service install
+npx agentlens-dashboard@latest service install
 
 agentlens service status      # check whether it's running and reachable
 agentlens service logs        # print the service's log file
@@ -321,9 +321,14 @@ agentlens service update      # upgrade to the latest version and restart on it
 agentlens service uninstall   # remove it (your data in ~/.agentlens is untouched)
 ```
 
-> **Installing the background service does not make it auto-update.** It keeps running whatever
-> version was installed until you run `agentlens service update` yourself — that pulls the latest
-> `agentlens-dashboard` from npm and restarts the service on it.
+`service install` fetches the latest `agentlens-dashboard` from npm before it writes the service
+definition, so re-running it is also how you upgrade. If that download can't happen (offline, npm
+registry unreachable), it prints a clear notice that the new version couldn't be downloaded and
+installs the service on whichever version is already present rather than failing.
+
+> **Once installed, the running service does not otherwise auto-update.** It keeps running whatever
+> version is installed until you run `agentlens service update` (or re-run `service install`) —
+> either one pulls the latest `agentlens-dashboard` from npm and restarts the service on it.
 
 `service install` uses whichever OS-native mechanism fits your platform, all installed per-user
 with no admin/root privileges required:
@@ -343,7 +348,8 @@ agentlens service install --ui-port 3001 --otlp-port 4319 --data-dir ~/agentlens
 
 Since `npx` always runs from a temporary cache with no stable path to launch from, running
 `service install` under `npx` installs `agentlens-dashboard` globally first (equivalent to
-`npm install -g agentlens-dashboard`) so the service definition has something fixed to point at.
+`npm install -g agentlens-dashboard@latest`) so the service definition has something fixed to
+point at.
 
 ### Docker (OTEL only)
 

--- a/src/serviceConfig.ts
+++ b/src/serviceConfig.ts
@@ -150,6 +150,35 @@ export function childEnvForReexec(parentEnv: NodeJS.ProcessEnv): NodeJS.ProcessE
   return env
 }
 
+// ── `service install` / `service update` npm-fetch messaging ────────────────
+//
+// `service install` and `service update` shell out to `npm install -g agentlens-dashboard@latest`
+// so the background service always lands on the newest published version rather than pinning
+// whatever copy happened to launch it. When that download can't happen (offline, npm registry
+// unreachable, npm missing, a permissions error) the service still starts on whatever version is
+// already installed — these pure helpers build the warning so that path is loud instead of silent.
+
+/** Condenses whatever `child_process` threw when `npm install -g` failed into one short clause
+ *  for the "couldn't download" warning. */
+export function describeNpmFailure(err: unknown): string {
+  const e = (err ?? {}) as { code?: string; status?: number; message?: string }
+  if (e.code === 'ENOENT') { return 'npm was not found on your PATH' }
+  if (typeof e.status === 'number') { return `npm exited with code ${e.status} — see its output above` }
+  if (e.code) { return `npm could not be run (${e.code})` }
+  return e.message ? e.message.split('\n')[0] : 'unknown error'
+}
+
+/** Warning shown when the latest agentlens-dashboard can't be fetched. `fallbackVersion` is the
+ *  version already on disk that the service will run instead (undefined if there is none). Not
+ *  fatal on its own — callers that truly have nothing to fall back on report that separately. */
+export function couldNotDownloadMessage(reason: string, fallbackVersion: string | undefined): string {
+  const head = `[AgentLens] Couldn't download the latest agentlens-dashboard from npm: ${reason}.`
+  const tail = fallbackVersion
+    ? `Keeping the version already installed (v${fallbackVersion}) — run \`agentlens service update\` later to retry.`
+    : 'Nothing is installed to fall back on.'
+  return `${head}\n[AgentLens] ${tail}`
+}
+
 // ── Service-definition generators (pure string builders) ────────────────────
 
 export interface ServiceProgram {

--- a/src/test/serviceConfig.test.ts
+++ b/src/test/serviceConfig.test.ts
@@ -9,6 +9,7 @@ import {
   generateLaunchdPlist, generateSystemdUnit, generateWindowsWrapperScript,
   launchdLabel, SYSTEMD_UNIT_NAME, WINDOWS_TASK_NAME,
   generateAuthToken, ensureAuthToken,
+  describeNpmFailure, couldNotDownloadMessage,
   type ServiceProgram,
 } from '../serviceConfig'
 
@@ -240,6 +241,54 @@ suite('serviceConfig', () => {
       assert.strictEqual(launchdLabel(), 'com.agentlens.server')
       assert.strictEqual(SYSTEMD_UNIT_NAME, 'agentlens.service')
       assert.strictEqual(WINDOWS_TASK_NAME, 'AgentLens')
+    })
+  })
+
+  suite('describeNpmFailure', () => {
+    test('names a missing npm binary explicitly', () => {
+      assert.strictEqual(describeNpmFailure({ code: 'ENOENT' }), 'npm was not found on your PATH')
+    })
+
+    test('reports a non-zero npm exit code', () => {
+      assert.strictEqual(
+        describeNpmFailure({ status: 1 }),
+        'npm exited with code 1 — see its output above',
+      )
+      // status 0 is still a "failure" only because execFileSync threw — but report it faithfully
+      assert.ok(describeNpmFailure({ status: 0 }).includes('code 0'))
+    })
+
+    test('falls back to a non-ENOENT error code', () => {
+      assert.strictEqual(describeNpmFailure({ code: 'EACCES' }), 'npm could not be run (EACCES)')
+    })
+
+    test('falls back to the first line of an error message', () => {
+      assert.strictEqual(
+        describeNpmFailure({ message: 'network timeout\n    at ClientRequest' }),
+        'network timeout',
+      )
+    })
+
+    test('handles a thrown non-object', () => {
+      assert.strictEqual(describeNpmFailure(undefined), 'unknown error')
+      assert.strictEqual(describeNpmFailure('boom'), 'unknown error')
+    })
+  })
+
+  suite('couldNotDownloadMessage', () => {
+    test('names the reason and the fallback version when one exists', () => {
+      const msg = couldNotDownloadMessage('npm exited with code 1', '0.14.0')
+      assert.ok(msg.includes('npm exited with code 1'))
+      assert.ok(msg.includes('v0.14.0'))
+      assert.ok(msg.includes('agentlens service update'))
+      assert.ok(msg.startsWith('[AgentLens]'))
+    })
+
+    test('says there is nothing to fall back on when no version is installed', () => {
+      const msg = couldNotDownloadMessage('offline', undefined)
+      assert.ok(msg.includes('offline'))
+      assert.ok(/nothing is installed/i.test(msg))
+      assert.ok(!msg.includes('v'.concat('undefined')))
     })
   })
 })

--- a/standalone/service/index.ts
+++ b/standalone/service/index.ts
@@ -5,6 +5,7 @@ import { execFileSync, spawn } from 'child_process'
 import {
   parseServiceInstallFlags, isRunningFromNpx, writeServiceConfig, readServiceConfig,
   shouldBlockRepeatedBootstrap, childEnvForReexec, serviceConfigPath,
+  describeNpmFailure, couldNotDownloadMessage,
   type ServiceConfig, type ServiceProgram,
 } from '../../src/serviceConfig'
 import * as macos from './macos'
@@ -38,6 +39,37 @@ function buildProgram(config: ServiceConfig): ServiceProgram {
   return { nodePath: process.execPath, cliPath: process.argv[1], config }
 }
 
+/** True when the running cli.js lives inside the global npm package dir — i.e. this *is* the
+ *  installed copy, so `service install` can safely refresh it to the latest published version.
+ *  A dev checkout or any other location is left exactly as-is. */
+function isRunningFromGlobalInstall(): boolean {
+  const dir = globalPackageDir()
+  if (!dir) { return false }
+  const running = process.argv[1] ?? ''
+  return running === dir || running.startsWith(dir + path.sep)
+}
+
+/** Builds the ServiceProgram for `service install`. When run from the global install, first brings
+ *  it up to the latest published version (see ensureLatestGlobalInstall) and points the service at
+ *  that copy — so a stale global install is upgraded on re-install rather than pinned. A dev
+ *  checkout or other non-standard location is pointed at exactly the running copy, untouched. */
+function resolveInstallProgram(config: ServiceConfig): ServiceProgram {
+  // Freshly re-invoked by bootstrapGlobalInstall after an npx run — it already installed @latest
+  // and is pointing us at that copy via argv[1]; don't run a second npm install.
+  if (shouldBlockRepeatedBootstrap(process.env)) {
+    return buildProgram(config)
+  }
+  if (!isRunningFromGlobalInstall()) {
+    return buildProgram(config)
+  }
+  const outcome = ensureLatestGlobalInstall()
+  const globalCliPath = outcome ? resolveGlobalCliPath() : undefined
+  if (globalCliPath && fs.existsSync(globalCliPath)) {
+    return { nodePath: process.execPath, cliPath: globalCliPath, config }
+  }
+  return buildProgram(config)
+}
+
 function printUsage(): void {
   console.log(`Usage: agentlens service <command>
 
@@ -45,14 +77,17 @@ Commands:
   install [--ui-port N] [--otlp-port N] [--mcp-port N] [--bind-host H] [--data-dir DIR]
                     Install and start the background service (macOS: launchd,
                     Linux: systemd --user, Windows: Scheduled Task at logon).
+                    Fetches the latest agentlens-dashboard from npm first, so a
+                    re-install also upgrades; if that download fails it says so
+                    and installs on the version already present.
   uninstall         Stop and remove the background service.
   start             Start the installed service.
   stop              Stop the installed service.
   restart           Restart the installed service.
   update            Install the latest agentlens-dashboard from npm and restart
-                    the service on it. This is how you upgrade — installing a
-                    background service does NOT auto-update; it keeps running
-                    whatever version was installed until you run this.
+                    the service on it. Installing a background service does NOT
+                    otherwise auto-update; it keeps running whatever version was
+                    installed until you run this (or re-run 'install').
   status            Check whether the service is running and reachable.
   logs [--follow]   Print (or tail) the service's log file.
 
@@ -62,28 +97,75 @@ avoids gaps in your session history from forgetting to start it, closing the
 terminal, or a reboot.`)
 }
 
-/** Resolves the just-installed global package's cli.js directly via `npm root -g`, rather than
- *  looking up `agentlens` by name on PATH — npx prepends its own cache's bin directory to PATH
- *  for its entire process tree (including children spawned from inside the npx-run script), so
- *  a bare-name lookup right after `npm install -g` still resolves back to the stale npx-cached
- *  copy instead of the new global one. */
-function resolveGlobalCliPath(): string {
-  const globalRoot = execFileSync('npm', ['root', '-g'], { encoding: 'utf-8' }).trim()
-  return path.join(globalRoot, 'agentlens-dashboard', 'standalone', 'cli.js')
+/** The globally-installed package directory (`<npm root -g>/agentlens-dashboard`), or undefined
+ *  if `npm root -g` can't be run at all (npm missing / not on PATH). */
+function globalPackageDir(): string | undefined {
+  try {
+    const globalRoot = execFileSync('npm', ['root', '-g'], { encoding: 'utf-8' }).trim()
+    return path.join(globalRoot, 'agentlens-dashboard')
+  } catch {
+    return undefined
+  }
+}
+
+/** Resolves the global package's cli.js directly via `npm root -g`, rather than looking up
+ *  `agentlens` by name on PATH — npx prepends its own cache's bin directory to PATH for its
+ *  entire process tree (including children spawned from inside the npx-run script), so a
+ *  bare-name lookup right after `npm install -g` still resolves back to the stale npx-cached
+ *  copy instead of the new global one. Undefined if npm can't be run. */
+function resolveGlobalCliPath(): string | undefined {
+  const dir = globalPackageDir()
+  return dir ? path.join(dir, 'standalone', 'cli.js') : undefined
 }
 
 /** Reads the version of the globally-installed package straight off disk — used to report what
  *  `service update` actually changed, since `npm install -g` prints its own noisy log rather than
- *  a clean before/after. */
+ *  a clean before/after, and to name the fallback version when a download fails. */
 function readGlobalVersion(): string | undefined {
+  const dir = globalPackageDir()
+  if (!dir) return undefined
   try {
-    const globalRoot = execFileSync('npm', ['root', '-g'], { encoding: 'utf-8' }).trim()
-    const pkgPath = path.join(globalRoot, 'agentlens-dashboard', 'package.json')
+    const pkgPath = path.join(dir, 'package.json')
     if (!fs.existsSync(pkgPath)) return undefined
     return JSON.parse(fs.readFileSync(pkgPath, 'utf-8')).version
   } catch {
     return undefined
   }
+}
+
+interface GlobalInstallOutcome {
+  /** Version on disk after the attempt (undefined only if nothing is installed and none could be). */
+  version: string | undefined
+  /** Version on disk before the attempt, for a before/after report. */
+  previousVersion: string | undefined
+  /** True if `npm install -g …@latest` actually succeeded; false if it failed and `version`
+   *  is a pre-existing fallback the caller can still use. */
+  downloaded: boolean
+}
+
+/** Runs `npm install -g agentlens-dashboard@latest` so the background service lands on the newest
+ *  published version rather than pinning whatever copy launched it. If the download fails (offline,
+ *  registry unreachable, npm missing, permissions) it prints a clear warning and reports the
+ *  version already on disk so the caller can carry on with it — returns null only when the
+ *  download failed *and* there is nothing installed to fall back on. */
+function ensureLatestGlobalInstall(): GlobalInstallOutcome | null {
+  const previousVersion = readGlobalVersion()
+  console.log('[AgentLens] Fetching the latest agentlens-dashboard from npm:')
+  console.log('  npm install -g agentlens-dashboard@latest')
+  try {
+    execFileSync('npm', ['install', '-g', 'agentlens-dashboard@latest'], { stdio: 'inherit' })
+  } catch (e) {
+    const fallback = readGlobalVersion()
+    console.error(couldNotDownloadMessage(describeNpmFailure(e), fallback))
+    return fallback ? { version: fallback, previousVersion, downloaded: false } : null
+  }
+  const version = readGlobalVersion()
+  if (previousVersion && version && previousVersion !== version) {
+    console.log(`[AgentLens] Updated v${previousVersion} → v${version}.`)
+  } else if (version) {
+    console.log(`[AgentLens] Up to date (v${version}).`)
+  }
+  return { version, previousVersion, downloaded: true }
 }
 
 /** npx runs from an ephemeral cache with no stable path a service definition can point
@@ -95,24 +177,31 @@ function bootstrapGlobalInstall(remainingArgs: string[]): number {
     console.error(
       '[AgentLens] Still detected as running via npx after installing globally and re-invoking ' +
       '`agentlens` — that shouldn\'t happen and looks like a bug rather than a real npx run. ' +
-      'Try running `npm install -g agentlens-dashboard` yourself, then `agentlens service install` directly.'
+      'Try running `npm install -g agentlens-dashboard@latest` yourself, then `agentlens service install` directly.'
     )
     return 1
   }
   console.log('[AgentLens] Running via npx — installing agentlens-dashboard globally first, ' +
-    'so the background service has a stable command to launch on every start:')
-  console.log('  npm install -g agentlens-dashboard')
-  execFileSync('npm', ['install', '-g', 'agentlens-dashboard'], { stdio: 'inherit' })
-  console.log('[AgentLens] Global install complete. Continuing with service install...')
+    'so the background service has a stable command to launch on every start.')
+  const outcome = ensureLatestGlobalInstall()
+  if (!outcome) {
+    console.error(
+      '[AgentLens] Can\'t install the background service without a global copy to point at, and ' +
+      'nothing is installed yet. Reconnect to npm and re-run `npx agentlens-dashboard@latest service install`.'
+    )
+    return 1
+  }
 
   const globalCliPath = resolveGlobalCliPath()
-  if (!fs.existsSync(globalCliPath)) {
+  if (!globalCliPath || !fs.existsSync(globalCliPath)) {
     console.error(
-      `[AgentLens] Installed globally, but couldn't find it at the expected path (${globalCliPath}). ` +
+      `[AgentLens] Global install present, but couldn't find its cli.js at the expected path ` +
+      `(${globalCliPath ?? '<npm root -g unavailable>'}). ` +
       'Run `agentlens service install` yourself to continue — the global install should now be on your PATH.'
     )
     return 1
   }
+  console.log('[AgentLens] Continuing with service install...')
   try {
     execFileSync(process.execPath, [globalCliPath, 'service', 'install', ...remainingArgs], {
       stdio: 'inherit', env: childEnvForReexec(process.env),
@@ -165,7 +254,7 @@ export async function runServiceCli(args: string[]): Promise<number> {
     case 'install': {
       const config = parseServiceInstallFlags(rest)
       writeServiceConfig(config)
-      platformService.install(buildProgram(config))
+      platformService.install(resolveInstallProgram(config))
       console.log(`[AgentLens] Background service installed and started. The dashboard now requires an access token — run \`agentlens service status\` once it's up for the URL to open (its first startup generates and persists the token to ${serviceConfigPath()}).`)
       return 0
     }
@@ -183,18 +272,20 @@ export async function runServiceCli(args: string[]): Promise<number> {
       platformService.restart()
       return 0
     case 'update': {
-      const before = readGlobalVersion()
-      console.log('[AgentLens] Updating agentlens-dashboard to the latest version:')
-      console.log('  npm install -g agentlens-dashboard@latest')
-      execFileSync('npm', ['install', '-g', 'agentlens-dashboard@latest'], { stdio: 'inherit' })
-      const after = readGlobalVersion()
-      if (before && after && before === after) {
-        console.log(`[AgentLens] Already up to date (v${after}) — no restart needed.`)
+      const outcome = ensureLatestGlobalInstall()
+      if (!outcome || !outcome.downloaded) {
+        // ensureLatestGlobalInstall already printed why; the service keeps running its current
+        // version, so this is a failed update rather than a broken service.
+        return 1
+      }
+      const { version, previousVersion } = outcome
+      if (previousVersion && version && previousVersion === version) {
+        console.log('[AgentLens] No restart needed.')
         return 0
       }
-      console.log(`[AgentLens] Updated${before ? ` v${before} →` : ''} v${after ?? '(unknown)'}. Restarting the background service...`)
+      console.log('[AgentLens] Restarting the background service on the new version...')
       platformService.restart()
-      console.log('[AgentLens] Background service restarted on the new version.')
+      console.log('[AgentLens] Background service restarted.')
       return 0
     }
     case 'status': {


### PR DESCRIPTION
## Problem

`service install` wrote the OS service definition pointing at whatever `cli.js` launched it and never resolved a newer version. An older global install already on PATH (npx downloads nothing when the package resolves), or a stale npx cache, left the background service a release or more behind — with nothing said. The `npm install -g` calls also had no error handling, so a registry outage surfaced as a raw stack trace.

## Change

- **`src/serviceConfig.ts`** — two pure, unit-tested helpers: `describeNpmFailure()` condenses whatever `child_process` threw into one clause; `couldNotDownloadMessage()` builds the "couldn't download, keeping vX" notice.
- **`standalone/service/index.ts`**:
  - `ensureLatestGlobalInstall()` runs `npm install -g agentlens-dashboard@latest` wrapped in try/catch. On failure it prints a clear one-line notice naming the likely cause and the fallback version, and returns that fallback — `null` only when nothing is installed at all.
  - `install`: when run from the global install, refreshes to `@latest` and points the service at that copy; a dev checkout is left exactly as-is (no npm call). Never aborts in the non-npx path.
  - npx bootstrap: now uses `@latest` (was a bare name), same error handling; aborts only when the download fails *and* nothing global exists.
  - `update`: rebuilt on the shared helper; a failed download exits non-zero with the service still on its old version.
  - A stray backtick pair in the `printUsage()` template literal is removed so esbuild can parse the file.
- **README / usage text** — documented command is now `npx agentlens-dashboard@latest service install`.

## Out of scope

Auto-updating the *running* service on a schedule (the README deliberately promises it doesn't); a server-side "update available" banner.

## Verification

`check-types` clean, `lint` 0 errors, production bundle builds, `serviceConfig` unit suite 35/35 passing (7 new: `describeNpmFailure` variants + `couldNotDownloadMessage` with/without fallback). The `index.ts` orchestration is `child_process` side effects and stays uncovered, consistent with the rest of that file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
