### PR TITLE
fix: graceful `service install` + fix the macOS reinstall race

### DIFF
--- a/src/serviceConfig.ts
+++ b/src/serviceConfig.ts
@@ -168,6 +168,21 @@ export function describeNpmFailure(err: unknown): string {
   return e.message ? e.message.split('\n')[0] : 'unknown error'
 }
 
+/** Condenses whatever `child_process` threw when the OS service manager (launchctl / systemctl /
+ *  schtasks) failed during `service install` into one short clause. `tool` names the command so
+ *  the message reads naturally on every platform. Captured stderr (when the caller passed it
+ *  through) is preferred over a bare exit code — it's what actually explains the failure. */
+export function describeServiceManagerFailure(err: unknown, tool = 'the service manager'): string {
+  const e = (err ?? {}) as { code?: string; status?: number; message?: string; stderr?: unknown }
+  const stderr = typeof e.stderr === 'string' ? e.stderr : Buffer.isBuffer(e.stderr) ? e.stderr.toString() : ''
+  const firstStderrLine = stderr.split('\n').map(l => l.trim()).find(Boolean)
+  if (e.code === 'ENOENT') { return `${tool} command was not found on your PATH` }
+  if (firstStderrLine) { return firstStderrLine }
+  if (typeof e.status === 'number') { return `${tool} exited with code ${e.status}` }
+  if (e.code) { return `${tool} could not be run (${e.code})` }
+  return e.message ? e.message.split('\n')[0] : 'unknown error'
+}
+
 /** Warning shown when the latest agentlens-dashboard can't be fetched. `fallbackVersion` is the
  *  version already on disk that the service will run instead (undefined if there is none). Not
  *  fatal on its own — callers that truly have nothing to fall back on report that separately. */

--- a/src/test/serviceConfig.test.ts
+++ b/src/test/serviceConfig.test.ts
@@ -9,7 +9,7 @@ import {
   generateLaunchdPlist, generateSystemdUnit, generateWindowsWrapperScript,
   launchdLabel, SYSTEMD_UNIT_NAME, WINDOWS_TASK_NAME,
   generateAuthToken, ensureAuthToken,
-  describeNpmFailure, couldNotDownloadMessage,
+  describeNpmFailure, couldNotDownloadMessage, describeServiceManagerFailure,
   type ServiceProgram,
 } from '../serviceConfig'
 
@@ -272,6 +272,42 @@ suite('serviceConfig', () => {
     test('handles a thrown non-object', () => {
       assert.strictEqual(describeNpmFailure(undefined), 'unknown error')
       assert.strictEqual(describeNpmFailure('boom'), 'unknown error')
+    })
+  })
+
+  suite('describeServiceManagerFailure', () => {
+    test('names a missing service-manager binary explicitly', () => {
+      assert.strictEqual(
+        describeServiceManagerFailure({ code: 'ENOENT' }, 'launchctl'),
+        'launchctl command was not found on your PATH',
+      )
+    })
+
+    test('prefers the first non-empty line of captured stderr over an exit code', () => {
+      assert.strictEqual(
+        describeServiceManagerFailure({ status: 5, stderr: '\nBootstrap failed: 5: Input/output error\n' }, 'launchctl'),
+        'Bootstrap failed: 5: Input/output error',
+      )
+    })
+
+    test('accepts stderr as a Buffer', () => {
+      assert.strictEqual(
+        describeServiceManagerFailure({ stderr: Buffer.from('Load failed: 37: Operation already in progress') }, 'launchctl'),
+        'Load failed: 37: Operation already in progress',
+      )
+    })
+
+    test('reports a non-zero exit code when there is no stderr', () => {
+      assert.strictEqual(
+        describeServiceManagerFailure({ status: 1 }, 'systemctl'),
+        'systemctl exited with code 1',
+      )
+    })
+
+    test('falls back to a non-ENOENT error code, then the message, then a default', () => {
+      assert.strictEqual(describeServiceManagerFailure({ code: 'EPERM' }, 'schtasks'), 'schtasks could not be run (EPERM)')
+      assert.strictEqual(describeServiceManagerFailure({ message: 'access denied\n at x' }, 'schtasks'), 'access denied')
+      assert.strictEqual(describeServiceManagerFailure(undefined), 'unknown error')
     })
   })
 

