### PR TITLE
fix: widen the Sessions conversation colored bar ~35%

### DIFF
--- a/media/src/tabs/Sessions.tsx
+++ b/media/src/tabs/Sessions.tsx
@@ -404,7 +404,7 @@ function SessionRow({ sess, showWorkspace, conversation }: {
             gesture, same spot) to clear it, same as the banner's "×" but without needing to look
             away to find it. A currently-active bar renders wider as a visible "you are here." */}
         <td
-          style={`padding:0;width:${isIsolatedToThisGroup ? 6 : 4}px${conversation ? ';cursor:pointer' : ''}`}
+          style={`padding:0;width:${isIsolatedToThisGroup ? 8 : 5}px${conversation ? ';cursor:pointer' : ''}`}
           title={conversation
             ? isIsolatedToThisGroup
               ? `Part ${conversation.index} of ${conversation.total} — showing just this conversation. Click again to clear.`
@@ -422,7 +422,7 @@ function SessionRow({ sess, showWorkspace, conversation }: {
             }
           } : undefined}
         >
-          <div style={`width:${isIsolatedToThisGroup ? 6 : 4}px;height:100%;min-height:20px;background:${conversation ? conversation.color : 'transparent'}`} />
+          <div style={`width:${isIsolatedToThisGroup ? 8 : 5}px;height:100%;min-height:20px;background:${conversation ? conversation.color : 'transparent'}`} />
         </td>
 
         {/* Chevron */}
@@ -556,7 +556,7 @@ export function Sessions() {
       <table style="width:100%;border-collapse:collapse;font-size:11px">
         <thead>
           <tr style="border-bottom:2px solid var(--vscode-panel-border)">
-            <th style="width:4px;padding:0" title="A colored bar marks sessions that are really one conversation split into multiple cards by a long gap between them." />
+            <th style="width:5px;padding:0" title="A colored bar marks sessions that are really one conversation split into multiple cards by a long gap between them." />
             <th style="width:16px;padding:3px 4px 3px 8px" />
             <th style={'width:10px;padding:3px 4px;' + thSort} onClick={() => onSortClick('source')} title="Sort by agent">{sortArrow('source')}</th>
             <th style={'text-align:left;' + thSort} onClick={() => onSortClick('start_time')}>Time{sortArrow('start_time')}</th>


### PR DESCRIPTION
The left-edge colored bar that marks Sessions rows belonging to the same split conversation (added in #229/#230) was **4px** wide (**6px** when that conversation is isolated) — easy to miss, and a small click target for the click-to-isolate / click-again-to-clear gesture.

Bumped ~35%: **5px normal / 8px isolated**. The change is in three inline widths in `media/src/tabs/Sessions.tsx`:
- the conversation-marker `<td>` and its inner `<div>` (`isIsolatedToThisGroup ? 6 : 4` → `? 8 : 5`, kept in sync as the comment there requires)
- the matching `<thead>` `<th>` width hint (`4px` → `5px`)

Widening the `<td>` also enlarges the isolate-toggle click target for free. Purely cosmetic — no state, interaction, or copy change; Help.tsx's "renders slightly wider" stays accurate.

Verified: check-types clean, lint 0 errors, production bundle builds. No test — `Sessions.tsx` has no unit coverage and nothing behavioral changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)