### PR TITLE
fix: run npx/bunx with @latest so a stale cache can't pin an old version

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -945,7 +945,7 @@ the actual `fs`/`child_process` calls for their platform.
 flowchart TD
     CLI["agentlens service install<br/>(standalone/cli.ts)"] --> NPX{Running via npx?}
 
-    NPX -- yes --> BOOT["npm install -g agentlens-dashboard<br/>(visible, not silent)"]
+    NPX -- yes --> BOOT["npm install -g agentlens-dashboard@latest<br/>(visible, not silent)"]
     BOOT --> REEXEC[Re-invoke as the now-globally-linked<br/>`agentlens service install`]
     REEXEC --> DISPATCH
 
@@ -964,8 +964,11 @@ flowchart TD
     NPMLATEST --> RESTART["platformService.restart&#40;&#41;<br/>(re-execs whatever now sits at the same install path)"]
 ```
 
-A global install pins a version — unlike `npx`, which always resolves latest, a service definition
-points at a fixed on-disk path that only changes when something overwrites it. `update` is that
+A global install pins a version — and so does `npx` in practice: a bare `npx agentlens-dashboard`
+re-runs whatever npx cached without revalidating against the registry, so only `npx …@latest`
+reliably resolves the newest release (the user-facing docs say `@latest` everywhere for this
+reason). Either way a service definition points at a fixed on-disk path that only changes when
+something overwrites it. `update` is that
 "something": it shells out to `npm install -g agentlens-dashboard@latest` (overwriting the files at
 the path already baked into the service definition) and then restarts, so no service definition
 rewrite is needed. `standalone/service/index.ts`'s `readGlobalVersion()` reads the installed

--- a/README.md
+++ b/README.md
@@ -21,16 +21,23 @@ Two things it does that a usage dashboard doesn't:
 The fastest way to get started — run directly on your machine with no install required. Because it runs natively it has full access to your local session log files.
 
 ```bash
-# One-off — always uses the latest published version
-npx agentlens-dashboard
-bunx agentlens-dashboard
+# One-off — the @latest tag forces a fresh fetch (see note below)
+npx agentlens-dashboard@latest
+bunx agentlens-dashboard@latest
 
 # Or install globally and run by command name
-npm install -g agentlens-dashboard
+npm install -g agentlens-dashboard@latest
 agentlens
 ```
 
 Open <http://localhost:3000> after the server starts. The OTLP receiver listens on port `4318`. Configure agents to point at `http://localhost:4318` (see [Manual Configuration](#manual-configuration)).
+
+> **Always include `@latest`.** A bare `npx agentlens-dashboard` (or `bunx`) re-runs whatever
+> version npx cached the first time you ran it — it does **not** check npm for a newer release, so
+> you can silently stay on an old version for weeks. `@latest` forces npx to resolve against the
+> registry. If a bare run already cached an old copy, clear it with `rm -rf ~/.npm/_npx` (npx) or
+> `npm cache clean --force`. A global install (`npm install -g`) has the same trap — re-run it with
+> `@latest`, or `npm update -g agentlens-dashboard`, to move forward.
 
 > **Log file ingestion** reads local session files from `~/.claude/`, `~/.codex/`, `~/.copilot/`, and OpenCode's SQLite database at `~/.local/share/opencode/` directly. See [Local Mode Options](#local-mode-options) for environment variables.
 >
@@ -298,7 +305,7 @@ Environment variables:
 The local server uses the same port as the VS Code extension — only one can run at a time. To run both simultaneously, use different ports:
 
 ```bash
-OTLP_PORT=4319 UI_PORT=3001 bunx agentlens-dashboard
+OTLP_PORT=4319 UI_PORT=3001 bunx agentlens-dashboard@latest
 ```
 
 ### Background Service (macOS / Windows / Linux)

--- a/media/src/tabs/Help.tsx
+++ b/media/src/tabs/Help.tsx
@@ -380,7 +380,7 @@ trace_exporter = { otlp-http = { endpoint = "http://localhost:4318", protocol = 
         window, a closed laptop lid, or a reboot means a gap in your session history. Installing it as a
         background service keeps it running automatically instead:
       </p>
-      <pre style="font-size:12px;background:var(--panel-bg);border:1px solid var(--border);border-radius:3px;padding:6px 10px;margin:0 0 8px;overflow-x:auto;white-space:pre">{`npx agentlens-dashboard service install`}</pre>
+      <pre style="font-size:12px;background:var(--panel-bg);border:1px solid var(--border);border-radius:3px;padding:6px 10px;margin:0 0 8px;overflow-x:auto;white-space:pre">{`npx agentlens-dashboard@latest service install`}</pre>
       <p style="font-size:12px;color:var(--muted);margin:0 0 8px">
         Works as a single command whether or not <code style={codeStyle}>agentlens-dashboard</code> is
         already installed — if it's running via <code style={codeStyle}>npx</code>, which has no stable

--- a/standalone/cli.ts
+++ b/standalone/cli.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
-// AgentLens standalone server — run with: bunx agentlens  |  npx agentlens  |  node standalone/cli.js
+// AgentLens standalone server — run with: npx agentlens-dashboard@latest  |  bunx agentlens-dashboard@latest  |  node standalone/cli.js
+// (use the @latest tag — a bare `npx agentlens-dashboard` re-runs npx's cached copy without checking npm for a newer release)
 // `agentlens service <install|uninstall|start|stop|restart|status|logs>` manages running this
 // as an OS-native background service instead — see standalone/service/index.ts.
 

--- a/standalone/server.ts
+++ b/standalone/server.ts
@@ -26,7 +26,7 @@ import { detectInstructionFiles, appendSuggestion } from '../src/instructionFile
 import type { Span } from '../src/types'
 import type { SessionSummaryCard } from '../src/summarizers/summarizerTypes'
 import { pruneSpans, DEFAULT_MAX_SPANS } from '../src/spanStore'
-import { readServiceConfig, ensureAuthToken } from '../src/serviceConfig'
+import { readServiceConfig, ensureAuthToken, isRunningFromNpx } from '../src/serviceConfig'
 import { isAllowedHostHeader, isAuthorized, isLoopbackHost, extractCookieToken, authCookieHeader } from '../src/httpSecurity'
 
 // `agentlens service install` persists its port/host/data-dir choices to
@@ -61,6 +61,11 @@ const MAX_SPANS  = Number.isNaN(parsedMaxSpans) ? DEFAULT_MAX_SPANS : parsedMaxS
 
 const PACKAGE_VERSION: string = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'package.json'), 'utf8')).version
 console.log(`[AgentLens] Version         ${PACKAGE_VERSION}`)