--- a/standalone/service/health.ts
+++ b/standalone/service/health.ts
@@ -13,3 +13,15 @@ export async function probeServiceHealth(uiPort: number, bindHost: string): Prom
     return false
   }
 }
+
+/** Polls `probeServiceHealth` until it succeeds or `timeoutMs` elapses. Used right after
+ *  `service install` to confirm the freshly-registered service actually came up, rather than
+ *  printing "installed and started" and hoping. */
+export async function waitForServiceHealth(uiPort: number, bindHost: string, timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs
+  for (;;) {
+    if (await probeServiceHealth(uiPort, bindHost)) { return true }
+    if (Date.now() >= deadline) { return false }
+    await new Promise(resolve => setTimeout(resolve, 500))
+  }
+}

--- a/standalone/service/index.ts
+++ b/standalone/service/index.ts
@@ -305,8 +305,12 @@ export async function runServiceCli(args: string[]): Promise<number> {
       try {
         platformService.install(program)
       } catch (e) {
+        // install() writes the service-definition file before registering it, so a failure here
+        // can leave that file orphaned — roll it back so `service status` doesn't report a
+        // service that was never actually started.
+        try { platformService.uninstall() } catch { /* best effort */ }
         console.error(`[AgentLens] Couldn't register the background service with ${serviceManagerName()}: ${describeServiceManagerFailure(e, serviceManagerName())}`)
-        console.error('[AgentLens] Nothing was left half-installed. To retry: `agentlens service uninstall` then `agentlens service install`. If it keeps failing, `agentlens service logs` shows any server-side error.')
+        console.error('[AgentLens] Rolled back — nothing is left half-installed. Fix the cause above, then re-run `agentlens service install`.')
         return 1
       }
 

--- a/standalone/service/index.ts
+++ b/standalone/service/index.ts
@@ -4,10 +4,11 @@ import * as path from 'path'
 import { execFileSync, spawn } from 'child_process'
 import {
   parseServiceInstallFlags, isRunningFromNpx, writeServiceConfig, readServiceConfig,
-  shouldBlockRepeatedBootstrap, childEnvForReexec, serviceConfigPath,
-  describeNpmFailure, couldNotDownloadMessage,
+  shouldBlockRepeatedBootstrap, childEnvForReexec,
+  describeNpmFailure, couldNotDownloadMessage, describeServiceManagerFailure,
   type ServiceConfig, type ServiceProgram,
 } from '../../src/serviceConfig'
+import { waitForServiceHealth } from './health'
 import * as macos from './macos'
 import * as linux from './linux'
 import * as windows from './windows'
@@ -20,6 +21,39 @@ interface PlatformService {
   restart(): void
   status(uiPort: number, bindHost: string): Promise<boolean>
   logsPath(program: ServiceProgram): string
+  isInstalled(): boolean
+}
+
+/** Name of the OS service manager `install` shells out to — used only for error messages. */
+function serviceManagerName(): string {
+  switch (os.platform()) {
+    case 'darwin': return 'launchctl'
+    case 'linux':  return 'systemctl'
+    case 'win32':  return 'schtasks'
+    default:       return 'the service manager'
+  }
+}
+
+/** Version of the running agentlens-dashboard, read from its own package.json. Bundled output
+ *  lives at <pkg>/standalone/cli.js, so `../package.json` from here; the extra `../../` fallback
+ *  covers running the un-bundled source from standalone/service/. */
+function readRunningVersion(): string | undefined {
+  for (const rel of [['..', 'package.json'], ['..', '..', 'package.json']]) {
+    try {
+      return JSON.parse(fs.readFileSync(path.join(__dirname, ...rel), 'utf-8')).version as string
+    } catch { /* try the next candidate */ }
+  }
+  return undefined
+}
+
+/** `platformService.isInstalled()` can itself shell out (schtasks on Windows); never let a probe
+ *  failure derail the actual install. */
+function safeIsInstalled(platformService: PlatformService): boolean {
+  try { return platformService.isInstalled() } catch { return false }
+}
+
+function dashboardUrl(config: ServiceConfig): string {
+  return `http://${config.bindHost}:${config.uiPort}` + (config.authToken ? `/?token=${config.authToken}` : '')
 }
 
 function getPlatformService(): PlatformService {
@@ -253,10 +287,40 @@ export async function runServiceCli(args: string[]): Promise<number> {
 
   switch (subcommand) {
     case 'install': {
+      const version = readRunningVersion()
+      console.log(`[AgentLens] service install${version ? ` — v${version}` : ''}`)
       const config = parseServiceInstallFlags(rest)
+      // Carry the existing access token across a reinstall so bookmarked dashboard URLs keep working
+      // — parseServiceInstallFlags starts from a blank token and the server would otherwise mint a
+      // fresh one on next start.
+      const existingToken = readServiceConfig().authToken
+      if (existingToken) { config.authToken = existingToken }
+      const program = resolveInstallProgram(config)
+
+      if (safeIsInstalled(platformService)) {
+        console.log('[AgentLens] An existing background service was found — replacing it (ports/data-dir updated, access token kept).')
+      }
       writeServiceConfig(config)
-      platformService.install(resolveInstallProgram(config))
-      console.log(`[AgentLens] Background service installed and started. The dashboard now requires an access token — run \`agentlens service status\` once it's up for the URL to open (its first startup generates and persists the token to ${serviceConfigPath()}).`)
+
+      try {
+        platformService.install(program)
+      } catch (e) {
+        console.error(`[AgentLens] Couldn't register the background service with ${serviceManagerName()}: ${describeServiceManagerFailure(e, serviceManagerName())}`)
+        console.error('[AgentLens] Nothing was left half-installed. To retry: `agentlens service uninstall` then `agentlens service install`. If it keeps failing, `agentlens service logs` shows any server-side error.')
+        return 1
+      }
+
+      // Don't claim success blindly — wait for the server to actually answer a health check.
+      const healthy = await waitForServiceHealth(config.uiPort, config.bindHost, 15_000)
+      const fresh = readServiceConfig()  // re-read: the server persists the auth token on first start
+      if (healthy) {
+        console.log(`[AgentLens] Background service is running${version ? ` (v${version})` : ''}. Open the dashboard at:`)
+        console.log(`  ${dashboardUrl(fresh)}`)
+        console.log('[AgentLens] It starts at login and restarts if it crashes. `agentlens service status` re-prints this URL; `agentlens service uninstall` removes it (your data in ~/.agentlens stays).')
+      } else {
+        console.log(`[AgentLens] Service registered, but it hasn't answered a health check on port ${config.uiPort} yet.`)
+        console.log('[AgentLens] Give it a few seconds, then run `agentlens service status`. If it stays down, `agentlens service logs` has the reason.')
+      }
       return 0
     }
     case 'uninstall':
@@ -273,6 +337,7 @@ export async function runServiceCli(args: string[]): Promise<number> {
       platformService.restart()
       return 0
     case 'update': {
+      console.log(`[AgentLens] service update${readRunningVersion() ? ` — currently v${readRunningVersion()}` : ''}`)
       const outcome = ensureLatestGlobalInstall()
       if (!outcome || !outcome.downloaded) {
         // ensureLatestGlobalInstall already printed why; the service keeps running its current
@@ -290,12 +355,15 @@ export async function runServiceCli(args: string[]): Promise<number> {
       return 0
     }
     case 'status': {
+      const version = readRunningVersion()
       const config = readServiceConfig()
       const running = await platformService.status(config.uiPort, config.bindHost)
-      const dashboardUrl = `http://${config.bindHost}:${config.uiPort}` + (config.authToken ? `/?token=${config.authToken}` : '')
+      const installed = safeIsInstalled(platformService)
       console.log(running
-        ? `[AgentLens] Running — dashboard reachable at ${dashboardUrl}`
-        : '[AgentLens] Not reachable. Run `agentlens service logs` to check for errors, or `agentlens service start`.')
+        ? `[AgentLens] Running${version ? ` (v${version})` : ''} — dashboard reachable at ${dashboardUrl(config)}`
+        : installed
+          ? '[AgentLens] Installed but not reachable. Run `agentlens service logs` to check for errors, or `agentlens service start`.'
+          : '[AgentLens] No background service is installed. Run `agentlens service install` to set one up.')
       return running ? 0 : 1
     }
     case 'logs': {

--- a/standalone/service/linux.ts
+++ b/standalone/service/linux.ts
@@ -15,6 +15,10 @@ function systemctl(...args: string[]): void {
   execFileSync('systemctl', ['--user', ...args], { stdio: 'inherit' })
 }
 
+export function isInstalled(): boolean {
+  return fs.existsSync(unitPath())
+}
+
 export function install(program: ServiceProgram): void {
   fs.mkdirSync(path.dirname(unitPath()), { recursive: true })
   fs.mkdirSync(path.dirname(serviceLogPath(program.config)), { recursive: true })

--- a/standalone/service/macos.ts
+++ b/standalone/service/macos.ts
@@ -63,11 +63,9 @@ function bootstrapWithRetry(): void {
         sleepSync(600)
         continue
       }
-      const wrapped = new Error(stderr.trim() || (e as Error).message)
-      ;(wrapped as { code?: string; status?: number }).code = (e as { code?: string }).code
-      ;(wrapped as { code?: string; status?: number }).status = (e as { status?: number }).status
-      ;(wrapped as { stderr?: string }).stderr = stderr
-      throw wrapped
+      // execFileSync's error already carries .stderr (Buffer), .status and .code —
+      // describeServiceManagerFailure() in index.ts reads all three.
+      throw e
     }
   }
 }

--- a/standalone/service/macos.ts
+++ b/standalone/service/macos.ts
@@ -19,13 +19,69 @@ function serviceTarget(): string {
   return `${guiTarget()}/${launchdLabel()}`
 }
 
+/** launchd domains have no synchronous "is it gone yet" — `launchctl print <target>` exits 0
+ *  while the service is still registered and non-zero once it's fully unloaded. */
+function serviceLoaded(): boolean {
+  try {
+    execFileSync('launchctl', ['print', serviceTarget()], { stdio: 'ignore' })
+    return true
+  } catch {
+    return false
+  }
+}
+
+function sleepSync(ms: number): void {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms)
+}
+
+/** `launchctl bootout` returns before the domain finishes tearing the service down, so a
+ *  `bootstrap` fired immediately after races the teardown and fails with
+ *  `Bootstrap failed: 5: Input/output error`. Boot it out, then wait until `launchctl print`
+ *  confirms it's actually gone (bounded ~5s) before the caller re-bootstraps. */
+function bootOutAndWait(): void {
+  if (!serviceLoaded()) { return }
+  try { execFileSync('launchctl', ['bootout', serviceTarget()], { stdio: 'ignore' }) } catch { /* already going */ }
+  for (let i = 0; i < 50 && serviceLoaded(); i++) { sleepSync(100) }
+}
+
+/** Bootstraps the plist, tolerating the two transient failures a reinstall can still hit even
+ *  after `bootOutAndWait`: a lingering `Input/output error` (retry after a short pause) and
+ *  `service already loaded` (something re-registered it in the gap — `kickstart -k` to make sure
+ *  it's running the plist we just wrote). Any other failure is thrown for index.ts to format. */
+function bootstrapWithRetry(): void {
+  for (let attempt = 1; ; attempt++) {
+    try {
+      execFileSync('launchctl', ['bootstrap', guiTarget(), plistPath()], { stdio: ['ignore', 'ignore', 'pipe'] })
+      return
+    } catch (e) {
+      const stderr = String((e as { stderr?: unknown }).stderr ?? '')
+      if (/already (loaded|bootstrapped)/i.test(stderr)) {
+        try { execFileSync('launchctl', ['kickstart', '-k', serviceTarget()], { stdio: 'ignore' }) } catch { /* best effort */ }
+        return
+      }
+      if (attempt < 3 && /input\/output error|operation now in progress|deadline/i.test(stderr)) {
+        sleepSync(600)
+        continue
+      }
+      const wrapped = new Error(stderr.trim() || (e as Error).message)
+      ;(wrapped as { code?: string; status?: number }).code = (e as { code?: string }).code
+      ;(wrapped as { code?: string; status?: number }).status = (e as { status?: number }).status
+      ;(wrapped as { stderr?: string }).stderr = stderr
+      throw wrapped
+    }
+  }
+}
+
+export function isInstalled(): boolean {
+  return fs.existsSync(plistPath())
+}
+
 export function install(program: ServiceProgram): void {
   fs.mkdirSync(path.dirname(plistPath()), { recursive: true })
   fs.mkdirSync(path.dirname(serviceLogPath(program.config)), { recursive: true })
   fs.writeFileSync(plistPath(), generateLaunchdPlist(program), 'utf-8')
-  // Unload first in case a stale copy is already loaded (e.g. re-running install to change ports).
-  try { execFileSync('launchctl', ['bootout', serviceTarget()], { stdio: 'ignore' }) } catch { /* not loaded — fine */ }
-  execFileSync('launchctl', ['bootstrap', guiTarget(), plistPath()], { stdio: 'inherit' })
+  bootOutAndWait()   // handles the "re-running install" case without racing the teardown
+  bootstrapWithRetry()
 }
 
 export function uninstall(): void {

--- a/standalone/service/windows.ts
+++ b/standalone/service/windows.ts
@@ -19,18 +19,43 @@ export function isInstalled(): boolean {
   }
 }
 
+/** `schtasks /end` returns before the task's process has fully exited and released its sockets,
+ *  so a reinstall that immediately `/run`s a fresh instance can hit the old one still holding the
+ *  UI/OTLP ports. Poll `schtasks /query` until the task reports it's no longer Running (bounded
+ *  ~5s). This is the Windows analogue of macОS's bootout-and-wait. */
+function endRunningInstanceAndWait(): void {
+  try { execFileSync('schtasks', ['/query', '/tn', WINDOWS_TASK_NAME], { stdio: 'ignore' }) }
+  catch { return }  // task doesn't exist yet — nothing to stop
+  try { execFileSync('schtasks', ['/end', '/tn', WINDOWS_TASK_NAME], { stdio: 'ignore' }) } catch { /* wasn't running */ }
+  for (let i = 0; i < 50; i++) {
+    let out = ''
+    try { out = execFileSync('schtasks', ['/query', '/tn', WINDOWS_TASK_NAME, '/fo', 'list'], { encoding: 'utf-8' }) }
+    catch { return }
+    if (!/status:\s*running/i.test(out)) { return }
+    sleepSync(100)
+  }
+}
+
+function sleepSync(ms: number): void {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms)
+}
+
 export function install(program: ServiceProgram): void {
   const scriptPath = wrapperScriptPath(program)
   fs.mkdirSync(path.dirname(scriptPath), { recursive: true })
   fs.mkdirSync(path.dirname(serviceLogPath(program.config)), { recursive: true })
   fs.writeFileSync(scriptPath, generateWindowsWrapperScript(program), 'utf-8')
+  // Stop a running instance from a previous install first, so it releases the ports before the
+  // fresh instance (started by /run below) tries to bind them.
+  endRunningInstanceAndWait()
   // /f overwrites a pre-existing task of the same name (re-running install to change ports).
+  // Capture stderr (rather than inherit) so index.ts's describeServiceManagerFailure can quote it.
   execFileSync('schtasks', [
     '/create', '/tn', WINDOWS_TASK_NAME, '/tr', `"${scriptPath}"`,
     '/sc', 'onlogon', '/rl', 'limited', '/f',
-  ], { stdio: 'inherit' })
+  ], { stdio: ['ignore', 'ignore', 'pipe'] })
   // The logon trigger won't fire until next login — start it now too, for immediate feedback.
-  try { execFileSync('schtasks', ['/run', '/tn', WINDOWS_TASK_NAME], { stdio: 'inherit' }) } catch { /* best effort */ }
+  try { execFileSync('schtasks', ['/run', '/tn', WINDOWS_TASK_NAME], { stdio: 'ignore' }) } catch { /* best effort */ }
 }
 
 export function uninstall(): void {
@@ -47,7 +72,7 @@ export function stop(): void {
 }
 
 export function restart(): void {
-  try { stop() } catch { /* wasn't running */ }
+  endRunningInstanceAndWait()  // wait for the old instance to release its ports before /run
   start()
 }
 

--- a/standalone/service/windows.ts
+++ b/standalone/service/windows.ts
@@ -10,6 +10,15 @@ function wrapperScriptPath(program: ServiceProgram): string {
   return path.join(program.config.dataDir, 'service', 'run.cmd')
 }
 
+export function isInstalled(): boolean {
+  try {
+    execFileSync('schtasks', ['/query', '/tn', WINDOWS_TASK_NAME], { stdio: 'ignore' })
+    return true
+  } catch {
+    return false
+  }
+}
+
 export function install(program: ServiceProgram): void {
   const scriptPath = wrapperScriptPath(program)
   fs.mkdirSync(path.dirname(scriptPath), { recursive: true })


### PR DESCRIPTION
## Problem

Running `service install` when the service is already installed printed an ugly raw error the first time, then "just started" on a second run.

**Root cause (macOS):** `launchctl bootout` returns *before* the launchd domain finishes tearing the service down, so the `bootstrap` fired immediately after races the teardown and fails with `Bootstrap failed: 5: Input/output error`. That line went straight to the terminal via `stdio: 'inherit'`, and the thrown `execFileSync` error propagated out of an **unguarded** `platformService.install(...)` call — the `install` case had no try/catch — to `cli.ts`'s top-level `main().catch(err => console.error(err))`, which dumps the whole `Error` with its stack. The second run worked because by then the first `bootout` had completed.

Beyond the race, `install` printed `Background service installed and started.` unconditionally (no health check), never showed the AgentLens version, and didn't mention it was replacing an existing service.

## Changes

**The race** — `standalone/service/macos.ts`:
- After `bootout`, poll `launchctl print <target>` until the service is actually gone (bounded ~5s) before `bootstrap`.
- Capture `bootstrap` stderr; retry a transient `Input/output error` / `Operation now in progress` up to 3×; on `service already loaded` (re-registered in the gap) `kickstart -k` instead of failing.

**Graceful `service install`** — `standalone/service/index.ts`:
- Prints the running AgentLens version (`update` / `status` too).
- Notes when it's replacing an existing service (new `isInstalled()` on each platform module).
- **Carries the existing access token across a reinstall** — it used to rotate, breaking bookmarked `?token=…` dashboard URLs.
- Wraps `platformService.install` in try/catch → a one-line summary via the new pure `describeServiceManagerFailure()` helper (mirrors `describeNpmFailure`) + a retry hint. No stack trace.
- Waits for a real health check (`waitForServiceHealth`, new in `health.ts`) before printing "running" and the dashboard URL. A slow start says so plainly and points at `service status` / `logs` rather than failing.
- `status` now distinguishes "installed but not reachable" from "nothing installed".

## Before / after

```
# before, 2nd run:
Error: Command failed: launchctl bootstrap gui/501 ...
Bootstrap failed: 5: Input/output error
    at genericNodeError (node:internal/errors:...)
    ... 8 more stack frames ...

# after, 2nd run:
[AgentLens] service install — v0.15.2
[AgentLens] An existing background service was found — replacing it (ports/data-dir updated, access token kept).
[AgentLens] Background service is running (v0.15.2). Open the dashboard at:
  http://127.0.0.1:3000/?token=…
[AgentLens] It starts at login and restarts if it crashes. `agentlens service status` re-prints this URL; `agentlens service uninstall` removes it (your data in ~/.agentlens stays).
```

## Verification

Smoke-tested on macOS: install → reinstall ×2 → status → uninstall — all clean, token stable across reinstalls, plist + launchd registration fully removed afterward. `check-types` clean, `lint` 0 errors, production bundle builds, `serviceConfig` suite **40/40** (5 new for `describeServiceManagerFailure`). The macOS shell orchestration stays uncovered by unit tests (all `child_process`), consistent with the rest of `standalone/service/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
