### PR TITLE
docs: point repository links to traceroost/core

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: true
 contact_links:
   - name: Discussion / question
-    url: https://github.com/rogerreed/agentlens/discussions
+    url: https://github.com/traceroost/core/discussions
     about: Ask a question or share feedback

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -27,14 +27,14 @@ jobs:
           PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_SIGNATURES_TOKEN }}
         with:
           path-to-signatures: signatures/cla.json
-          path-to-document: https://github.com/RogerReed/agentlens/blob/main/.github/CLA.md
+          path-to-document: https://github.com/traceroost/core/blob/main/.github/CLA.md
           # Dedicated, unprotected branch for signature storage — main requires PRs, so the
           # action's own commit of the signature record can't land there directly.
           branch: cla-signatures
           allowlist: RogerReed
           custom-notsigned-prcomment: |
             Thanks for this contribution! Before it can be merged, please read the
-            [Contributor License Agreement](https://github.com/RogerReed/agentlens/blob/main/.github/CLA.md)
+            [Contributor License Agreement](https://github.com/traceroost/core/blob/main/.github/CLA.md)
             and sign it by commenting on this pull request with:
 
             > I have read the CLA Document and I hereby sign the CLA

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ the PR.
 
 ## Reporting bugs
 
-Open an issue at <https://github.com/rogerreed/agentlens/issues> and use the bug report template. Include:
+Open an issue at <https://github.com/traceroost/core/issues> and use the bug report template. Include:
 
 - The agent you were using (Copilot, Claude Code, Codex)
 - Whether you're using the VS Code extension or standalone mode
@@ -28,7 +28,7 @@ Open an issue at <https://github.com/rogerreed/agentlens/issues> and use the bug
 ## Development setup
 
 ```bash
-git clone https://github.com/rogerreed/agentlens
+git clone https://github.com/traceroost/core
 cd agentlens
 pnpm install
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <h1><img src="media/mascot.png" alt="AgentLens logo" width="48" align="center" /> AgentLens</h1>
 
-[![CI](https://github.com/RogerReed/agentlens/actions/workflows/ci.yml/badge.svg)](https://github.com/RogerReed/agentlens/actions/workflows/ci.yml)
+[![CI](https://github.com/traceroost/core/actions/workflows/ci.yml/badge.svg)](https://github.com/traceroost/core/actions/workflows/ci.yml)
 [![License](https://img.shields.io/github/license/RogerReed/agentlens)](LICENSE)
 
 ![AgentLens dashboard showing OTEL traces, session monitoring, and agent observability charts](media/demo.gif)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 <h1><img src="media/mascot.png" alt="AgentLens logo" width="48" align="center" /> AgentLens</h1>
 
+> [!IMPORTANT]
+> **AgentLens is transitioning to TraceRoost.** The project is moving away from the crowded "AgentLens" name because several unrelated projects already use it. During the transition, release identifiers such as `agentlens-dashboard`, `agentlens.agentlens-dashboard`, and `agentlens/agentlens` remain unchanged. The rebrand will be completed in a future release.
+
 [![CI](https://github.com/traceroost/core/actions/workflows/ci.yml/badge.svg)](https://github.com/traceroost/core/actions/workflows/ci.yml)
-[![License](https://img.shields.io/github/license/RogerReed/agentlens)](LICENSE)
+[![License](https://img.shields.io/github/license/traceroost/core)](LICENSE)
 
 ![AgentLens dashboard showing OTEL traces, session monitoring, and agent observability charts](media/demo.gif)
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 <h1><img src="media/mascot.png" alt="AgentLens logo" width="48" align="center" /> AgentLens</h1>
 
-> [!IMPORTANT]
-> **AgentLens is transitioning to TraceRoost.** The project is moving away from the crowded "AgentLens" name because several unrelated projects already use it. During the transition, release identifiers such as `agentlens-dashboard`, `agentlens.agentlens-dashboard`, and `agentlens/agentlens` remain unchanged. The rebrand will be completed in a future release.
+> **TraceRoost rebrand in progress**
+>
+> AgentLens is transitioning to TraceRoost because several unrelated projects already use the AgentLens name. During the transition, release identifiers such as `agentlens-dashboard`, `agentlens.agentlens-dashboard`, and `agentlens/agentlens` remain unchanged. The rebrand will be completed in a future release.
 
 [![CI](https://github.com/traceroost/core/actions/workflows/ci.yml/badge.svg)](https://github.com/traceroost/core/actions/workflows/ci.yml)
 [![License](https://img.shields.io/github/license/traceroost/core)](LICENSE)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <h1><img src="media/mascot.png" alt="AgentLens logo" width="48" align="center" /> AgentLens</h1>
 
-> **TraceRoost rebrand in progress**
+> **Note:** AgentLens is transitioning to TraceRoost.
 >
 > AgentLens is transitioning to TraceRoost because several unrelated projects already use the AgentLens name. During the transition, release identifiers such as `agentlens-dashboard`, `agentlens.agentlens-dashboard`, and `agentlens/agentlens` remain unchanged. The rebrand will be completed in a future release.
 

--- a/media/src/tabs/Help.tsx
+++ b/media/src/tabs/Help.tsx
@@ -250,7 +250,7 @@ function ConfigSection() {
         </tbody>
       </table>
       <p style="font-size:12px;color:var(--muted);margin:8px 0 0">Start a short <a href="#gl-session">session</a> and check whether a session card appears in the sidebar to confirm data is arriving.</p>
-      <p style="font-size:12px;color:var(--muted);margin:8px 0 6px">If configuration is missing or stale, use <strong>Configure OTEL</strong> in Settings, or review the <a href="https://github.com/RogerReed/agentlens/tree/main/scripts" target="_blank" rel="noreferrer">configuration scripts in the repository</a>.</p>
+      <p style="font-size:12px;color:var(--muted);margin:8px 0 6px">If configuration is missing or stale, use <strong>Configure OTEL</strong> in Settings, or review the <a href="https://github.com/traceroost/core/tree/main/scripts" target="_blank" rel="noreferrer">configuration scripts in the repository</a>.</p>
       <pre style="font-size:12px;background:var(--panel-bg);border:1px solid var(--border);border-radius:3px;padding:6px 10px;margin:0 0 8px;overflow-x:auto;white-space:pre">{`# macOS / Linux — make executable (once), then run:
 chmod +x scripts/configure-agents.sh
 ./scripts/configure-agents.sh             # all agents
@@ -269,7 +269,7 @@ chmod +x scripts/configure-agents.sh
   ) : (
     <div style="margin-bottom:20px;background:var(--hover);border:1px solid var(--border);border-left:3px solid var(--warning,#ffb74d);border-radius:4px;padding:10px 14px">
       <p style="font-size:12px;font-weight:600;margin:0 0 8px;color:var(--foreground)">Not seeing any detailed OTEL data?</p>
-      <p style="font-size:12px;color:var(--muted);margin:0 0 8px">AgentLens automatically configures all supported agents on startup/activation, including Codex's <code style={codeStyle}>[otel]</code> section. It only rewrites a file when a required setting is missing or differs, so this is silent after the first successful run. Works in VS Code, Cursor, Windsurf, VSCodium, Trae, Kiro, and other VS Code-family IDEs. After configuration, restart each <a href="#gl-agent">agent</a> once so it reads the new settings. Changed an agent's OTEL settings yourself? Use the <strong>Configure OTEL</strong> button in Settings (gear icon), or review the <a href="https://github.com/RogerReed/agentlens/tree/main/scripts" target="_blank" rel="noreferrer">repository scripts</a>. Disable auto-configuration entirely via the <code style={codeStyle}>agentLens.autoConfigureAgents</code> setting.</p>
+      <p style="font-size:12px;color:var(--muted);margin:0 0 8px">AgentLens automatically configures all supported agents on startup/activation, including Codex's <code style={codeStyle}>[otel]</code> section. It only rewrites a file when a required setting is missing or differs, so this is silent after the first successful run. Works in VS Code, Cursor, Windsurf, VSCodium, Trae, Kiro, and other VS Code-family IDEs. After configuration, restart each <a href="#gl-agent">agent</a> once so it reads the new settings. Changed an agent's OTEL settings yourself? Use the <strong>Configure OTEL</strong> button in Settings (gear icon), or review the <a href="https://github.com/traceroost/core/tree/main/scripts" target="_blank" rel="noreferrer">repository scripts</a>. Disable auto-configuration entirely via the <code style={codeStyle}>agentLens.autoConfigureAgents</code> setting.</p>
       <p style="font-size:11px;color:var(--muted);margin:0 0 6px">Config is read at startup — restart after AgentLens activates:</p>
       <table style="font-size:11px;border-collapse:collapse;width:100%">
         <tbody style="color:var(--muted)">
@@ -396,7 +396,7 @@ trace_exporter = { otlp-http = { endpoint = "http://localhost:4318", protocol = 
         output, <code style={codeStyle}>stop</code>/<code style={codeStyle}>start</code>/<code style={codeStyle}>restart</code> control
         it, and <code style={codeStyle}>uninstall</code> removes it — your data in{' '}
         <code style={codeStyle}>~/.agentlens</code> is untouched either way. See{' '}
-        <a href="https://github.com/RogerReed/agentlens#background-service-macos--windows--linux" target="_blank" rel="noreferrer">the README</a> for
+        <a href="https://github.com/traceroost/core#background-service-macos--windows--linux" target="_blank" rel="noreferrer">the README</a> for
         the full command reference and custom port/data-dir options.
       </p>
       <p style="font-size:12px;color:var(--muted);margin:0;background:var(--panel-bg);border-radius:3px;padding:8px 10px">

--- a/media/src/tabs/Pricing.tsx
+++ b/media/src/tabs/Pricing.tsx
@@ -133,7 +133,7 @@ export function Pricing() {
       <div style="margin-top:24px;padding-top:16px;border-top:1px solid var(--vscode-panel-border);font-size:11px;color:var(--muted);line-height:1.7">
         Full sourcing detail, known gaps, and per-model notes:{' '}
         <a
-          href="https://github.com/RogerReed/agentlens/blob/main/PRICING_SOURCES.md"
+          href="https://github.com/traceroost/core/blob/main/PRICING_SOURCES.md"
           target="_blank" rel="noopener noreferrer"
           style="color:inherit;text-decoration:underline;text-underline-offset:2px"
         >PRICING_SOURCES.md</a>.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/RogerReed/agentlens"
+    "url": "https://github.com/traceroost/core"
   },
   "engines": {
     "vscode": "^1.118.0",


### PR DESCRIPTION
## Summary
- update repository, issue, CLA, README, and in-app documentation links to `traceroost/core`
- keep the AgentLens npm package, VS Code publisher, Open VSX identity, and Docker Hub image unchanged during the rebrand transition

## Release compatibility
This does not change `agentlens-dashboard`, publisher `agentlens`, or `agentlens/agentlens`. Tagged releases continue publishing to the existing AgentLens destinations; only repository links move to the new GitHub location.