+if (isRunningFromNpx(process.env.npm_config_user_agent, process.argv[1] ?? '')) {
+  // A bare `npx agentlens-dashboard` re-runs npx's cached copy without checking npm, so the version
+  // above can be an old release even right after a publish. Surface that at the moment it's on screen.
+  console.log('[AgentLens] Launched via npx — if this isn\'t the version you expect, npx served a cached copy. Re-run as `npx agentlens-dashboard@latest` (or clear it with `rm -rf ~/.npm/_npx`).')
+}
 
 const mediaDir  = path.join(__dirname, '..', 'media')
 const DATA_DIR  = process.env.DATA_DIR ?? fileConfig.dataDir

--- a/standalone/service/index.ts
+++ b/standalone/service/index.ts
@@ -169,9 +169,10 @@ function ensureLatestGlobalInstall(): GlobalInstallOutcome | null {
 }
 
 /** npx runs from an ephemeral cache with no stable path a service definition can point
- *  at, so a first-time `npx agentlens-dashboard service install` bootstraps a real global
+ *  at, so a first-time `npx agentlens-dashboard@latest service install` bootstraps a real global
  *  install for the user (visibly, not silently — this touches global npm state) and then
- *  re-invokes the newly-installed copy directly to continue. */
+ *  re-invokes the newly-installed copy directly to continue. ensureLatestGlobalInstall() below
+ *  always installs `@latest`, so this is safe even when the npx cache itself is stale. */
 function bootstrapGlobalInstall(remainingArgs: string[]): number {
   if (shouldBlockRepeatedBootstrap(process.env)) {
     console.error(


### PR DESCRIPTION
## Problem

A bare `npx agentlens-dashboard` re-runs whatever version npx cached the first time it was invoked and **never revalidates against the registry**. A user can sit on an old release for weeks while `npm view agentlens-dashboard version` still reports the new one — which is exactly what happened live: `npx agentlens-dashboard` kept launching v0.13.0 the day after v0.15.1 published. The README's quick-start comment made it worse by claiming the bare form "always uses the latest published version".

[#234](https://github.com/RogerReed/agentlens/pull/234) fixed the `service install` *code* path (it shells out to `npm install -g agentlens-dashboard@latest` regardless of invocation). This PR fixes every remaining documented `npx` / `bunx` invocation and adds an in-app signal.

## Changes

- **`README.md`** — §Local: `npx agentlens-dashboard@latest` / `bunx agentlens-dashboard@latest`, the misleading comment reworded, `npm install -g agentlens-dashboard@latest` for the global path, and a `>` note explaining the npx cache + the two cache-clear commands (`rm -rf ~/.npm/_npx`, `npm cache clean --force`). §Local Mode Options: the port-override `bunx` example gets `@latest`.
- **`media/src/tabs/Help.tsx`** — the in-app Background Service snippet → `npx agentlens-dashboard@latest service install`.
- **`standalone/server.ts`** — when launched via npx (`isRunningFromNpx`, already unit-tested), print one line right after the version banner: the number may be a cached copy, re-run with `@latest`. No network call, no version comparison — just surfaces the failure mode at the moment the wrong number is on screen.
- **`standalone/cli.ts`** header comment and **`standalone/service/index.ts`** bootstrap comment → `@latest`.
- **`ARCHITECTURE.md`** — npx-bootstrap diagram node → `@latest`, and corrected the "npx always resolves latest" claim in the prose.

Out of scope (deferred in #234's notes too): a real startup update-checker that pings the registry — it adds a network call and failure mode to every launch. The static npx-only hint covers the reported case without that cost.

## Verification

`check-types` clean, `lint` 0 errors, production bundle builds (`server.ts` import + branch compile), `serviceConfig` suite 35/35. No new tests — the hint is gated entirely by `isRunningFromNpx`, whose test suite already covers both npx signals and the negative case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
