### PR TITLE
fix: reconcile Claude message usage without dropping content blocks

### DIFF
--- a/src/claudeUsageLines.ts
+++ b/src/claudeUsageLines.ts
@@ -1,0 +1,29 @@
+type Row = Record<string, unknown>;
+
+/** Select whole cumulative usage snapshots; never discard content blocks.
+ * Claude output grows within a request. Prefer the greatest output snapshot,
+ * and the later record on ties. Missing IDs stay independent. Conflicting
+ * non-monotonic producer formats are outside this reconciliation contract.
+ */
+export function claudeUsageLines(lines: string[]): Set<number> {
+  const selected = new Map<string, { index: number; output: number }>()
+  const result = new Set<number>()
+  lines.forEach((line, index) => {
+    let row: Row
+    try { row = JSON.parse(line) as Row } catch { return }
+    if (!row || row.type !== 'assistant') return
+    const msg = row.message as Row | undefined
+    const usage = msg?.usage as Row | undefined
+    if (!usage) return
+    const output = typeof usage.output_tokens === 'number' ? usage.output_tokens : 0
+    if (typeof msg?.id !== 'string' || !msg.id) { result.add(index); return }
+    const key = JSON.stringify([row.sessionId ?? row.session_id ?? '', row.requestId ?? '', msg.id])
+    const previous = selected.get(key)
+    if (!previous || output >= previous.output) {
+      if (previous) result.delete(previous.index)
+      selected.set(key, { index, output })
+      result.add(index)
+    }
+  })
+  return result
+}

--- a/src/logReader.ts
+++ b/src/logReader.ts
@@ -1,3 +1,4 @@
+import { claudeUsageLines } from './claudeUsageLines'
 /**
  * Reads local session logs for Claude Code, Codex, Copilot CLI, and
  * Copilot Chat (VS Code sidebar), and synthesises SessionSummaryCard records.
@@ -366,16 +367,9 @@ export class LogReader {
     const timeline: TimelineEntry[] = []
     let idx = 0
     let initiator: 'user' | 'agent' | 'api' = 'user'
-    // Claude Code persists one assistant response as one line per content block,
-    // and every line repeats the same `message.id` and the same `message.usage`
-    // (a text block plus N tool_use blocks is the common agent shape). Only the
-    // first line of each message id bills tokens/turns; the later lines' content
-    // blocks still parse below for tools/files. dedupeByUuid can't catch this —
-    // those lines carry *different* top-level uuids. Lines without an id (older
-    // transcript formats) keep the per-line behaviour.
-    const billedMessageIds = new Set<string>()
+    const usageLines = claudeUsageLines(lines)
 
-    for (const line of lines) {
+    for (const [lineIndex, line] of lines.entries()) {
       let entry: Record<string, unknown>
       try { entry = JSON.parse(line) as Record<string, unknown> } catch { continue }
 
@@ -410,11 +404,8 @@ export class LogReader {
         const rawUsage = msg?.['usage'] as Record<string, unknown> | undefined
         if (rawUsage?.['speed'] === 'fast') hasFastMode = true
         const usage = rawUsage as Record<string, number> | undefined
-        const messageId = typeof msg?.['id'] === 'string' ? (msg['id'] as string) : ''
-        const firstLineOfMessage = messageId === '' || !billedMessageIds.has(messageId)
         let msgTotalInput = 0, msgCacheRead = 0, msgCacheCreate = 0, msgOutput = 0
-        if (usage && firstLineOfMessage) {
-          if (messageId !== '') billedMessageIds.add(messageId)
+        if (usage && usageLines.has(lineIndex)) {
           const inp  = usage['input_tokens']                ?? 0
           const cr   = usage['cache_read_input_tokens']     ?? 0
           const cc   = usage['cache_creation_input_tokens'] ?? 0

--- a/src/logReader.ts
+++ b/src/logReader.ts
@@ -366,6 +366,14 @@ export class LogReader {
     const timeline: TimelineEntry[] = []
     let idx = 0
     let initiator: 'user' | 'agent' | 'api' = 'user'
+    // Claude Code persists one assistant response as one line per content block,
+    // and every line repeats the same `message.id` and the same `message.usage`
+    // (a text block plus N tool_use blocks is the common agent shape). Only the
+    // first line of each message id bills tokens/turns; the later lines' content
+    // blocks still parse below for tools/files. dedupeByUuid can't catch this —
+    // those lines carry *different* top-level uuids. Lines without an id (older
+    // transcript formats) keep the per-line behaviour.
+    const billedMessageIds = new Set<string>()
 
     for (const line of lines) {
       let entry: Record<string, unknown>
@@ -402,8 +410,11 @@ export class LogReader {
         const rawUsage = msg?.['usage'] as Record<string, unknown> | undefined
         if (rawUsage?.['speed'] === 'fast') hasFastMode = true
         const usage = rawUsage as Record<string, number> | undefined
+        const messageId = typeof msg?.['id'] === 'string' ? (msg['id'] as string) : ''
+        const firstLineOfMessage = messageId === '' || !billedMessageIds.has(messageId)
         let msgTotalInput = 0, msgCacheRead = 0, msgCacheCreate = 0, msgOutput = 0
-        if (usage) {
+        if (usage && firstLineOfMessage) {
+          if (messageId !== '') billedMessageIds.add(messageId)
           const inp  = usage['input_tokens']                ?? 0
           const cr   = usage['cache_read_input_tokens']     ?? 0
           const cc   = usage['cache_creation_input_tokens'] ?? 0

--- a/src/test/logReader.claudeMessageId.test.ts
+++ b/src/test/logReader.claudeMessageId.test.ts
@@ -1,0 +1,63 @@
+import * as assert from 'assert'
+import * as path from 'path'
+import * as fs from 'fs'
+import * as os from 'os'
+import { LogReader } from '../logReader'
+
+function writeJsonl(filePath: string, lines: Record<string, unknown>[]) {
+  fs.writeFileSync(filePath, lines.map(l => JSON.stringify(l)).join('\n') + '\n')
+}
+
+// A multi-block assistant response as Claude Code persists it: one line per
+// content block, every line repeating the same message.id and the same
+// message.usage (the per-block lines differ only in content and top-level uuid).
+function multiBlockMessage(id: string) {
+  const usage = { input_tokens: 100, output_tokens: 50, cache_read_input_tokens: 1000, cache_creation_input_tokens: 0 }
+  return [
+    {
+      type: 'assistant', timestamp: '2026-01-01T00:00:05.000Z', uuid: 'line-1-' + id,
+      message: { id, model: 'claude-sonnet-5', usage, content: [{ type: 'text', text: 'thinking...' }] },
+    },
+    {
+      type: 'assistant', timestamp: '2026-01-01T00:00:05.000Z', uuid: 'line-2-' + id,
+      message: { id, model: 'claude-sonnet-5', usage, content: [{ type: 'tool_use', name: 'Read', id: 'toolu-1', input: { file_path: '/workspace/a.ts' } }] },
+    },
+    {
+      type: 'assistant', timestamp: '2026-01-01T00:00:05.000Z', uuid: 'line-3-' + id,
+      message: { id, model: 'claude-sonnet-5', usage, content: [{ type: 'text', text: 'done' }] },
+    },
+  ]
+}
+
+suite('LogReader — Claude multi-block message usage', () => {
+  let tmpDir: string
+
+  setup(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'traceroost-h1-'))
+  })
+
+  teardown(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  test('bills usage once per message.id, not once per content-block line', () => {
+    const filePath = path.join(tmpDir, 'sess-1.jsonl')
+    writeJsonl(filePath, [
+      { type: 'user', cwd: '/workspace', timestamp: '2026-01-01T00:00:00.000Z', message: { content: 'fix the bug' } },
+      ...multiBlockMessage('msg_multi'),
+      { type: 'user', cwd: '/workspace', timestamp: '2026-01-01T00:10:00.000Z', message: { content: 'thanks' } },
+    ])
+
+    const reader = new LogReader()
+    const results = reader.parseFile(filePath, 'claude')
+    assert.strictEqual(results.length, 1, 'expected one parsed session')
+    const card = results[0].card
+
+    // One API message = one usage record: 3 lines must not triple it.
+    // (card.inputTokens is the total context: raw input + cacheRead + cacheCreate.)
+    assert.strictEqual(card.inputTokens, 1100, 'total context must be billed once')
+    assert.strictEqual(card.outputTokens, 50, 'outputTokens must be billed once')
+    assert.strictEqual(card.cacheReadTokens, 1000, 'cacheReadTokens must be billed once')
+    assert.strictEqual(card.turns, 1, 'turns must count the message once')
+  })
+})

--- a/src/test/logReader.claudeMessageId.test.ts
+++ b/src/test/logReader.claudeMessageId.test.ts
@@ -60,4 +60,23 @@ suite('LogReader — Claude multi-block message usage', () => {
     assert.strictEqual(card.cacheReadTokens, 1000, 'cacheReadTokens must be billed once')
     assert.strictEqual(card.turns, 1, 'turns must count the message once')
   })
+  test('retains growing output and content while counting equal distinct messages', () => {
+    const filePath = path.join(tmpDir, 'growing.jsonl')
+    const blocks = multiBlockMessage('growing')
+    blocks[0].message.usage.output_tokens = 3
+    // Give each line an independent usage snapshot.
+    blocks[1].message.usage = { ...blocks[1].message.usage, output_tokens: 2055 }
+    blocks[2].message.usage = { ...blocks[2].message.usage, output_tokens: 3 }
+    writeJsonl(filePath, [
+      { type: 'user', cwd: '/workspace', timestamp: '2026-01-01T00:00:00.000Z', message: { content: 'fix' } },
+      ...blocks,
+      ...multiBlockMessage('distinct'),
+    ])
+    const card = new LogReader().parseFile(filePath, 'claude')[0].card
+    assert.strictEqual(card.outputTokens, 2105)
+    assert.strictEqual(card.inputTokens, 2200)
+    assert.strictEqual(card.turns, 2)
+    assert.strictEqual(card.totalToolCalls, 2)
+  })
+
 })


### PR DESCRIPTION
Claude transcript rows can repeat a message's usage across content blocks, and later rows can carry a larger cumulative output count. First-wins deduplication therefore fixes overcounting but can introduce undercounting.

This revision selects one **whole usage snapshot** per parsed-segment session/request/message identity: greatest `output_tokens`, with later records winning ties. Anonymous records remain independent. It does not construct a synthetic usage vector from independent field maxima. The rule assumes cumulative, monotonic output within a Claude request; it is not a general reconciliation rule for arbitrary producers or a claim of billing accuracy.

Usage selection happens before the existing content parser. Only selected rows contribute usage and turns; every content block remains available for tool/file/timeline parsing.

Regression coverage includes repeated equal usage, growing output followed by a stale snapshot, distinct messages, and retaining tool calls. The growing case now yields output 2105 across two messages, two turns and two tool calls.

Validation: TypeScript test compilation passes; complete Mocha unit suite: **400 passing**. The new growing-snapshot regression fails on the previous PR head and passes with this revision. ESLint reports no errors; existing unrelated equality warnings remain. Fixtures are synthetic.
